### PR TITLE
feat(parser): parse TS type-syntax edges as annotations

### DIFF
--- a/docs/language.md
+++ b/docs/language.md
@@ -421,6 +421,8 @@ Lowercase tags produce string tag names (`"div"`, `"span"`); uppercase tags are 
 
 The transformer generates an internal source map for accurate error line/column reporting. JSX is enabled by default via `DefaultPreprocessors`; embedders can disable it with `Engine.Preprocessors := Engine.Preprocessors - [ppJSX]`. Opening-tag detection is a heuristic, so source that merely looks like JSX — a TypeScript type annotation such as `: <T>(x: T) => T`, for example — can start a JSX scan; when that scan stalls on a character no branch consumes, exceeds the nesting bound, or reaches the end of input inside an opening tag, the transformer reports a `SyntaxError` positioned in the original source rather than scanning on.
 
+**Extensions:** the transformer runs for `.js`, `.jsx`, `.tsx`, and `.mjs`. It never runs for `.ts`, where a leading `<` is type syntax rather than a tag — see [Angle Brackets and JSX](#angle-brackets-and-jsx). `.js` and `.mjs` sources containing JSX are still transformed, and report a "JSX syntax found in source with a non-JSX extension" warning.
+
 ### Regular Expressions
 
 **Supported.** GocciaScript implements:
@@ -532,8 +534,24 @@ const greet = (name?: string) => name === undefined ? "hi" : "hi " + name;
 const sum = (...nums: number[]) => nums.reduce((a, b) => a + b, 0);
 const first = ({ name, age }: { name: string, age: number }) => name;
 
-// Return type annotations
+// Return type annotations, including unions and intersections of object types
 const double = (x: number): number => x * 2;
+class Registry {
+  lookup(flag: boolean): string | { code: number } { return flag ? "ok" : { code: 7 }; }
+  build(): { name: string } & { size: number } { return { name: "box", size: 2 }; }
+}
+
+// Template literal types
+const id: `id-${number}` = "id-42";
+const also = "id-42" as `id-${number}`;
+
+// Definite assignment assertions (require an annotation, forbid an initializer)
+let pending!: number;
+pending = 5;
+
+// Generic arrow function expressions
+const identity = <T,>(v: T): T => v;
+const withDefault = <T = string,>(v: T): T => v;
 
 // Type and interface declarations (skipped entirely)
 type Point = { x: number, y: number };
@@ -570,11 +588,34 @@ class Box<T> implements Container {
 try { throw new Error("oops"); } catch (e: Error) { }
 ```
 
+#### Angle Brackets and JSX
+
+A leading `<` is ambiguous: it can open a JSX element or a type parameter list. GocciaScript resolves this by file extension, the same way TypeScript does.
+
+- **`.ts`** — JSX is never recognised, so `<` is always type syntax. Generic function type annotations and every generic arrow form parse here:
+
+  ```typescript
+  const identity: <T>(x: T) => T = (x) => x;
+  const wrap = <T>(v: T): T[] => [v];
+  const idOf = <T extends { id: number }>(v: T): number => v.id;
+  ```
+
+- **`.js`, `.jsx`, `.tsx`, `.mjs`** — JSX is recognised, so a bare `<T>` or `<T extends U>` is read as a JSX element. Generic arrows still parse when the type parameter list cannot be mistaken for a tag, which means a trailing comma, a default, or more than one parameter:
+
+  ```javascript
+  const identity = <T,>(v: T): T => v;
+  const withDefault = <T = string,>(v: T): T => v;
+  const pair = <A, B>(a: A, b: B) => [a, b];
+  ```
+
+  Use a `.ts` source when an annotation needs the bare `<T>` form.
+
 #### Not Supported
 
 - Namespaces (`namespace Foo { ... }`).
 - Parameter properties in constructors (`constructor(public x: number)`).
 - Angle-bracket type assertions (`<string>value`) — use `value as string` instead.
+- Definite assignment assertions on class fields (`class C { x!: number }`) — only variable declarations accept `!`.
 
 ### Pattern Matching (Stage 1)
 

--- a/docs/language.md
+++ b/docs/language.md
@@ -549,6 +549,11 @@ const also = "id-42" as `id-${number}`;
 let pending!: number;
 pending = 5;
 
+// Non-null assertions (postfix !, erased — the chain continues unchanged)
+const nonNull = { v: "x" };
+nonNull.v!.length;
+const first = [{ y: 1 }][0]!.y;
+
 // Generic arrow function expressions
 const identity = <T,>(v: T): T => v;
 const withDefault = <T = string,>(v: T): T => v;
@@ -618,7 +623,7 @@ A leading `<` is ambiguous: it can open a JSX element or a type parameter list. 
 - Definite assignment assertions on class fields (`class C { x!: number }`) — only variable declarations accept `!`.
 - Generic **async** arrow expressions (`async <T,>(v: T) => v`) — the generic form is wired into primary-expression position only, so the `async` prefix is not recognised ahead of it.
 
-A definite assignment assertion is a restricted production: the `!` must appear on the same line as the binding name. A `!` at the start of the next line begins a new expression statement, so ASI code such as `let x` followed by `!fn()` keeps its usual meaning.
+Both `!` forms are restricted productions: the `!` must appear on the same line as the binding name (definite assignment) or its operand (non-null assertion). A `!` at the start of the next line begins a new expression statement, so ASI code such as `let x` followed by `!fn()` keeps its usual meaning. `!=` and `!==` lex as single tokens and are never assertions.
 
 ### Pattern Matching (Stage 1)
 

--- a/docs/language.md
+++ b/docs/language.md
@@ -616,6 +616,9 @@ A leading `<` is ambiguous: it can open a JSX element or a type parameter list. 
 - Parameter properties in constructors (`constructor(public x: number)`).
 - Angle-bracket type assertions (`<string>value`) — use `value as string` instead.
 - Definite assignment assertions on class fields (`class C { x!: number }`) — only variable declarations accept `!`.
+- Generic **async** arrow expressions (`async <T,>(v: T) => v`) — the generic form is wired into primary-expression position only, so the `async` prefix is not recognised ahead of it.
+
+A definite assignment assertion is a restricted production: the `!` must appear on the same line as the binding name. A `!` at the start of the next line begins a new expression statement, so ASI code such as `let x` followed by `!fn()` keeps its usual meaning.
 
 ### Pattern Matching (Stage 1)
 
@@ -834,6 +837,8 @@ GocciaScript requires explicit semicolons by default, preventing this class of b
 ./build/GocciaTestRunner tests/language/asi
 ./build/GocciaREPL --compat-asi
 ```
+
+Type-level declarations that are skipped rather than parsed (`type`, `import type`, `export type`) end at the first line break that is a legal ASI point. A type argument list wrapped across lines is fine, because its breaks fall after a `<` or `,` or before a `>`; a break at another operator, such as a union `|` leading the next line, ends the declaration early. Terminate multi-line type declarations with an explicit `;`, or keep the operator at the end of the line.
 
 ```pascal
 // Enable ASI via the engine API

--- a/scripts/test-cli-parser.ts
+++ b/scripts/test-cli-parser.ts
@@ -842,4 +842,112 @@ console.log("JSX preprocessor termination...");
     });
 }
 
+// -- Definite assignment assertion rules ----------------------------------------
+
+console.log("Definite assignment assertion rules...");
+{
+  // TypeScript's three rules for `!` on a variable declaration. These are parse
+  // errors, so they cannot be asserted from a JS test file — see
+  // tests/language/types-as-comments/definite-assignment.js for the accepted
+  // forms.
+  const cases = [
+    {
+      desc: "definite assignment without a type annotation",
+      source: "let x!;\n",
+      messageIncludes: "must also have type annotations",
+    },
+    {
+      desc: "definite assignment with an initializer",
+      source: "let x!: number = 1;\n",
+      messageIncludes: "cannot also have definite assignment assertions",
+    },
+    {
+      desc: "definite assignment on a const declaration",
+      source: "const x!: number;\n",
+      messageIncludes: "not permitted on a const declaration",
+    },
+    {
+      desc: "definite assignment without an annotation on var",
+      source: "var x!;\n",
+      messageIncludes: "must also have type annotations",
+      args: ["--compat-var"],
+    },
+    {
+      desc: "definite assignment with an initializer on var",
+      source: "var x!: number = 1;\n",
+      messageIncludes: "cannot also have definite assignment assertions",
+      args: ["--compat-var"],
+    },
+  ] as const;
+
+  for (const { desc, source, messageIncludes, args } of cases)
+    assertSyntaxErrorInBothModes(source, desc, args ?? [], { messageIncludes });
+
+  // The '!' is a restricted production: on the next line it starts a new
+  // expression statement rather than being absorbed as an assertion.
+  const asiSource = [
+    "let x",
+    "!(() => { console.log('ran'); })()",
+    "console.log(typeof x)",
+    "",
+  ].join("\n");
+  for (const modeArgs of [[] as string[], ["--mode=bytecode"]]) {
+    const label = modeArgs.length ? "leading-! after ASI (bytecode)" : "leading-! after ASI";
+    const res = runLoaderJson(asiSource, ["--compat-asi", ...modeArgs]);
+    if (res.exitCode !== 0)
+      throw new Error(`${label}: should parse, got exit ${res.exitCode} ${JSON.stringify(res.json.error)}`);
+    if (normalizeLineEndings(res.json.output) !== "ran\nundefined\n")
+      throw new Error(`${label}: expected "ran\\nundefined", got ${JSON.stringify(res.json.output)}`);
+  }
+}
+
+// -- Type alias skipping across line breaks under ASI ---------------------------
+
+console.log("Type alias skipping under ASI...");
+{
+  // A skipped `type` alias may wrap its type argument list across lines. The
+  // skipper does not depth-count '<' / '>', so it relies on the line break
+  // never being a legal ASI point: it follows a '<' or ',', or precedes a '>'.
+  const source = [
+    "type Handler = Map<",
+    "  string,",
+    "  number",
+    ">;",
+    "const after = 2",
+    "console.log(after)",
+    "",
+  ].join("\n");
+
+  for (const modeArgs of [[] as string[], ["--mode=bytecode"]]) {
+    const label = modeArgs.length ? "multi-line type alias (bytecode)" : "multi-line type alias";
+    const res = runLoaderJson(source, ["--compat-asi", ...modeArgs]);
+    if (res.exitCode !== 0)
+      throw new Error(`${label}: should parse, got exit ${res.exitCode} ${JSON.stringify(res.json.error)}`);
+    if (normalizeLineEndings(res.json.output) !== "2\n")
+      throw new Error(`${label}: expected "2", got ${JSON.stringify(res.json.output)}`);
+  }
+
+  // The complementary guarantee: a relational expression in a skipped statement
+  // still ends at its own line break instead of swallowing what follows.
+  const relationalSource = [
+    "var skipped = 1 < 2",
+    "const after = 3",
+    "console.log(after)",
+    "",
+  ].join("\n");
+
+  for (const modeArgs of [[] as string[], ["--mode=bytecode"]]) {
+    const label = modeArgs.length ? "relational in skipped var (bytecode)" : "relational in skipped var";
+    const res = runLoaderJson(relationalSource, [
+      "--warning-unsupported-features",
+      "--compat-asi",
+      ...modeArgs,
+    ]);
+    if (res.exitCode !== 0)
+      throw new Error(`${label}: should recover, got exit ${res.exitCode} ${JSON.stringify(res.json.error)}`);
+    if (normalizeLineEndings(res.json.output) !== "3\n")
+      throw new Error(`${label}: expected "3", got ${JSON.stringify(res.json.output)}`);
+  }
+}
+
 console.log("\nAll test-cli-parser.ts tests passed.");

--- a/scripts/test-cli-parser.ts
+++ b/scripts/test-cli-parser.ts
@@ -815,18 +815,6 @@ console.log("JSX preprocessor termination...");
     line?: number;
   }[] = [
     {
-      desc: "type-parameter arrow after a function type annotation",
-      // `: <T>` looks like a JSX opening tag, so the children scan runs on the
-      // rest of the file and reaches `<T,` — where no attribute branch
-      // consumes the ','.
-      source: [
-        "const g: <T>(x: T) => T = (x) => x;",
-        "const w = <T,>(v: T): T => v;",
-        "",
-      ].join("\n"),
-      messageIncludes: "attribute list",
-    },
-    {
       desc: "unterminated JSX opening tag",
       source: 'const element = <div className="a"\n',
       messageIncludes: "Unterminated opening tag",
@@ -888,6 +876,61 @@ console.log("JSX preprocessor termination...");
       messageIncludes,
       line,
     });
+
+  // The attribute-list stall is extension-sensitive, so it is pinned to real
+  // files instead of extensionless stdin. `: <T>` looks like a JSX opening tag,
+  // so the children scan runs on the rest of the file and reaches `<T,`, where
+  // no attribute branch consumes the ','.
+  const angleBracketSource = [
+    "const g: <T>(x: T) => T = (x) => x;",
+    "const w = <T,>(v: T): T => v;",
+    "console.log(g('a') + w('b'));",
+    "",
+  ].join("\n");
+
+  const tmp = mkdtemp("goccia-parser-jsx-");
+  try {
+    // A JSX-processed extension still runs the transformer, so the
+    // zero-progress guard must still turn the stall into a clean error rather
+    // than spinning.
+    const jsxFile = join(tmp, "stall.jsx");
+    writeFileSync(jsxFile, angleBracketSource);
+
+    for (const modeArgs of [[] as string[], ["--mode=bytecode"]]) {
+      const label = modeArgs.length
+        ? "attribute list stall in .jsx (bytecode)"
+        : "attribute list stall in .jsx";
+      const res = runLoaderJson("", [...modeArgs, jsxFile], {
+        timeout: JSX_SCAN_TIMEOUT_MS,
+      });
+      if (res.exitCode !== 1)
+        throw new Error(`${label}: should exit 1, got ${res.exitCode}`);
+      if (res.json.ok !== false || res.json.error?.type !== "SyntaxError")
+        throw new Error(`${label}: expected SyntaxError, got ${JSON.stringify(res.json.error)}`);
+      if (!String(res.json.error?.message ?? "").includes("attribute list"))
+        throw new Error(`${label}: expected an attribute-list stall, got ${res.json.error?.message}`);
+    }
+
+    // The same source in a '.ts' file is never handed to the transformer, so
+    // '<' stays type syntax and the annotations parse and run.
+    const tsFile = join(tmp, "annotations.ts");
+    writeFileSync(tsFile, angleBracketSource);
+
+    for (const modeArgs of [[] as string[], ["--mode=bytecode"]]) {
+      const label = modeArgs.length
+        ? "angle-bracket type syntax in .ts (bytecode)"
+        : "angle-bracket type syntax in .ts";
+      const res = runLoaderJson("", [...modeArgs, tsFile], {
+        timeout: JSX_SCAN_TIMEOUT_MS,
+      });
+      if (res.exitCode !== 0)
+        throw new Error(`${label}: should parse, got exit ${res.exitCode} ${JSON.stringify(res.json.error)}`);
+      if (normalizeLineEndings(res.json.output) !== "ab\n")
+        throw new Error(`${label}: expected "ab", got ${JSON.stringify(res.json.output)}`);
+    }
+  } finally {
+    clean(tmp);
+  }
 }
 
 // -- Definite assignment assertion rules ----------------------------------------

--- a/source/units/Goccia.Error.Suggestions.pas
+++ b/source/units/Goccia.Error.Suggestions.pas
@@ -104,6 +104,9 @@ resourcestring
   SSuggestAddPropertyInitializer = 'Add ''= value'' to initialize the property';
   SSuggestAddConstInitializer = 'Add ''= value'' after the variable name';
   SSuggestComputedPropertyNeedsValue = 'Add '': value'' after the computed property (e.g., [key]: value)';
+  SSuggestDefiniteAssignmentNeedsAnnotation = 'Add a type annotation after ''!'' (e.g., let x!: number)';
+  SSuggestDefiniteAssignmentNoInitializer = 'Remove the ''!'' — a declaration with an initializer is already assigned';
+  SSuggestDefiniteAssignmentNotOnConst = 'Remove the ''!'' — a const is always assigned at its declaration';
 
   // Imports and exports
   SSuggestImportMetaSyntax = 'Use import.meta to access module metadata (e.g., import.meta.url)';

--- a/source/units/Goccia.FileExtensions.pas
+++ b/source/units/Goccia.FileExtensions.pas
@@ -32,6 +32,14 @@ const
     EXT_JSX, EXT_TSX
   );
 
+  // Extensions where a leading '<' is always type syntax and never JSX, so the
+  // JSX preprocessor must not run. TypeScript draws the same line: '.ts' keeps
+  // angle-bracket type assertions and generic arrow functions (`<T>(x: T) => T`),
+  // and only '.tsx' hands '<' to JSX and requires the `<T,>` disambiguation.
+  JSXExcludedExtensions: array[0..0] of string = (
+    EXT_TS
+  );
+
   ModuleImportExtensions: array[0..15] of string = (
     EXT_JS, EXT_JSX, EXT_TS, EXT_TSX, EXT_MJS,
     EXT_JSON, EXT_JSON5, EXT_JSONC, EXT_JSONL, EXT_TOML, EXT_YAML, EXT_YML,
@@ -48,6 +56,7 @@ function IsCSVExtension(const AExtension: string): Boolean;
 function IsJSON5Extension(const AExtension: string): Boolean;
 function IsJSONLExtension(const AExtension: string): Boolean;
 function IsJSXNativeExtension(const AExtension: string): Boolean;
+function IsJSXExcludedExtension(const AExtension: string): Boolean;
 function IsModuleSourceExtension(const AExtension: string): Boolean;
 function IsModuleSourceFileName(const AFileName: string): Boolean;
 function IsTextAssetExtension(const AExtension: string): Boolean;
@@ -82,6 +91,18 @@ begin
   Ext := LowerCase(AExtension);
   for I := Low(JSXNativeExtensions) to High(JSXNativeExtensions) do
     if Ext = JSXNativeExtensions[I] then
+      Exit(True);
+  Result := False;
+end;
+
+function IsJSXExcludedExtension(const AExtension: string): Boolean;
+var
+  Ext: string;
+  I: Integer;
+begin
+  Ext := LowerCase(AExtension);
+  for I := Low(JSXExcludedExtensions) to High(JSXExcludedExtensions) do
+    if Ext = JSXExcludedExtensions[I] then
       Exit(True);
   Result := False;
 end;

--- a/source/units/Goccia.Keywords.Contextual.pas
+++ b/source/units/Goccia.Keywords.Contextual.pas
@@ -48,6 +48,9 @@ const
   KEYWORD_READONLY     = 'readonly';
   KEYWORD_OVERRIDE     = 'override';
   KEYWORD_ABSTRACT     = 'abstract';
+  KEYWORD_KEYOF        = 'keyof';
+  KEYWORD_INFER        = 'infer';
+  KEYWORD_ASSERTS      = 'asserts';
 
   // Contextual keywords that the lexer tokenizes directly. Other contextual
   // keywords stay as identifiers so the parser can interpret them by context.

--- a/source/units/Goccia.Parser.pas
+++ b/source/units/Goccia.Parser.pas
@@ -277,6 +277,10 @@ type
     function CollectExpressionTypeAnnotation: string;
     function CollectGenericParameters: string;
     function TryCollectNewExpressionTypeArguments: Boolean;
+    function TryParseGenericArrowFunction(
+      out AExpression: TGocciaExpression): Boolean;
+    function ParseDefiniteAssignmentAssertion(
+      const AIsConst: Boolean): Boolean;
     procedure SkipUntilSemicolon;
     procedure SkipBlock;
     procedure SkipBalancedParens;
@@ -2965,12 +2969,80 @@ begin
       begin
         Advance;
         Result := ObjectLiteral;
+      end;
+    gttLess:
+      begin
+        // A '<' only reaches Primary in operand position, where a relational
+        // operator is impossible — `a < b > (c)` consumes its '<' in the
+        // comparison parser and never lands here. The only expression that can
+        // start with '<' is a generic arrow function, so probe for one and keep
+        // the previous "Expected expression" error when it is not.
+        if not TryParseGenericArrowFunction(Result) then
+          raise TGocciaSyntaxError.Create('Expected expression',
+            Peek.Line, Peek.Column, FFileName, FSourceLines,
+            SSuggestExpressionExpected);
       end
   else
     raise TGocciaSyntaxError.Create('Expected expression',
       Peek.Line, Peek.Column, FFileName, FSourceLines,
       SSuggestExpressionExpected);
   end;
+end;
+
+// `<T,>(v: T): T => v` and friends. The type parameter list is collected
+// speculatively: it must be followed by '(' opening a real arrow parameter
+// list, otherwise the parser cursor and lexer are rewound so the caller can
+// report its own error.
+function TGocciaParser.TryParseGenericArrowFunction(
+  out AExpression: TGocciaExpression): Boolean;
+var
+  SavedCurrent: Integer;
+  SavedLexer: TGocciaLexerCheckpoint;
+  Line, Column: Integer;
+  IsGenericArrow: Boolean;
+begin
+  Result := False;
+  AExpression := nil;
+
+  Line := Peek.Line;
+  Column := Peek.Column;
+  SavedCurrent := FCurrent;
+  if Assigned(FLexer) then
+    SavedLexer := FLexer.CreateCheckpoint;
+  IsGenericArrow := False;
+
+  try
+    try
+      if CollectGenericParameters = '' then
+        Exit;
+      if not CheckWithLexicalGoal(gttLeftParen, glgInputElementDiv) then
+        Exit;
+      Advance; // consume '(' so IsArrowFunction probes from the parameter list
+      IsGenericArrow := IsArrowFunction;
+    except
+      // A lexer error inside the probe only means "not a generic arrow"; the
+      // rewound source is re-parsed and reports the genuine error.
+      on E: TGocciaLexerError do
+        IsGenericArrow := False;
+    end;
+  finally
+    if not IsGenericArrow then
+    begin
+      FCurrent := SavedCurrent;
+      if Assigned(FLexer) then
+        FLexer.RestoreCheckpoint(SavedLexer);
+    end;
+  end;
+
+  if not IsGenericArrow then
+    Exit;
+
+  AExpression := ArrowFunction;
+  // ArrowFunction anchors its source text at the '(' it was entered on; widen
+  // it to include the type parameter list.
+  TGocciaArrowFunctionExpression(AExpression).SourceText :=
+    ExtractSourceRange(Line, Column);
+  Result := True;
 end;
 
 function TGocciaParser.ParseMatchExpression: TGocciaMatchExpression;
@@ -4908,9 +4980,32 @@ begin
   end;
 end;
 
+// TypeScript definite assignment assertion: `let x!: number;` tells the type
+// checker the binding is assigned elsewhere. It carries no runtime meaning, so
+// it is consumed and discarded — but the surrounding TypeScript rules are
+// enforced so accepted programs are the ones TypeScript accepts: the assertion
+// requires a type annotation, forbids an initializer, and is not allowed on a
+// const (which is always assigned at its declaration).
+function TGocciaParser.ParseDefiniteAssignmentAssertion(
+  const AIsConst: Boolean): Boolean;
+begin
+  Result := Check(gttNot);
+  if not Result then
+    Exit;
+
+  if AIsConst then
+    raise TGocciaSyntaxError.Create(
+      'A definite assignment assertion is not permitted on a const declaration',
+      Peek.Line, Peek.Column, FFileName, FSourceLines,
+      SSuggestDefiniteAssignmentNotOnConst);
+
+  Advance;
+end;
+
 function TGocciaParser.DeclarationStatement: TGocciaStatement;
 var
   IsConst: Boolean;
+  HasDefiniteAssignment: Boolean;
   Name: string;
   Line, Column: Integer;
   Variables: TArray<TGocciaVariableInfo>;
@@ -4945,11 +5040,24 @@ begin
         SSuggestProvideVariableName).Lexeme;
       Variables[VariableCount].Name := Name;
 
+      HasDefiniteAssignment := ParseDefiniteAssignmentAssertion(IsConst);
+
       if Check(gttColon) then
       begin
         Advance;
         Variables[VariableCount].TypeAnnotation := CollectTypeAnnotation([gttAssign, gttSemicolon, gttComma]);
-      end;
+      end
+      else if HasDefiniteAssignment then
+        raise TGocciaSyntaxError.Create(
+          'Declarations with definite assignment assertions must also have type annotations',
+          Previous.Line, Previous.Column, FFileName, FSourceLines,
+          SSuggestDefiniteAssignmentNeedsAnnotation);
+
+      if HasDefiniteAssignment and Check(gttAssign) then
+        raise TGocciaSyntaxError.Create(
+          'Declarations with initializers cannot also have definite assignment assertions',
+          Peek.Line, Peek.Column, FFileName, FSourceLines,
+          SSuggestDefiniteAssignmentNoInitializer);
 
       if Match(gttAssign) then
       begin
@@ -5421,6 +5529,7 @@ function TGocciaParser.VarStatement: TGocciaStatement;
 var
   Line, Column: Integer;
   Name: string;
+  HasDefiniteAssignment: Boolean;
   Variables: TArray<TGocciaVariableInfo>;
   VariableCount: Integer;
 
@@ -5470,11 +5579,24 @@ begin
       Name := ConsumeVarBindingName.Lexeme;
       Variables[VariableCount].Name := Name;
 
+      HasDefiniteAssignment := ParseDefiniteAssignmentAssertion(False);
+
       if Check(gttColon) then
       begin
         Advance;
         Variables[VariableCount].TypeAnnotation := CollectTypeAnnotation([gttAssign, gttSemicolon, gttComma]);
-      end;
+      end
+      else if HasDefiniteAssignment then
+        raise TGocciaSyntaxError.Create(
+          'Declarations with definite assignment assertions must also have type annotations',
+          Previous.Line, Previous.Column, FFileName, FSourceLines,
+          SSuggestDefiniteAssignmentNeedsAnnotation);
+
+      if HasDefiniteAssignment and Check(gttAssign) then
+        raise TGocciaSyntaxError.Create(
+          'Declarations with initializers cannot also have definite assignment assertions',
+          Peek.Line, Peek.Column, FFileName, FSourceLines,
+          SSuggestDefiniteAssignmentNoInitializer);
 
       if Match(gttAssign) then
       begin
@@ -8104,6 +8226,27 @@ end;
 
 { Type annotation helpers (Types as Comments) }
 
+// True when AToken cannot end a type, so whatever follows it is still part
+// of the same type expression. Used to tell a structured type operand apart
+// from the '{' that opens a function body: in `(): string | { a: number } {`
+// the first '{' follows a '|' and continues the union, while the second follows
+// a complete type and starts the body.
+function TypeOperatorExpectsOperand(const AToken: TGocciaToken): Boolean;
+begin
+  case AToken.TokenType of
+    gttBitwiseOr, gttBitwiseAnd, gttArrow, gttExtends, gttQuestion, gttColon:
+      Result := True;
+    gttIdentifier:
+      Result := (AToken.Lexeme = KEYWORD_KEYOF) or
+        (AToken.Lexeme = KEYWORD_READONLY) or
+        (AToken.Lexeme = KEYWORD_INFER) or
+        (AToken.Lexeme = KEYWORD_ASSERTS) or
+        (AToken.Lexeme = KEYWORD_IS);
+  else
+    Result := False;
+  end;
+end;
+
 function TGocciaParser.CollectTypeAnnotation(
   const ATerminators: array of TGocciaTokenType;
   const AContextualTerminator: string;
@@ -8112,11 +8255,23 @@ function TGocciaParser.CollectTypeAnnotation(
 var
   Depth: Integer;
   I: Integer;
+  TemplateStart: Integer;
   TokenType: TGocciaTokenType;
   IsTerminator: Boolean;
+  ContinuesType: Boolean;
+  PreviousTypeToken: TGocciaToken;
+
+  procedure AppendLexeme(const ALexeme: string);
+  begin
+    if Result <> '' then
+      Result := Result + ' ';
+    Result := Result + ALexeme;
+  end;
+
 begin
   Result := '';
   Depth := 0;
+  PreviousTypeToken := nil;
 
   while not IsAtEnd do
   begin
@@ -8142,10 +8297,30 @@ begin
           IsTerminator := True;
           Break;
         end;
-      if IsTerminator and not
-         (AAllowInitialObjectType and (Result = '') and
-          (TokenType = gttLeftBrace)) then
+      // A '{' terminator opens the function body only once the type collected
+      // so far is complete — at the start of the annotation, and after a type
+      // operator such as '|', '&' or '=>', it is a structured type instead.
+      ContinuesType := AAllowInitialObjectType and (TokenType = gttLeftBrace) and
+        ((Result = '') or
+         (Assigned(PreviousTypeToken) and
+          TypeOperatorExpectsOperand(PreviousTypeToken)));
+      if IsTerminator and not ContinuesType then
         Exit;
+    end;
+
+    // Template literal types (`id-${number}`) are consumed whole with the
+    // operand-aware skipper: lexing them token by token under the default goal
+    // would let the substitution's '}' close a structural brace and re-lex the
+    // trailing chunk as a fresh, unterminated template literal.
+    if (TokenType = gttTemplate) or (TokenType = gttTemplateHead) then
+    begin
+      TemplateStart := FCurrent;
+      SkipTemplateLiteral;
+      for I := TemplateStart to FCurrent - 1 do
+        AppendLexeme(FTokens[I].Lexeme);
+      if FCurrent > TemplateStart then
+        PreviousTypeToken := FTokens[FCurrent - 1];
+      Continue;
     end;
 
     case TokenType of
@@ -8160,10 +8335,15 @@ begin
       gttRightShift: Dec(Depth, 2);
       gttUnsignedRightShift: Dec(Depth, 3);
     end;
+    // Clamp so an unbalanced closer (a stray '>', or a '>>' closing a single
+    // '<') cannot drive Depth negative — the terminator checks above only run
+    // at Depth = 0, and a negative Depth would never reach it again, silently
+    // swallowing the rest of the file.
+    if Depth < 0 then
+      Depth := 0;
 
-    if Result <> '' then
-      Result := Result + ' ';
-    Result := Result + Peek.Lexeme;
+    PreviousTypeToken := Peek;
+    AppendLexeme(Peek.Lexeme);
     Advance;
   end;
 end;
@@ -8193,6 +8373,9 @@ begin
   Advance;
   Depth := 1;
 
+  // Depth is clamped at zero after every closer so a '>>' or '>>>' that closes
+  // fewer '<' than it decrements leaves the counter at the balanced value
+  // instead of going negative.
   while not IsAtEnd and (Depth > 0) do
   begin
     case Peek.TokenType of
@@ -8201,6 +8384,8 @@ begin
       gttRightShift:
       begin
         Dec(Depth, 2);
+        if Depth < 0 then
+          Depth := 0;
         Result := Result + ' ' + Peek.Lexeme;
         Advance;
         Continue;
@@ -8208,11 +8393,15 @@ begin
       gttUnsignedRightShift:
       begin
         Dec(Depth, 3);
+        if Depth < 0 then
+          Depth := 0;
         Result := Result + ' ' + Peek.Lexeme;
         Advance;
         Continue;
       end;
     end;
+    if Depth < 0 then
+      Depth := 0;
     Result := Result + ' ' + Peek.Lexeme;
     Advance;
   end;
@@ -8292,11 +8481,15 @@ begin
       Continue;
     end;
 
+    // '<' and '>' are deliberately not counted here. Nothing they can enclose
+    // needs protection from the ';' / '}' terminators (a type argument list
+    // holds no bare ';', and any ';' inside a mapped type is already covered by
+    // the brace depth), while counting them desynchronises the skip on ordinary
+    // relational expressions: `var x = a < b;` would leave Depth at 1 and run
+    // the skip past its own statement.
     case Peek.TokenType of
-      gttLeftParen, gttLeftBracket, gttLeftBrace, gttLess: Inc(Depth);
-      gttRightParen, gttRightBracket, gttRightBrace, gttGreater: Dec(Depth);
-      gttRightShift: Dec(Depth, 2);
-      gttUnsignedRightShift: Dec(Depth, 3);
+      gttLeftParen, gttLeftBracket, gttLeftBrace: Inc(Depth);
+      gttRightParen, gttRightBracket, gttRightBrace: Dec(Depth);
       gttSemicolon:
         if Depth = 0 then
         begin
@@ -8304,6 +8497,8 @@ begin
           Exit;
         end;
     end;
+    if Depth < 0 then
+      Depth := 0;
     Advance;
   end;
 end;

--- a/source/units/Goccia.Parser.pas
+++ b/source/units/Goccia.Parser.pas
@@ -4989,7 +4989,11 @@ end;
 function TGocciaParser.ParseDefiniteAssignmentAssertion(
   const AIsConst: Boolean): Boolean;
 begin
-  Result := Check(gttNot);
+  // Restricted production: the '!' must sit on the same line as the binding
+  // name. Without this, ASI code such as `let x` / newline / `!fn()` would have
+  // its leading-'!' expression statement swallowed as an assertion instead of
+  // starting a new statement. Mirrors the break/continue label restriction.
+  Result := Check(gttNot) and (Previous.Line = Peek.Line);
   if not Result then
     Exit;
 
@@ -8290,6 +8294,17 @@ begin
           Exit;
       end;
 
+      // Under ASI a line break ends the annotation once the collected type is
+      // complete. An annotation without an initializer has no terminator on its
+      // own line, so without this the collector runs into the next statement:
+      // `let v: number` / newline / `v = 5` collected "number v" and then took
+      // the next line's assignment as the declaration's initializer. A break
+      // after a type operator ('|', '&', '=>', ...) still continues the type.
+      if FAutomaticSemicolonInsertion and (Result <> '') and
+         (Previous.Line < Peek.Line) and Assigned(PreviousTypeToken) and
+         not TypeOperatorExpectsOperand(PreviousTypeToken) then
+        Exit;
+
       IsTerminator := False;
       for I := 0 to High(ATerminators) do
         if TokenType = ATerminators[I] then
@@ -8463,14 +8478,37 @@ end;
 procedure TGocciaParser.SkipUntilSemicolon;
 var
   Depth: Integer;
+
+  // A line break ends the skipped statement under ASI — except where a
+  // semicolon could not legally be inserted anyway. Since '<' and '>' are not
+  // depth-counted below, that carve-out is what keeps a type argument list
+  // broken across lines together:
+  //
+  //   type Handler = Map<
+  //     string,
+  //     number
+  //   >;
+  //
+  // The line breaks there follow a '<' or a ',' (neither can end a statement)
+  // or precede a '>' (which cannot start one), so none of them is an ASI point.
+  // A relational expression like `var x = 1 < 2` followed by a new statement
+  // still breaks at the newline, because its break sits after a complete
+  // operand.
+  function IsAutomaticSemicolonPoint: Boolean;
+  begin
+    Result := FAutomaticSemicolonInsertion and (Previous.Line < Peek.Line) and
+      not (Previous.TokenType in [gttLess, gttComma]) and
+      not (Peek.TokenType in [gttGreater, gttRightShift,
+        gttUnsignedRightShift]);
+  end;
+
 begin
   Depth := 0;
   while not IsAtEnd do
   begin
     if (Depth = 0) and Check(gttRightBrace) then
       Exit;
-    if (Depth = 0) and FAutomaticSemicolonInsertion and
-      (Previous.Line < Peek.Line) then
+    if (Depth = 0) and IsAutomaticSemicolonPoint then
       Exit;
 
     // Skip template literals whole so a substitution's closing '}' is not

--- a/source/units/Goccia.Parser.pas
+++ b/source/units/Goccia.Parser.pas
@@ -2159,6 +2159,24 @@ begin
         begin
           Result := ParseMemberAccessSegment(Result, False, True, Line, Column);
         end;
+      gttNot:
+        begin
+          // TypeScript non-null assertion (postfix '!'): `a.b!.c`, `f()!.x`,
+          // `arr[0]!.y`, `a?.b!.c`, `x!++`. Types-as-comments, so it is erased
+          // — Result is left untouched and the chain continues, which keeps
+          // optional-chain short-circuiting and assignment targets intact.
+          //
+          // Restricted production: no LineTerminator before the '!', matching
+          // TypeScript. Without this, `const a = b` / newline / `!fn()` under
+          // ASI would absorb the next statement's leading '!'.
+          //
+          // '!=' and '!==' lex as single tokens (gttLooseNotEqual /
+          // gttNotEqual), so a comparison never reaches this branch.
+          if Peek.Line <> Previous.Line then
+            Break;
+
+          Advance;
+        end;
       gttIncrement, gttDecrement:
         begin
           if Peek.Line <> Previous.Line then

--- a/source/units/Goccia.SourcePipeline.pas
+++ b/source/units/Goccia.SourcePipeline.pas
@@ -183,7 +183,13 @@ begin
   Result := ASource;
   ASourceMap := nil;
 
-  if ppJSX in AOptions.Preprocessors then
+  // '.ts' sources never contain JSX, so '<' stays type syntax there: running
+  // the transformer would rewrite generic annotations such as
+  // `const g: <T>(x: T) => T` into a bogus JSX element before the parser sees
+  // them. Every other extension keeps its current behaviour, including JSX in
+  // '.js' (transformed, with the non-JSX-extension warning).
+  if (ppJSX in AOptions.Preprocessors) and
+     not IsJSXExcludedExtension(ExtractFileExt(AFileName)) then
   begin
     JSXResult := TGocciaJSXTransformer.Transform(Result, AFileName);
     Result := JSXResult.Source;

--- a/tests/language/asi/definite-assignment-restriction.js
+++ b/tests/language/asi/definite-assignment-restriction.js
@@ -1,0 +1,41 @@
+/*---
+description: A definite assignment assertion "!" must follow the binding name on the same line, so a leading-"!" statement after ASI is not absorbed
+features: [automatic-semicolon-insertion, types-as-comments]
+---*/
+
+describe("definite assignment assertion line restriction", () => {
+  test("leading-! expression statement starts a new statement", () => {
+    let ran = false
+    let x
+    !(() => { ran = true; })()
+
+    expect(ran).toBe(true);
+    expect(x).toBeUndefined();
+  });
+
+  test("leading-! negation after an uninitialized declaration", () => {
+    const truthy = 1
+    let flag
+    !truthy
+
+    expect(flag).toBeUndefined();
+    expect(!truthy).toBe(false);
+  });
+
+  test("same-line assertion is still an assertion", () => {
+    let value!: number
+    value = 5
+
+    expect(value).toBe(5);
+  });
+
+  test("assertion and a following leading-! statement", () => {
+    let seen = false
+    let value!: number
+    value = 7
+    !(() => { seen = true; })()
+
+    expect(value).toBe(7);
+    expect(seen).toBe(true);
+  });
+});

--- a/tests/language/asi/non-null-assertion-restriction.js
+++ b/tests/language/asi/non-null-assertion-restriction.js
@@ -1,0 +1,42 @@
+/*---
+description: A postfix non-null assertion "!" must follow its operand on the same line, so a leading-"!" statement after ASI is not absorbed
+features: [automatic-semicolon-insertion, types-as-comments]
+---*/
+
+describe("non-null assertion line restriction", () => {
+  test("leading-! expression statement starts a new statement", () => {
+    let ran = false
+    const value = 1
+    !(() => { ran = true; })()
+
+    expect(value).toBe(1);
+    expect(ran).toBe(true);
+  });
+
+  test("leading-! after a member access starts a new statement", () => {
+    let ran = false
+    const holder = { v: "x" }
+    const read = holder.v
+    !(() => { ran = true; })()
+
+    expect(read).toBe("x");
+    expect(ran).toBe(true);
+  });
+
+  test("same-line assertion is still erased", () => {
+    const holder = { v: "abc" }
+    const length = holder.v!.length
+
+    expect(length).toBe(3);
+  });
+
+  test("assertion and a following leading-! statement", () => {
+    let ran = false
+    const holder = { v: "abc" }
+    const length = holder.v!.length
+    !(() => { ran = true; })()
+
+    expect(length).toBe(3);
+    expect(ran).toBe(true);
+  });
+});

--- a/tests/language/asi/type-annotations.js
+++ b/tests/language/asi/type-annotations.js
@@ -1,0 +1,51 @@
+/*---
+description: A type annotation with no initializer ends at the line break under ASI instead of running into the next statement
+features: [automatic-semicolon-insertion, types-as-comments]
+---*/
+
+describe("ASI type annotations", () => {
+  test("annotation without an initializer does not absorb the next statement", () => {
+    let value: number
+    value = 5
+
+    expect(value).toBe(5);
+  });
+
+  test("the statement after an uninitialized annotation still runs", () => {
+    let first: string
+    let ran = false
+    ran = true
+
+    expect(first).toBeUndefined();
+    expect(ran).toBe(true);
+  });
+
+  test("annotated declaration with an initializer is unchanged", () => {
+    let value: number = 3
+    const doubled = value * 2
+
+    expect(doubled).toBe(6);
+  });
+
+  test("a union broken after the operator continues on the next line", () => {
+    let value: string |
+      number = "kept"
+
+    expect(value).toBe("kept");
+  });
+
+  test("an annotation broken right after the colon continues", () => {
+    let value:
+      number = 4
+
+    expect(value).toBe(4);
+  });
+
+  test("structured annotation spanning lines", () => {
+    let config: {
+      retries: number
+    } = { retries: 2 }
+
+    expect(config.retries).toBe(2);
+  });
+});

--- a/tests/language/types-as-comments/definite-assignment.js
+++ b/tests/language/types-as-comments/definite-assignment.js
@@ -1,0 +1,60 @@
+/*---
+description: Definite assignment assertions on variable declarations are parsed and ignored at runtime
+features: [types-as-comments]
+---*/
+
+describe("definite assignment assertions", () => {
+
+test("let with a definite assignment assertion", () => {
+  let value!: number;
+  value = 5;
+
+  expect(value).toBe(5);
+});
+
+test("structured annotation after the assertion", () => {
+  let config!: { retries: number };
+  config = { retries: 2 };
+
+  expect(config.retries).toBe(2);
+});
+
+test("union annotation after the assertion", () => {
+  let entry!: string | null;
+  entry = "ready";
+
+  expect(entry).toBe("ready");
+});
+
+test("mixed declarators in one statement", () => {
+  let first!: string, second: number = 2, third!: boolean;
+  first = "x";
+  third = true;
+
+  expect(first).toBe("x");
+  expect(second).toBe(2);
+  expect(third).toBe(true);
+});
+
+test("the binding is undefined before it is assigned", () => {
+  let pending!: number;
+
+  expect(pending).toBeUndefined();
+});
+
+test("the annotation is still enforced after the assertion", () => {
+  let counter!: number;
+  counter = 1;
+
+  expect(counter).toBe(1);
+  expect(() => { counter = "two"; }).toThrow(TypeError);
+});
+
+test("logical not is unaffected", () => {
+  let flag = true;
+
+  expect(!flag).toBe(false);
+  expect(!!flag).toBe(true);
+});
+
+});

--- a/tests/language/types-as-comments/definite-assignment.js
+++ b/tests/language/types-as-comments/definite-assignment.js
@@ -3,6 +3,11 @@ description: Definite assignment assertions on variable declarations are parsed 
 features: [types-as-comments]
 ---*/
 
+// The three rejection rules ('!' without an annotation, '!' with an initializer,
+// '!' on a const) are parse errors and are covered in scripts/test-cli-parser.ts.
+// The same-line restriction on '!' is covered in
+// tests/language/asi/definite-assignment-restriction.js.
+
 describe("definite assignment assertions", () => {
 
 test("let with a definite assignment assertion", () => {

--- a/tests/language/types-as-comments/function-keyword/union-intersection-return-types.js
+++ b/tests/language/types-as-comments/function-keyword/union-intersection-return-types.js
@@ -1,0 +1,38 @@
+/*---
+description: Union and intersection return types on function-keyword forms are parsed and ignored at runtime
+features: [types-as-comments, compat-function]
+---*/
+
+test("function declaration with a union return type", () => {
+  function classify(flag: boolean): string | { code: number } {
+    return flag ? "ok" : { code: 7 };
+  }
+
+  expect(classify(true)).toBe("ok");
+  expect(classify(false).code).toBe(7);
+});
+
+test("function declaration with an intersection return type", () => {
+  function combine(): { a: string } & { b: number } {
+    return { a: "s", b: 1 };
+  }
+
+  expect(combine().a).toBe("s");
+  expect(combine().b).toBe(1);
+});
+
+test("function expression with a union of object types", () => {
+  const make = function (): { kind: string } | { kind: string; size: number } {
+    return { kind: "leaf" };
+  };
+
+  expect(make().kind).toBe("leaf");
+});
+
+test("generic function declaration with a structured union return type", () => {
+  function wrap<T>(value: T): { value: T } | null {
+    return { value: value };
+  }
+
+  expect(wrap(3).value).toBe(3);
+});

--- a/tests/language/types-as-comments/generic-arrow-functions.js
+++ b/tests/language/types-as-comments/generic-arrow-functions.js
@@ -1,0 +1,72 @@
+/*---
+description: Generic arrow function expressions parse in JSX-capable sources when the type parameter list is unambiguous
+features: [types-as-comments]
+---*/
+
+describe("generic arrow functions", () => {
+
+test("trailing-comma type parameter list", () => {
+  const identity = <T,>(v: T): T => v;
+
+  expect(identity("hi")).toBe("hi");
+  expect(identity(3)).toBe(3);
+});
+
+test("default type parameter", () => {
+  const withDefault = <T = string,>(v: T): T => v;
+
+  expect(withDefault("hi")).toBe("hi");
+});
+
+test("multiple type parameters", () => {
+  const pair = <A, B>(a: A, b: B): [A, B] => [a, b];
+  const result = pair("x", 1);
+
+  expect(result[0]).toBe("x");
+  expect(result[1]).toBe(1);
+});
+
+test("block body and destructured parameters", () => {
+  const sum = <T,>({ a, b }: { a: number, b: number }): number => {
+    return a + b;
+  };
+
+  expect(sum({ a: 1, b: 2 })).toBe(3);
+});
+
+test("no-parameter generic arrow", () => {
+  const make = <T,>(): string => "made";
+
+  expect(make()).toBe("made");
+});
+
+test("generic arrow returning a generic arrow", () => {
+  const outer = <T,>(v: T) => <U,>(u: U): T => v;
+
+  expect(outer("kept")(1)).toBe("kept");
+});
+
+test("generic arrow as a call argument", () => {
+  const apply = (fn, value) => fn(value);
+
+  expect(apply(<T,>(v: T): T => v, "through")).toBe("through");
+});
+
+test("relational chains are unchanged", () => {
+  const a = 1;
+  const b = 2;
+  const c = 3;
+
+  expect(a < b > c).toBe(false);
+  expect(a < b).toBe(true);
+});
+
+test("comparison followed by a parenthesized operand stays relational", () => {
+  const a = 1;
+  const b = 5;
+  const c = 0;
+
+  expect(a < b > (c)).toBe(true);
+});
+
+});

--- a/tests/language/types-as-comments/generic-function-types.ts
+++ b/tests/language/types-as-comments/generic-function-types.ts
@@ -1,0 +1,60 @@
+/*---
+description: Angle-bracket type syntax in .ts sources, where '<' is never JSX
+features: [types-as-comments]
+---*/
+
+describe("generic function type annotations", () => {
+
+test("generic function type annotation on a const", () => {
+  const identity: <T>(x: T) => T = (x) => x;
+
+  expect(identity("hi")).toBe("hi");
+  expect(identity(1)).toBe(1);
+});
+
+test("multi-parameter generic function type", () => {
+  const first: <T, U>(a: T, b: U) => T = (a) => a;
+
+  expect(first("a", 1)).toBe("a");
+});
+
+test("constrained generic function type", () => {
+  const pluck: <T extends { id: number }>(v: T) => number = (v) => v.id;
+
+  expect(pluck({ id: 4 })).toBe(4);
+});
+
+test("generic function type inside a union", () => {
+  const maybe: (<T>(x: T) => T) | null = (x) => x;
+
+  expect(maybe("kept")).toBe("kept");
+});
+
+test("bare type parameter on a generic arrow expression", () => {
+  const wrap = <T>(v: T): T[] => [v];
+
+  expect(wrap("x")[0]).toBe("x");
+});
+
+test("constrained type parameter on a generic arrow expression", () => {
+  const idOf = <T extends { id: number }>(v: T): number => v.id;
+
+  expect(idOf({ id: 9 })).toBe(9);
+});
+
+test("default type parameter on a generic arrow expression", () => {
+  const withDefault = <T = string>(v: T): T => v;
+
+  expect(withDefault("hi")).toBe("hi");
+});
+
+test("relational chains are unchanged", () => {
+  const a = 1;
+  const b = 2;
+  const c = 3;
+
+  expect(a < b > c).toBe(false);
+  expect(a < b).toBe(true);
+});
+
+});

--- a/tests/language/types-as-comments/non-null-assertion.js
+++ b/tests/language/types-as-comments/non-null-assertion.js
@@ -1,0 +1,106 @@
+/*---
+description: Postfix non-null assertions are parsed and erased, leaving the member/call chain untouched
+features: [types-as-comments]
+---*/
+
+describe("non-null assertions", () => {
+
+test("assertion before a member access", () => {
+  const nonNull = { v: "x" };
+
+  expect(nonNull.v!.length).toBe(1);
+});
+
+test("assertion at the end of an expression", () => {
+  const nonNull = { v: "x" };
+  const bare = nonNull.v!;
+
+  expect(bare).toBe("x");
+});
+
+test("assertion after a call", () => {
+  const make = () => ({ x: 7 });
+
+  expect(make()!.x).toBe(7);
+});
+
+test("assertion after an index access", () => {
+  const arr = [{ y: 3 }];
+
+  expect(arr[0]!.y).toBe(3);
+});
+
+test("chained assertions", () => {
+  const deep = { a: { b: { c: 5 } } };
+
+  expect(deep.a!.b!.c).toBe(5);
+});
+
+test("assertion on a parenthesized expression before a call", () => {
+  const fn = () => "called";
+
+  expect((fn)!()).toBe("called");
+});
+
+test("assertion combined with optional chaining", () => {
+  const present = { a: { b: "deep" } };
+
+  expect(present.a?.b!.length).toBe(4);
+});
+
+test("optional chain still short-circuits through an assertion", () => {
+  const absent = { a: null };
+
+  expect(absent.a?.b!.c).toBeUndefined();
+});
+
+test("assertion before postfix increment", () => {
+  let counter = 1;
+  const previous = counter!++;
+
+  expect(previous).toBe(1);
+  expect(counter).toBe(2);
+});
+
+test("assertion on an assignment target", () => {
+  const target = { value: 0 };
+  target!.value = 9;
+
+  expect(target.value).toBe(9);
+});
+
+test("assertion before a call on the result", () => {
+  const holder = { fn: () => "ran" };
+
+  expect(holder.fn!()).toBe("ran");
+});
+
+test("strict inequality is not an assertion", () => {
+  // '!==' and '!=' lex as single tokens, so they never reach the postfix
+  // assertion branch. '!=' needs --compat-loose-equality and is covered in
+  // tests/language/expressions/loose-equality/.
+  const a = 1;
+  const b = 2;
+
+  expect(a !== b).toBe(true);
+  expect(a !== 1).toBe(false);
+});
+
+test("prefix logical not is unaffected", () => {
+  const truthy = 1;
+  const nested = { v: "x" };
+
+  expect(!truthy).toBe(false);
+  expect(!nested.v!.length).toBe(false);
+  expect(!!nested.v!).toBe(true);
+});
+
+test("assertion inside call arguments and array literals", () => {
+  const nonNull = { v: "abc" };
+  const lengths = [nonNull.v!.length];
+
+  expect(lengths[0]).toBe(3);
+  expect(Math.max(nonNull.v!.length, 1)).toBe(3);
+});
+
+});

--- a/tests/language/types-as-comments/template-literal-types.js
+++ b/tests/language/types-as-comments/template-literal-types.js
@@ -1,0 +1,66 @@
+/*---
+description: Template literal types are parsed and ignored at runtime
+features: [types-as-comments]
+---*/
+
+describe("template literal types", () => {
+
+test("variable annotation with a substitution", () => {
+  const id: `id-${number}` = "id-42";
+
+  expect(id).toBe("id-42");
+});
+
+test("as-expression position", () => {
+  const id = "id-42" as `id-${number}`;
+
+  expect(id).toBe("id-42");
+});
+
+test("template type without substitutions", () => {
+  const tag: `fixed` = "fixed";
+
+  expect(tag).toBe("fixed");
+});
+
+test("multiple substitutions", () => {
+  const key: `${string}-${number}` = "a-1";
+
+  expect(key).toBe("a-1");
+});
+
+test("union with a template literal member", () => {
+  const value: `on-${string}` | null = "on-click";
+
+  expect(value).toBe("on-click");
+});
+
+test("parameter and return annotations", () => {
+  const echo = (input: `v${number}`): `v${number}` => input;
+
+  expect(echo("v1")).toBe("v1");
+});
+
+test("nested template type inside a substitution", () => {
+  const nested: `a-${`b-${string}`}` = "a-b-c";
+
+  expect(nested).toBe("a-b-c");
+});
+
+test("template literal expressions are unaffected", () => {
+  const n = 42;
+  const label: `id-${number}` = "id-7";
+
+  expect(`id-${n}`).toBe("id-42");
+  expect(`${label}!`).toBe("id-7!");
+});
+
+test("statements after a template literal type still parse", () => {
+  const first: `id-${number}` = "id-1";
+  const second = 2;
+
+  expect(first).toBe("id-1");
+  expect(second).toBe(2);
+});
+
+});

--- a/tests/language/types-as-comments/union-intersection-return-types.js
+++ b/tests/language/types-as-comments/union-intersection-return-types.js
@@ -1,0 +1,114 @@
+/*---
+description: Union and intersection return types whose members are object types are parsed and ignored at runtime
+features: [types-as-comments]
+---*/
+
+describe("union and intersection return types", () => {
+
+test("class method union return type with an object member", () => {
+  class Registry {
+    lookup(flag: boolean): string | { code: number } {
+      return flag ? "ok" : { code: 7 };
+    }
+  }
+
+  const registry = new Registry();
+
+  expect(registry.lookup(true)).toBe("ok");
+  expect(registry.lookup(false).code).toBe(7);
+});
+
+test("class method intersection return type", () => {
+  class Builder {
+    build(): { name: string } & { size: number } {
+      return { name: "box", size: 2 };
+    }
+  }
+
+  const built = new Builder().build();
+
+  expect(built.name).toBe("box");
+  expect(built.size).toBe(2);
+});
+
+test("object type leading a union return type", () => {
+  class Reader {
+    read(): { value: number } | null {
+      return { value: 3 };
+    }
+  }
+
+  expect(new Reader().read().value).toBe(3);
+});
+
+test("object method with a structured union return type", () => {
+  const factory = {
+    make(): { kind: string } | string {
+      return { kind: "leaf" };
+    },
+  };
+
+  expect(factory.make().kind).toBe("leaf");
+});
+
+test("getter with a structured union return type", () => {
+  class Cell {
+    get current(): number | { boxed: number } {
+      return 9;
+    }
+  }
+
+  expect(new Cell().current).toBe(9);
+});
+
+test("function-type return type followed by the body brace", () => {
+  class Maker {
+    make(): () => { tag: string } {
+      return () => ({ tag: "leaf" });
+    }
+  }
+
+  expect(new Maker().make()().tag).toBe("leaf");
+});
+
+test("conditional return type with object branches", () => {
+  class Picker {
+    pick(): string extends string ? { hit: boolean } : { miss: boolean } {
+      return { hit: true };
+    }
+  }
+
+  expect(new Picker().pick().hit).toBe(true);
+});
+
+test("nested unions and intersections", () => {
+  class Deep {
+    shape(): { a: { b: string } } & ({ c: number } | { d: number }) {
+      return { a: { b: "x" }, c: 1 };
+    }
+  }
+
+  expect(new Deep().shape().a.b).toBe("x");
+});
+
+test("union members separated across lines", () => {
+  class Wrapped {
+    read():
+      | string
+      | { code: number } {
+      return "ok";
+    }
+  }
+
+  expect(new Wrapped().read()).toBe("ok");
+});
+
+test("arrow function union return type is unchanged", () => {
+  const pick = (flag: boolean): string | { code: number } =>
+    flag ? "ok" : { code: 1 };
+
+  expect(pick(true)).toBe("ok");
+  expect(pick(false).code).toBe(1);
+});
+
+});

--- a/tests/language/var/definite-assignment.js
+++ b/tests/language/var/definite-assignment.js
@@ -3,6 +3,9 @@ description: var declarations accept definite assignment assertions, which are e
 features: [compat-var, types-as-comments]
 ---*/
 
+// The rejection rules are parse errors and are covered in
+// scripts/test-cli-parser.ts.
+
 test("var with a definite assignment assertion", () => {
   var value!: number;
   value = 5;

--- a/tests/language/var/definite-assignment.js
+++ b/tests/language/var/definite-assignment.js
@@ -1,0 +1,24 @@
+/*---
+description: var declarations accept definite assignment assertions, which are erased at runtime
+features: [compat-var, types-as-comments]
+---*/
+
+test("var with a definite assignment assertion", () => {
+  var value!: number;
+  value = 5;
+
+  expect(value).toBe(5);
+});
+
+test("var assertion with a structured annotation", () => {
+  var config!: { retries: number };
+  config = { retries: 2 };
+
+  expect(config.retries).toBe(2);
+});
+
+test("var binding is undefined before it is assigned", () => {
+  var pending!: string;
+
+  expect(pending).toBeUndefined();
+});


### PR DESCRIPTION
## Summary

- Closes the five TS type-syntax gaps from the handover (F5–F9), all verified byte-identical to bun's transpile semantics: union/intersection return types (a `{` after a type operator continues the type), template-literal types (goal-switching template skip inside the type collector), generic function-type annotations, generic arrow expressions (speculative `<` parse in operand position with checkpoint/restore), definite-assignment assertions with TS's three usage rules enforced as a same-line restricted production, and postfix non-null assertions erased throughout member/call chains (`a.b!.c`, `f()!.x`, `a?.b!.c`).
- The JSX preprocessor is skipped for `.ts` files — TypeScript's own rule (`.ts` keeps angle-bracket syntax; JSX needs `.jsx`/`.tsx`); JSX-in-`.js` behavior is unchanged.
- Hardening: type-collector depth counters clamp at zero; `SkipUntilSemicolon` no longer counts `< >` as brackets (a stray comparison can no longer swallow statements) with an ASI carve-out for multi-line generic type aliases; a pre-existing ASI annotation-swallowing bug (no line-break stop in the collector) is fixed.
- `a < b > c` / `a < b > (c)` comparison chains are regression-guarded.

Part of the 0.11.0 adversarial-findings stacked-PR train (8 layers, each PR targets the layer below; merge bottom-up). Mini-spec: fix the differential-testing findings F1–F13/G4/G5 — JSX-transformer hang, toThrow semantics, Vitest matcher parity, coverage consistency, TS type-syntax gaps, AbortSignal events — and land the goccia-vs-bun differential battery harness as a CI gate, green at every layer.

## Testing

- [x] End-to-end tests — ~90 new assertions across types-as-comments/ASI/var test files, green in both modes; negative parse-error cases in `scripts/test-cli-parser.ts`; differential battery A (13 type-syntax tests) goes 13p/0f under goccia-interp, goccia-bytecode, and bun in the capstone layer
- [x] Updated documentation — `docs/language.md` (new supported forms, Angle Brackets and JSX section, ASI notes, non-support entries)
- [ ] Optional: native Pascal tests — n/a (parser changes exercised via JS/CLI suites per project convention)
- [ ] Optional: benchmarks — n/a

Review: fresh-context review probed the type-collector, speculative parse, and checkpoint discipline and could not construct a counterexample; its two "fix-first" items (ASI restricted production, negative tests) resolved in the follow-up commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
