### PR TITLE
feat(runtime): WHATWG EventTarget base with AbortSignal abort events

### DIFF
--- a/docs/adr/0104-whatwg-eventtarget-base.md
+++ b/docs/adr/0104-whatwg-eventtarget-base.md
@@ -1,0 +1,69 @@
+# WHATWG EventTarget base for AbortSignal
+
+**Date:** 2026-08-05
+**Area:** `runtime`
+
+GocciaScript provides a real `EventTarget` base class and a minimal `Event`
+value, and `AbortSignal` genuinely inherits from it. This supersedes the
+narrower non-goal recorded in [ADR 0031](0031-fetch-only-async-io.md), which
+stated that EventTarget listeners and the `abort` event were out of scope for
+the fetch-only cancellation surface. The rest of ADR 0031 stands unchanged: no
+general event loop, no timer task queue, and fetch completions still drain
+through the existing pump.
+
+`EventTarget` is constructible (`new EventTarget()`), exposes
+`addEventListener`, `removeEventListener`, and `dispatchEvent`, and follows
+[WHATWG DOM](https://dom.spec.whatwg.org/) § 2.7 listener-list semantics: a
+listener is identified by the `(type, callback, capture)` triple and is not
+added twice, `once` removes the listener before invoking it, removal during a
+dispatch is respected, and listeners appended during a dispatch are not invoked
+for that event. Non-callable object listeners are invoked through `handleEvent`
+with the listener object as the receiver. `Event` (§ 2.2) carries `type`,
+`target`, `currentTarget`, `bubbles`, `cancelable`, `defaultPrevented`, and
+`preventDefault()`. `dispatchEvent` throws an `InvalidStateError` `DOMException`
+when the event's dispatch flag is already set.
+
+The prototype chain is real rather than simulated: `AbortSignal.prototype`'s
+`[[Prototype]]` is `EventTarget.prototype` and `AbortSignal`'s `[[Prototype]]`
+is `EventTarget`, so `signal instanceof EventTarget` holds and the shared
+listener machinery is inherited rather than duplicated. `AbortSignal` follows
+§ 3.2 signal abort ordering: an already-aborted signal returns early, the abort
+reason is set, fetch's rejection (the only abort algorithm in this runtime) runs
+next, and the `abort` event is fired last. A signal aborts at most once, so the
+`abort` event fires at most once and a listener registered after the abort never
+runs. `onabort` is an event handler IDL attribute (§ 8.1.5.1): its listener is
+registered when a non-null handler is first assigned and keeps that registration
+position, so assigning `null` clears the handler without reordering the
+remaining listeners.
+
+Because there is no timer task queue, an `AbortSignal.timeout()` signal aborts
+at the moment the host observes its expiry, and the `abort` event is delivered
+at that same observation point — reading `.aborted` or `.reason` after expiry
+both flips the state and dispatches the event, exactly once. The state flip and
+the dispatch are separated internally so the fetch pump can settle its pending
+list before any listener runs; no script executes between the two, so a listener
+still cannot be registered after a signal aborted but before its event fires.
+
+`EventTarget` and `Event` ship with the same runtime extension as
+`AbortController`, `AbortSignal`, `Headers`, and `Response` rather than as core
+realm globals, because the core GocciaScript realm is ECMA-262 only and every
+WHATWG surface is opt-in through a runtime profile.
+
+One deliberate deviation: WHATWG DOM § 2.9 inner invoke *reports* an exception
+thrown by a listener rather than propagating it, so `dispatchEvent` and
+`controller.abort()` never throw on the listener's behalf. GocciaScript has no
+global error-reporting channel to report into, so an exception thrown by a
+listener propagates out of `dispatchEvent` (and out of `controller.abort()`)
+instead of being swallowed. Making it observable is preferred over discarding
+it; the dispatch state is still unwound, so the event and the target remain
+usable afterwards, and a signal's `abort` event is still marked as fired and
+never re-dispatched.
+
+Deliberately out of scope: there is no node tree, so `bubbles` and `capture` are
+recorded and reported faithfully but produce no propagation — `eventPhase`,
+`stopPropagation`, `stopImmediatePropagation`, `composed`, and `composedPath`
+are absent. `Event.timeStamp` and `isTrusted` are omitted rather than backed by
+an invented time origin. The `passive` listener option is accepted and ignored,
+the `signal` member of `AddEventListenerOptions` is not supported, and
+`AbortSignal.any()` and its dependent-signal propagation (§ 3.2 signal abort
+step 5) remain unimplemented. `CustomEvent` is not provided.

--- a/docs/adr/0104-whatwg-eventtarget-base.md
+++ b/docs/adr/0104-whatwg-eventtarget-base.md
@@ -27,11 +27,19 @@ The prototype chain is real rather than simulated: `AbortSignal.prototype`'s
 `[[Prototype]]` is `EventTarget.prototype` and `AbortSignal`'s `[[Prototype]]`
 is `EventTarget`, so `signal instanceof EventTarget` holds and the shared
 listener machinery is inherited rather than duplicated. `AbortSignal` follows
-§ 3.2 signal abort ordering: an already-aborted signal returns early, the abort
-reason is set, fetch's rejection (the only abort algorithm in this runtime) runs
-next, and the `abort` event is fired last. A signal aborts at most once, so the
-`abort` event fires at most once and a listener registered after the abort never
-runs. `onabort` is an event handler IDL attribute (§ 8.1.5.1): its listener is
+§ 3.2 signal abort ordering, and does so through the spec's own mechanism: the
+signal carries an abort-algorithms set that hosts register into. An
+already-aborted signal returns early, the abort reason is set, the registered
+algorithms run and the set is emptied, and the `abort` event is fired last.
+`fetch` is the one host that registers an algorithm today — it adds one per
+in-flight request that rejects that request's promise and drops its pending
+entry — so `controller.abort()` settles the fetch synchronously, before any
+listener observes the abort, rather than deferring the rejection to the next
+completion pump. Registering an algorithm on an already-aborted signal is
+refused, the same rule that governs listeners, and the host removes its
+algorithm when a request completes normally. A signal aborts at most once, so
+the `abort` event fires at most once and a listener registered after the abort
+never runs. `onabort` is an event handler IDL attribute (§ 8.1.5.1): its listener is
 registered when a non-null handler is first assigned and keeps that registration
 position, so assigning `null` clears the handler without reordering the
 remaining listeners.
@@ -39,10 +47,21 @@ remaining listeners.
 Because there is no timer task queue, an `AbortSignal.timeout()` signal aborts
 at the moment the host observes its expiry, and the `abort` event is delivered
 at that same observation point — reading `.aborted` or `.reason` after expiry
-both flips the state and dispatches the event, exactly once. The state flip and
-the dispatch are separated internally so the fetch pump can settle its pending
-list before any listener runs; no script executes between the two, so a listener
-still cannot be registered after a signal aborted but before its event fires.
+both flips the state and dispatches the event, exactly once. Timeout expiry is
+the one case where the state flip is separated from the algorithms and the
+event: it is detected while the fetch pump walks its pending-request list, and
+an abort algorithm mutates that list, so the pump flips the state during the
+walk and then runs the algorithms and fires the event once the walk is over. No
+script executes in that window, so a listener still cannot be registered after a
+signal aborted but before its event fires.
+
+A listener that throws during that pump-driven dispatch propagates out of the
+pumping call (typically an `await` on a fetch). The containment is deliberate
+and bounded: each signal's algorithms and event are processed as a unit, so the
+requests already rejected stay rejected and the signals not yet reached keep
+their pending state and are settled by the next pump. Completions already
+queued by worker threads are not lost either — they remain queued and settle at
+the next pump rather than being discarded.
 
 `EventTarget` and `Event` ship with the same runtime extension as
 `AbortController`, `AbortSignal`, `Headers`, and `Response` rather than as core

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -113,3 +113,4 @@ Durable architecture and implementation decisions for GocciaScript. New ADRs use
 - [0101 — Closed numeric scalar self-call frames](0101-closed-numeric-scalar-self-call-frames.md)
 - [0102 — Explicit bounded FFI call descriptors](0102-explicit-bounded-ffi-call-descriptors.md)
 - [0103 — Layer untrusted execution boundaries](0103-layered-untrusted-execution-boundaries.md)
+- [0104 — WHATWG EventTarget base for AbortSignal](0104-whatwg-eventtarget-base.md)

--- a/docs/built-ins-fetch.md
+++ b/docs/built-ins-fetch.md
@@ -77,7 +77,7 @@ GocciaScript does not provide a general timer task queue. Timeout signals theref
 | `signal.onabort` | Event handler attribute for the `abort` event; `null` when unset |
 | `event.type` / `event.target` | `"abort"` and the signal itself |
 
-Per [WHATWG DOM §3.2](https://dom.spec.whatwg.org/#abortsignal-signal-abort), a signal aborts at most once, so the `abort` event fires at most once and a listener registered after the abort never runs. The abort reason is already readable when listeners run, and `controller.abort()` dispatches synchronously.
+Per [WHATWG DOM §3.2](https://dom.spec.whatwg.org/#abortsignal-signal-abort), a signal aborts at most once, so the `abort` event fires at most once and a listener registered after the abort never runs. `controller.abort()` dispatches synchronously, and it runs the signal's abort algorithms before firing the event: an in-flight `fetch` registers one, so its promise is already rejected and the abort reason already readable by the time any listener runs.
 
 ```js
 const controller = new AbortController();
@@ -112,7 +112,7 @@ target.dispatchEvent(new Event("ready")); // logs "ready"
 target.dispatchEvent(new Event("ready")); // listener already removed
 ```
 
-An exception thrown by a listener propagates out of `dispatchEvent` (and out of `controller.abort()`). The WHATWG algorithm instead reports the exception to a global error handler, which GocciaScript does not have; propagating keeps the failure observable rather than discarding it. The dispatch state is still unwound, so the event and the target stay usable.
+An exception thrown by a listener propagates out of `dispatchEvent` (and out of `controller.abort()`, or out of an `await` when a timeout signal is observed by the fetch pump). The WHATWG algorithm instead reports the exception to a global error handler, which GocciaScript does not have; propagating keeps the failure observable rather than discarding it. The dispatch state is still unwound, so the event and the target stay usable, already-rejected requests stay rejected, and any signal not yet reached settles at the next pump.
 
 GocciaScript has no node tree, so `bubbles` and `capture` are recorded and reported but cause no propagation. `eventPhase`, `stopPropagation`, `stopImmediatePropagation`, `composed`, `composedPath`, `timeStamp`, `isTrusted`, and `CustomEvent` are not implemented; the `passive` listener option is accepted and ignored, and the `signal` member of `AddEventListenerOptions` is not supported.
 

--- a/docs/built-ins-fetch.md
+++ b/docs/built-ins-fetch.md
@@ -7,7 +7,8 @@
 - **Network authority stays explicit** — `fetch` supports only `GET` and `HEAD` and requires a host allowlist.
 - **Cancellation is fetch-scoped** — `AbortController`, `AbortSignal.abort`, and `AbortSignal.timeout` reject associated fetch promises with the signal's exact reason.
 - **No general event loop** — timeout state is observed at signal access and fetch-completion pump checkpoints.
-- **Focused object model** — `Request`, streaming bodies, CORS, EventTarget listeners, `AbortSignal.any`, and `onabort` are not implemented.
+- **Real EventTarget base** — `EventTarget` and `Event` are runtime globals, and `AbortSignal` inherits from `EventTarget` for `addEventListener`, `onabort`, and the `abort` event.
+- **Focused object model** — `Request`, streaming bodies, CORS, event propagation, and `AbortSignal.any` are not implemented.
 
 ## fetch
 
@@ -64,7 +65,56 @@ The cancellation values follow [WHATWG DOM §3, Aborting ongoing activities](htt
 
 GocciaScript does not provide a general timer task queue. Timeout signals therefore transition when the host reaches an observable checkpoint: reading signal state, calling `throwIfAborted()`, or pumping an associated fetch. This preserves bounded fetch cancellation without adding an unrelated browser event loop.
 
-EventTarget behavior (`addEventListener`, `removeEventListener`, `onabort`, and the `abort` event) and `AbortSignal.any()` are not implemented.
+`AbortSignal.any()` is not implemented.
+
+### The abort event
+
+`AbortSignal` inherits from [`EventTarget`](#eventtarget-and-event), so an abort is observable as an event as well as a state change.
+
+| API | Behavior |
+|-----|----------|
+| `signal.addEventListener("abort", listener)` | Registers a listener for the one-shot `abort` event |
+| `signal.onabort` | Event handler attribute for the `abort` event; `null` when unset |
+| `event.type` / `event.target` | `"abort"` and the signal itself |
+
+Per [WHATWG DOM §3.2](https://dom.spec.whatwg.org/#abortsignal-signal-abort), a signal aborts at most once, so the `abort` event fires at most once and a listener registered after the abort never runs. The abort reason is already readable when listeners run, and `controller.abort()` dispatches synchronously.
+
+```js
+const controller = new AbortController();
+controller.signal.addEventListener("abort", (event) => {
+  console.log(event.type, event.target.reason.name); // "abort" "AbortError"
+});
+controller.abort();
+```
+
+Because there is no timer task queue, an `AbortSignal.timeout()` signal aborts at the moment the host observes its expiry, and its `abort` event is delivered at that same point — reading `.aborted` after the deadline both flips the state and dispatches the event, exactly once. See [ADR 0104](adr/0104-whatwg-eventtarget-base.md).
+
+## EventTarget and Event
+
+`EventTarget` implements the [WHATWG DOM `EventTarget` interface](https://dom.spec.whatwg.org/#interface-eventtarget) for single-target dispatch.
+
+| API | Behavior |
+|-----|----------|
+| `new EventTarget()` | Creates a dispatch target with an empty listener list |
+| `target.addEventListener(type, callback, options?)` | Registers a listener; `options` is a boolean capture flag or `{ capture, once }` |
+| `target.removeEventListener(type, callback, options?)` | Removes the listener matching `(type, callback, capture)` |
+| `target.dispatchEvent(event)` | Invokes matching listeners in registration order; returns `false` when a cancelable event was canceled |
+| `new Event(type, eventInit?)` | Creates an event; `eventInit` accepts `bubbles` and `cancelable` |
+| `event.type`, `event.target`, `event.currentTarget` | Event identity and dispatch state |
+| `event.bubbles`, `event.cancelable`, `event.defaultPrevented`, `event.preventDefault()` | Cancellation surface |
+
+A listener is identified by `(type, callback, capture)` and is never added twice. `once` removes the listener before invoking it, removal during a dispatch is respected, and listeners added during a dispatch are not invoked for that event. A non-callable object listener is invoked through its `handleEvent` method. `dispatchEvent` throws an `InvalidStateError` `DOMException` when the event is already being dispatched.
+
+```js
+const target = new EventTarget();
+target.addEventListener("ready", (event) => console.log(event.type), { once: true });
+target.dispatchEvent(new Event("ready")); // logs "ready"
+target.dispatchEvent(new Event("ready")); // listener already removed
+```
+
+An exception thrown by a listener propagates out of `dispatchEvent` (and out of `controller.abort()`). The WHATWG algorithm instead reports the exception to a global error handler, which GocciaScript does not have; propagating keeps the failure observable rather than discarding it. The dispatch state is still unwound, so the event and the target stay usable.
+
+GocciaScript has no node tree, so `bubbles` and `capture` are recorded and reported but cause no propagation. `eventPhase`, `stopPropagation`, `stopImmediatePropagation`, `composed`, `composedPath`, `timeStamp`, `isTrusted`, and `CustomEvent` are not implemented; the `passive` listener option is accepted and ignored, and the `signal` member of `AddEventListenerOptions` is not supported.
 
 ## Headers
 

--- a/docs/built-ins.md
+++ b/docs/built-ins.md
@@ -6,7 +6,7 @@
 
 ## Executive Summary
 
-- **Core vs runtime registration** — `TGocciaEngine` always registers core language built-ins (Math, Object, Array, String, Number, RegExp, JSON, Symbol, Set, Map, Promise, Temporal, Intl, ArrayBuffer, SharedArrayBuffer, Atomics, TypedArrays, Proxy, Reflect, Iterator, DisposableStack, etc.); `Goccia.Runtime` provides optional runtime globals (Console, Performance, TextEncoder/TextDecoder, URL, fetch, Headers, Response, AbortController/AbortSignal) and import-only `goccia:` runtime modules
+- **Core vs runtime registration** — `TGocciaEngine` always registers core language built-ins (Math, Object, Array, String, Number, RegExp, JSON, Symbol, Set, Map, Promise, Temporal, Intl, ArrayBuffer, SharedArrayBuffer, Atomics, TypedArrays, Proxy, Reflect, Iterator, DisposableStack, etc.); `Goccia.Runtime` provides optional runtime globals (Console, Performance, TextEncoder/TextDecoder, URL, fetch, Headers, Response, AbortController/AbortSignal, EventTarget/Event) and import-only `goccia:` runtime modules
 - **Runtime opt-ins** — Testing, benchmarking, FFI, data-format APIs, and SemVer extend the runtime surface through concrete runtime extension classes
 - **Goccia runtime modules** — Non-standard data-format APIs and SemVer are named-export-only modules (`goccia:csv`, `goccia:json5`, `goccia:jsonl`, `goccia:toml`, `goccia:tsv`, `goccia:yaml`, `goccia:semver`); use namespace imports for `CSV.parse(...)`-style call sites
 - **Sandbox modules** — `GocciaSandboxRunner` installs import-only `"fs"` and `"goccia"` modules for sandbox filesystem and shell/nested-execution access; they are not globals
@@ -20,7 +20,7 @@ GocciaScript provides a set of built-in global objects that mirror JavaScript's 
 
 Core language built-ins (Math, Object, Array, Number, JSON, Symbol, Set, Map, WeakSet, WeakMap, Promise, Temporal, Intl, ArrayBuffer, SharedArrayBuffer, Atomics, Proxy, Reflect, etc.) are always registered unconditionally by the engine.
 
-Runtime globals (Console, Performance, TextEncoder/TextDecoder, URL, fetch, Headers, Response, AbortController/AbortSignal) are registered by the loader runtime profile and runtime extension classes under `source/units/Goccia.RuntimeExtensions.*.pas`. The same runtime profile also installs named-export-only Goccia modules for non-standard data-format APIs and SemVer: `goccia:csv`, `goccia:json5`, `goccia:jsonl`, `goccia:toml`, `goccia:tsv`, `goccia:yaml`, and `goccia:semver`. CLI hosts such as `GocciaScriptLoader` and `GocciaREPL` call `ApplyLoaderRuntimeProfile`; `GocciaTestRunner` applies the loader runtime profile plus `TGocciaTestingLibraryRuntimeExtension`; `GocciaBenchmarkRunner` applies the loader runtime profile plus `TGocciaBenchmarkRuntimeExtension`. `GocciaScriptLoaderBare` does not attach a runtime and exposes only a CLI-local `print(...args)` helper by default; the test262 conformance runner may opt into private test262 host capabilities with `--test262-host`.
+Runtime globals (Console, Performance, TextEncoder/TextDecoder, URL, fetch, Headers, Response, AbortController/AbortSignal, EventTarget/Event) are registered by the loader runtime profile and runtime extension classes under `source/units/Goccia.RuntimeExtensions.*.pas`. The same runtime profile also installs named-export-only Goccia modules for non-standard data-format APIs and SemVer: `goccia:csv`, `goccia:json5`, `goccia:jsonl`, `goccia:toml`, `goccia:tsv`, `goccia:yaml`, and `goccia:semver`. CLI hosts such as `GocciaScriptLoader` and `GocciaREPL` call `ApplyLoaderRuntimeProfile`; `GocciaTestRunner` applies the loader runtime profile plus `TGocciaTestingLibraryRuntimeExtension`; `GocciaBenchmarkRunner` applies the loader runtime profile plus `TGocciaBenchmarkRuntimeExtension`. `GocciaScriptLoaderBare` does not attach a runtime and exposes only a CLI-local `print(...args)` helper by default; the test262 conformance runner may opt into private test262 host capabilities with `--test262-host`.
 
 `GocciaSandboxRunner` applies the loader runtime profile and then installs `TGocciaSandboxRuntimeExtension`. That extension registers sandbox capabilities as import-only runtime modules named `"fs"` and `"goccia"`; it does not create global `fs`, `$`, or `runScript` bindings.
 
@@ -926,7 +926,7 @@ Implements the [WHATWG URLSearchParams](https://developer.mozilla.org/en-US/docs
 
 ### Fetch runtime APIs
 
-The focused WHATWG `fetch`, `Headers`, `Response`, `AbortController`, and `AbortSignal` surface is documented in [Fetch Runtime APIs](built-ins-fetch.md).
+The focused WHATWG `fetch`, `Headers`, `Response`, `AbortController`, `AbortSignal`, `EventTarget`, and `Event` surface is documented in [Fetch Runtime APIs](built-ins-fetch.md). `AbortSignal` inherits from `EventTarget`, so `addEventListener`, `onabort`, and the one-shot `abort` event are available; see [ADR 0104](adr/0104-whatwg-eventtarget-base.md).
 
 ### DisposableStack / AsyncDisposableStack (`Goccia.Builtins.DisposableStack.pas`)
 

--- a/docs/language-tables.md
+++ b/docs/language-tables.md
@@ -60,7 +60,8 @@ APIs from WHATWG and W3C specifications — not part of ECMA-262, but widely exp
 | `TextEncoder` | [WHATWG Encoding §8.3](https://encoding.spec.whatwg.org/#textencoder) | Supported |
 | `TextDecoder` | [WHATWG Encoding §8.2](https://encoding.spec.whatwg.org/#textdecoder) | Supported |
 | `performance.now`, `timeOrigin` | [High Resolution Time](https://w3c.github.io/hr-time/#dom-performance-now) | Supported |
-| `AbortController`, `AbortSignal` | [WHATWG DOM §3](https://dom.spec.whatwg.org/#aborting-ongoing-activities) | Supported subset (fetch-scoped; no events or `any`) |
+| `EventTarget`, `Event` | [WHATWG DOM §2](https://dom.spec.whatwg.org/#events) | Supported subset (single-target dispatch; no propagation) |
+| `AbortController`, `AbortSignal` | [WHATWG DOM §3](https://dom.spec.whatwg.org/#aborting-ongoing-activities) | Supported subset (fetch-scoped; `abort` event and `onabort`; no `any`) |
 | `fetch`, `Headers`, `Response` | [WHATWG Fetch](https://fetch.spec.whatwg.org/) | Supported (GET/HEAD only) |
 
 ## TC39 Proposals

--- a/source/units/Goccia.Builtins.GlobalAbort.pas
+++ b/source/units/Goccia.Builtins.GlobalAbort.pas
@@ -32,7 +32,8 @@ type
       const AThisValue: TGocciaValue): TGocciaValue;
   public
     constructor Create(const AName: string; const AScope: TGocciaScope;
-      const AThrowError: TGocciaThrowErrorCallback);
+      const AThrowError: TGocciaThrowErrorCallback;
+      const AEventTargetConstructor: TGocciaValue = nil);
   end;
 
 implementation
@@ -54,7 +55,8 @@ const
 
 constructor TGocciaGlobalAbort.Create(const AName: string;
   const AScope: TGocciaScope;
-  const AThrowError: TGocciaThrowErrorCallback);
+  const AThrowError: TGocciaThrowErrorCallback;
+  const AEventTargetConstructor: TGocciaValue);
 var
   AbortSignalConstructor: TGocciaNativeFunctionValue;
   Members: TGocciaMemberCollection;
@@ -75,6 +77,12 @@ begin
     AbortSignalCall, CONSTRUCTOR_ABORT_SIGNAL, 0);
   AbortSignalConstructor.NotConstructable := True;
   TGocciaAbortSignalValue.ExposePrototype(AbortSignalConstructor);
+  // WHATWG DOM §3.2 `interface AbortSignal : EventTarget` — the prototype-chain
+  // link is made in TGocciaAbortSignalValue.InitializePrototype; this is the
+  // matching constructor-inherits-constructor link.
+  if Assigned(AEventTargetConstructor) then
+    AbortSignalConstructor.Prototype :=
+      TGocciaObjectValue(AEventTargetConstructor);
   Members := TGocciaMemberCollection.Create;
   try
     Members.AddNamedMethod(PROP_ABORT, AbortSignalAbort, 1,
@@ -130,6 +138,9 @@ begin
     Signal.SignalAbort(AArgs.GetElement(0))
   else
     Signal.SignalAbort;
+  // The signal is aborted before it can be observed, so settle its one-shot
+  // "abort" event now: a listener added later must never fire.
+  Signal.FlushAbortEvent;
   Result := Signal;
 end;
 

--- a/source/units/Goccia.Builtins.GlobalEventTarget.pas
+++ b/source/units/Goccia.Builtins.GlobalEventTarget.pas
@@ -1,0 +1,138 @@
+unit Goccia.Builtins.GlobalEventTarget;
+
+// WHATWG DOM EventTarget and Event global registration.
+
+{$I Goccia.inc}
+
+interface
+
+uses
+  Goccia.Arguments.Collection,
+  Goccia.Builtins.Base,
+  Goccia.Error.ThrowErrorCallback,
+  Goccia.Scope,
+  Goccia.Values.NativeFunction,
+  Goccia.Values.ObjectValue,
+  Goccia.Values.Primitives;
+
+type
+  TGocciaGlobalEventTarget = class(TGocciaBuiltin)
+  private
+    FEventTargetConstructor: TGocciaNativeFunctionValue;
+    FEventTargetPrototype: TGocciaObjectValue;
+    FEventConstructor: TGocciaNativeFunctionValue;
+    FEventPrototype: TGocciaObjectValue;
+    function EventTargetCall(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function EventTargetConstruct(const AArgs: TGocciaArgumentsCollection;
+      const ANewTarget: TGocciaValue): TGocciaValue;
+    function EventCall(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function EventConstruct(const AArgs: TGocciaArgumentsCollection;
+      const ANewTarget: TGocciaValue): TGocciaValue;
+  public
+    constructor Create(const AName: string; const AScope: TGocciaScope;
+      const AThrowError: TGocciaThrowErrorCallback);
+
+    property EventTargetConstructor: TGocciaNativeFunctionValue
+      read FEventTargetConstructor;
+    property EventTargetPrototype: TGocciaObjectValue
+      read FEventTargetPrototype;
+  end;
+
+implementation
+
+uses
+  Goccia.Constants.ConstructorNames,
+  Goccia.Constants.PropertyNames,
+  Goccia.Values.ErrorHelper,
+  Goccia.Values.EventTargetValue,
+  Goccia.Values.EventValue,
+  Goccia.Values.FunctionBase;
+
+constructor TGocciaGlobalEventTarget.Create(const AName: string;
+  const AScope: TGocciaScope;
+  const AThrowError: TGocciaThrowErrorCallback);
+begin
+  inherited Create(AName, AScope, AThrowError);
+
+  FEventTargetConstructor := TGocciaNativeFunctionValue.Create(
+    EventTargetCall, CONSTRUCTOR_EVENT_TARGET, 0);
+  FEventTargetConstructor.ConstructCallback := EventTargetConstruct;
+  TGocciaEventTargetValue.ExposePrototype(FEventTargetConstructor);
+  FEventTargetPrototype := TGocciaObjectValue(
+    FEventTargetConstructor.GetProperty(PROP_PROTOTYPE));
+  AScope.DefineLexicalBinding(CONSTRUCTOR_EVENT_TARGET,
+    FEventTargetConstructor, dtConst, True);
+
+  FEventConstructor := TGocciaNativeFunctionValue.Create(
+    EventCall, CONSTRUCTOR_EVENT, 1);
+  FEventConstructor.ConstructCallback := EventConstruct;
+  TGocciaEventValue.ExposePrototype(FEventConstructor);
+  FEventPrototype := TGocciaObjectValue(
+    FEventConstructor.GetProperty(PROP_PROTOTYPE));
+  AScope.DefineLexicalBinding(CONSTRUCTOR_EVENT, FEventConstructor, dtConst,
+    True);
+end;
+
+function TGocciaGlobalEventTarget.EventTargetCall(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  ThrowTypeError('Class constructor EventTarget cannot be invoked without new');
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+end;
+
+// WHATWG DOM §2.7 new EventTarget().
+function TGocciaGlobalEventTarget.EventTargetConstruct(
+  const AArgs: TGocciaArgumentsCollection;
+  const ANewTarget: TGocciaValue): TGocciaValue;
+var
+  Target: TGocciaEventTargetValue;
+begin
+  Target := TGocciaEventTargetValue.Create;
+  Target.Prototype := GetProtoFromConstructorWithIntrinsic(ANewTarget,
+    FEventTargetPrototype);
+  Result := Target;
+end;
+
+function TGocciaGlobalEventTarget.EventCall(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  ThrowTypeError('Class constructor Event cannot be invoked without new');
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+end;
+
+// WHATWG DOM §2.2 new Event(type, eventInitDict).
+function TGocciaGlobalEventTarget.EventConstruct(
+  const AArgs: TGocciaArgumentsCollection;
+  const ANewTarget: TGocciaValue): TGocciaValue;
+var
+  Event: TGocciaEventValue;
+  Options, Member: TGocciaValue;
+begin
+  if AArgs.Length = 0 then
+    ThrowTypeError('Event constructor requires a type');
+
+  Event := TGocciaEventValue.Create;
+  Event.Prototype := GetProtoFromConstructorWithIntrinsic(ANewTarget,
+    FEventPrototype);
+  Event.EventType := AArgs.GetElement(0).ToStringLiteral.Value;
+
+  if AArgs.Length > 1 then
+  begin
+    Options := AArgs.GetElement(1);
+    if Options is TGocciaObjectValue then
+    begin
+      Member := TGocciaObjectValue(Options).GetProperty(PROP_BUBBLES);
+      Event.Bubbles := Assigned(Member) and Member.ToBooleanLiteral.Value;
+      Member := TGocciaObjectValue(Options).GetProperty(PROP_CANCELABLE);
+      Event.Cancelable := Assigned(Member) and Member.ToBooleanLiteral.Value;
+    end;
+  end;
+
+  Result := Event;
+end;
+
+end.

--- a/source/units/Goccia.Builtins.GlobalEventTarget.pas
+++ b/source/units/Goccia.Builtins.GlobalEventTarget.pas
@@ -129,7 +129,12 @@ begin
       Event.Bubbles := Assigned(Member) and Member.ToBooleanLiteral.Value;
       Member := TGocciaObjectValue(Options).GetProperty(PROP_CANCELABLE);
       Event.Cancelable := Assigned(Member) and Member.ToBooleanLiteral.Value;
-    end;
+    end
+    // WebIDL dictionary conversion: null and undefined mean "no members
+    // present", anything else that is not an object is a TypeError.
+    else if not (Options is TGocciaNullLiteralValue) and
+            not (Options is TGocciaUndefinedLiteralValue) then
+      ThrowTypeError('Event init dictionary must be an object');
   end;
 
   Result := Event;

--- a/source/units/Goccia.Constants.ConstructorNames.pas
+++ b/source/units/Goccia.Constants.ConstructorNames.pas
@@ -61,6 +61,8 @@ const
   CONSTRUCTOR_RESPONSE = 'Response';
   CONSTRUCTOR_ABORT_CONTROLLER = 'AbortController';
   CONSTRUCTOR_ABORT_SIGNAL     = 'AbortSignal';
+  CONSTRUCTOR_EVENT_TARGET     = 'EventTarget';
+  CONSTRUCTOR_EVENT            = 'Event';
 
 implementation
 

--- a/source/units/Goccia.Constants.ErrorNames.pas
+++ b/source/units/Goccia.Constants.ErrorNames.pas
@@ -18,6 +18,7 @@ const
   INVALID_CHARACTER_ERROR_NAME = 'InvalidCharacterError';
   ABORT_ERROR_NAME              = 'AbortError';
   TIMEOUT_ERROR_NAME            = 'TimeoutError';
+  INVALID_STATE_ERROR_NAME      = 'InvalidStateError';
   SUPPRESSED_ERROR_NAME        = 'SuppressedError';
 
 implementation

--- a/source/units/Goccia.Constants.PropertyNames.pas
+++ b/source/units/Goccia.Constants.PropertyNames.pas
@@ -214,6 +214,20 @@ const
   PROP_THROW_IF_ABORTED    = 'throwIfAborted';
   PROP_TIMEOUT             = 'timeout';
 
+  PROP_ADD_EVENT_LISTENER    = 'addEventListener';
+  PROP_REMOVE_EVENT_LISTENER = 'removeEventListener';
+  PROP_DISPATCH_EVENT        = 'dispatchEvent';
+  PROP_HANDLE_EVENT          = 'handleEvent';
+  PROP_ONABORT               = 'onabort';
+  PROP_TARGET                = 'target';
+  PROP_CURRENT_TARGET        = 'currentTarget';
+  PROP_DEFAULT_PREVENTED     = 'defaultPrevented';
+  PROP_PREVENT_DEFAULT       = 'preventDefault';
+  PROP_BUBBLES               = 'bubbles';
+  PROP_CANCELABLE            = 'cancelable';
+  PROP_ONCE                  = 'once';
+  PROP_CAPTURE               = 'capture';
+
 implementation
 
 end.

--- a/source/units/Goccia.Constants.PropertyNames.pas
+++ b/source/units/Goccia.Constants.PropertyNames.pas
@@ -227,6 +227,7 @@ const
   PROP_CANCELABLE            = 'cancelable';
   PROP_ONCE                  = 'once';
   PROP_CAPTURE               = 'capture';
+  PROP_PASSIVE               = 'passive';
 
 implementation
 

--- a/source/units/Goccia.FetchManager.pas
+++ b/source/units/Goccia.FetchManager.pas
@@ -124,6 +124,9 @@ type
     RequestID: Integer;
     Promise: TGocciaPromiseValue;
     Signal: TGocciaAbortSignalValue;
+    // WHATWG DOM §3.2 abort algorithm registration for this request, removed
+    // again whenever the pending entry leaves FPending.
+    AbortAlgorithmHandle: Integer;
   end;
 
   TGocciaFetchWorker = class(TThread)
@@ -155,6 +158,7 @@ type
     function PopCompletion(out ACompletion: TGocciaFetchCompletion): Boolean;
     function FindPendingIndex(const ARequestID: Integer): Integer;
     function RejectAbortedFetches: Integer;
+    procedure AbortPendingFetch(const AToken: Int64);
     procedure ReleasePendingRoots(const APending: TGocciaPendingFetch);
     procedure SettleCompletion(const ACompletion: TGocciaFetchCompletion);
   public
@@ -467,6 +471,7 @@ begin
 
   Pending.RequestID := FNextRequestID;
   Inc(FNextRequestID);
+  Pending.AbortAlgorithmHandle := 0;
   Pending.Promise := APromise;
   Pending.Signal := ASignal;
 
@@ -502,6 +507,13 @@ begin
       Rooted := True;
     end;
 
+    // WHATWG DOM §3.2 / Fetch: register this request's abort algorithm so a
+    // later abort rejects it before the "abort" event is fired, instead of
+    // waiting for the next pump.
+    if Assigned(ASignal) then
+      Pending.AbortAlgorithmHandle :=
+        ASignal.AddAbortAlgorithm(AbortPendingFetch, Pending.RequestID);
+
     FPending.Add(Pending);
     Added := True;
     Worker.Start;
@@ -509,6 +521,8 @@ begin
   except
     if Added then
       FPending.Delete(FPending.Count - 1);
+    if Assigned(ASignal) and (Pending.AbortAlgorithmHandle <> 0) then
+      ASignal.RemoveAbortAlgorithm(Pending.AbortAlgorithmHandle);
     if Rooted and (TGarbageCollector.Instance <> nil) then
     begin
       TGarbageCollector.Instance.RemoveTempRoot(APromise);
@@ -525,6 +539,12 @@ end;
 procedure TGocciaFetchManagerImpl.ReleasePendingRoots(
   const APending: TGocciaPendingFetch);
 begin
+  // The pending entry is leaving FPending, so its abort algorithm must go with
+  // it. This is a no-op when the algorithm list was already emptied by the
+  // signal abort that brought us here.
+  if Assigned(APending.Signal) and (APending.AbortAlgorithmHandle <> 0) then
+    APending.Signal.RemoveAbortAlgorithm(APending.AbortAlgorithmHandle);
+
   if TGarbageCollector.Instance = nil then
     Exit;
   TGarbageCollector.Instance.RemoveTempRoot(APending.Promise);
@@ -532,47 +552,80 @@ begin
     TGarbageCollector.Instance.RemoveTempRoot(APending.Signal);
 end;
 
+// WHATWG DOM §3.2 abort algorithm for one in-flight fetch: reject the request's
+// promise and drop its pending entry. Runs during signal abort, before the
+// "abort" event, so a listener already sees the fetch settled.
+procedure TGocciaFetchManagerImpl.AbortPendingFetch(const AToken: Int64);
+var
+  PendingIndex: Integer;
+  Pending: TGocciaPendingFetch;
+begin
+  PendingIndex := FindPendingIndex(Integer(AToken));
+  if PendingIndex < 0 then
+    Exit;
+
+  Pending := FPending[PendingIndex];
+  FPending.Delete(PendingIndex);
+  try
+    Pending.Promise.Reject(Pending.Signal.Reason);
+  finally
+    ReleasePendingRoots(Pending);
+  end;
+end;
+
+// Settles fetches whose signal has aborted. Controller-driven aborts already
+// rejected themselves through their abort algorithm, so what reaches here is
+// the lazily observed case: a timeout signal that expired since the last pump.
 function TGocciaFetchManagerImpl.RejectAbortedFetches: Integer;
 var
-  I: Integer;
-  Pending: TGocciaPendingFetch;
+  I, CountBefore: Integer;
+  Signal: TGocciaAbortSignalValue;
   AbortedSignals: TGocciaAbortSignalList;
+  SignalRoot: TGocciaTempRoot;
 begin
-  Result := 0;
-  // Listeners must not run while this loop walks FPending, so the "abort"
-  // events are collected here and dispatched once the walk is finished. No
-  // script runs in between, so a listener still cannot be registered after the
-  // signal aborted but before its event fires.
+  CountBefore := FPending.Count;
   AbortedSignals := TGocciaAbortSignalList.Create(False);
   try
-    for I := FPending.Count - 1 downto 0 do
+    // Phase 1 flips expired timeouts only. RefreshTimeout deliberately does not
+    // run abort algorithms, because an algorithm mutates FPending and this
+    // walks it.
+    for I := 0 to FPending.Count - 1 do
     begin
-      Pending := FPending[I];
-      if not Assigned(Pending.Signal) or not Pending.Signal.IsAborted then
+      Signal := FPending[I].Signal;
+      if not Assigned(Signal) then
         Continue;
-
-      FPending.Delete(I);
-      Pending.Promise.Reject(Pending.Signal.Reason);
-      // Keep the signal alive across ReleasePendingRoots so its pending
-      // "abort" event can still be dispatched below.
-      if AbortedSignals.IndexOf(Pending.Signal) < 0 then
-      begin
-        AbortedSignals.Add(Pending.Signal);
-        if TGarbageCollector.Instance <> nil then
-          TGarbageCollector.Instance.AddTempRoot(Pending.Signal);
-      end;
-      ReleasePendingRoots(Pending);
-      Inc(Result);
+      Signal.RefreshTimeout;
+      if not Signal.IsAborted then
+        Continue;
+      if AbortedSignals.IndexOf(Signal) < 0 then
+        AbortedSignals.Add(Signal);
     end;
 
+    // Phase 2 runs with no walk in progress, so each signal may now run its
+    // abort algorithms (rejecting and removing its own pending entries) and
+    // then fire its one-shot "abort" event. No script runs between the two, so
+    // a listener still cannot be registered after the signal aborted but
+    // before its event fires.
     for I := 0 to AbortedSignals.Count - 1 do
-      AbortedSignals[I].FlushAbortEvent;
+    begin
+      Signal := AbortedSignals[I];
+      Signal.RunPendingAbortAlgorithms;
+      // Those algorithms dropped the pending entries that were rooting this
+      // signal, so root it for the dispatch itself. AddTempRootIfNeeded is a
+      // no-op when another pending fetch still holds a root on it, which is
+      // why the raw AddTempRoot/RemoveTempRoot pair must not be used here.
+      InitializeTempRoot(SignalRoot);
+      AddTempRootIfNeeded(SignalRoot, Signal);
+      try
+        Signal.FlushAbortEvent;
+      finally
+        RemoveTempRootIfNeeded(SignalRoot);
+      end;
+    end;
   finally
-    if TGarbageCollector.Instance <> nil then
-      for I := 0 to AbortedSignals.Count - 1 do
-        TGarbageCollector.Instance.RemoveTempRoot(AbortedSignals[I]);
     AbortedSignals.Free;
   end;
+  Result := CountBefore - FPending.Count;
 end;
 
 function TGocciaFetchManagerImpl.PopCompletion(

--- a/source/units/Goccia.FetchManager.pas
+++ b/source/units/Goccia.FetchManager.pas
@@ -451,7 +451,10 @@ begin
 
   if Assigned(ASignal) and ASignal.IsAborted then
   begin
+    // WHATWG DOM §3.2 signal abort: abort algorithms (the fetch rejection)
+    // run before the "abort" event is fired at the signal.
     APromise.Reject(ASignal.Reason);
+    ASignal.FlushAbortEvent;
     Exit;
   end;
 
@@ -476,6 +479,7 @@ begin
       begin
         ASignal.RefreshTimeout;
         APromise.Reject(ASignal.Reason);
+        ASignal.FlushAbortEvent;
         FLimiter.ReleaseWorker;
         Exit;
       end;
@@ -532,18 +536,42 @@ function TGocciaFetchManagerImpl.RejectAbortedFetches: Integer;
 var
   I: Integer;
   Pending: TGocciaPendingFetch;
+  AbortedSignals: TGocciaAbortSignalList;
 begin
   Result := 0;
-  for I := FPending.Count - 1 downto 0 do
-  begin
-    Pending := FPending[I];
-    if not Assigned(Pending.Signal) or not Pending.Signal.IsAborted then
-      Continue;
+  // Listeners must not run while this loop walks FPending, so the "abort"
+  // events are collected here and dispatched once the walk is finished. No
+  // script runs in between, so a listener still cannot be registered after the
+  // signal aborted but before its event fires.
+  AbortedSignals := TGocciaAbortSignalList.Create(False);
+  try
+    for I := FPending.Count - 1 downto 0 do
+    begin
+      Pending := FPending[I];
+      if not Assigned(Pending.Signal) or not Pending.Signal.IsAborted then
+        Continue;
 
-    FPending.Delete(I);
-    Pending.Promise.Reject(Pending.Signal.Reason);
-    ReleasePendingRoots(Pending);
-    Inc(Result);
+      FPending.Delete(I);
+      Pending.Promise.Reject(Pending.Signal.Reason);
+      // Keep the signal alive across ReleasePendingRoots so its pending
+      // "abort" event can still be dispatched below.
+      if AbortedSignals.IndexOf(Pending.Signal) < 0 then
+      begin
+        AbortedSignals.Add(Pending.Signal);
+        if TGarbageCollector.Instance <> nil then
+          TGarbageCollector.Instance.AddTempRoot(Pending.Signal);
+      end;
+      ReleasePendingRoots(Pending);
+      Inc(Result);
+    end;
+
+    for I := 0 to AbortedSignals.Count - 1 do
+      AbortedSignals[I].FlushAbortEvent;
+  finally
+    if TGarbageCollector.Instance <> nil then
+      for I := 0 to AbortedSignals.Count - 1 do
+        TGarbageCollector.Instance.RemoveTempRoot(AbortedSignals[I]);
+    AbortedSignals.Free;
   end;
 end;
 

--- a/source/units/Goccia.RuntimeExtensions.Fetch.pas
+++ b/source/units/Goccia.RuntimeExtensions.Fetch.pas
@@ -8,6 +8,7 @@ uses
   Classes,
 
   Goccia.Builtins.GlobalAbort,
+  Goccia.Builtins.GlobalEventTarget,
   Goccia.Builtins.GlobalFetch,
   Goccia.Runtime;
 
@@ -15,6 +16,7 @@ type
   TGocciaFetchRuntimeExtension = class(TGocciaRuntimeExtension)
   private
     FBuiltinAbort: TGocciaGlobalAbort;
+    FBuiltinEventTarget: TGocciaGlobalEventTarget;
     FBuiltinFetch: TGocciaGlobalFetch;
   public
     procedure Attach(const ARuntime: TGocciaRuntimeCore); override;
@@ -57,8 +59,15 @@ var
 begin
   inherited Attach(ARuntime);
   TGocciaFetchManager.Initialize;
-  FBuiltinAbort := TGocciaGlobalAbort.Create('Abort',
+  // EventTarget must exist before AbortSignal so the signal's prototype and
+  // constructor can be linked into the EventTarget chain (WHATWG DOM §3.2).
+  FBuiltinEventTarget := TGocciaGlobalEventTarget.Create('EventTarget',
     Runtime.Engine.Interpreter.GlobalScope, Runtime.Engine.ThrowError);
+  Runtime.RegisterRuntimeGlobalName(CONSTRUCTOR_EVENT_TARGET);
+  Runtime.RegisterRuntimeGlobalName(CONSTRUCTOR_EVENT);
+  FBuiltinAbort := TGocciaGlobalAbort.Create('Abort',
+    Runtime.Engine.Interpreter.GlobalScope, Runtime.Engine.ThrowError,
+    FBuiltinEventTarget.EventTargetConstructor);
   Runtime.RegisterRuntimeGlobalName(CONSTRUCTOR_ABORT_CONTROLLER);
   Runtime.RegisterRuntimeGlobalName(CONSTRUCTOR_ABORT_SIGNAL);
   FBuiltinFetch := TGocciaGlobalFetch.Create('Fetch',
@@ -99,6 +108,8 @@ begin
   FBuiltinFetch := nil;
   FBuiltinAbort.Free;
   FBuiltinAbort := nil;
+  FBuiltinEventTarget.Free;
+  FBuiltinEventTarget := nil;
   TGocciaFetchManager.Shutdown;
   inherited;
 end;

--- a/source/units/Goccia.Values.AbortValue.pas
+++ b/source/units/Goccia.Values.AbortValue.pas
@@ -17,6 +17,21 @@ uses
   Goccia.Values.Primitives;
 
 type
+  TGocciaAbortSignalValue = class;
+
+  // WHATWG DOM §3.2 abort algorithm: a host-registered callback run when the
+  // signal aborts, before the "abort" event is fired. `AToken` identifies the
+  // host-side work the algorithm cancels (for fetch, the pending request id).
+  TGocciaAbortAlgorithmCallback = procedure(const AToken: Int64) of object;
+
+  TGocciaAbortAlgorithmEntry = record
+    Handle: Integer;
+    Callback: TGocciaAbortAlgorithmCallback;
+    Token: Int64;
+  end;
+
+  TGocciaAbortAlgorithmEntryList = TList<TGocciaAbortAlgorithmEntry>;
+
   // WHATWG DOM §3.2: `interface AbortSignal : EventTarget`. The prototype chain
   // genuinely runs through EventTarget.prototype, so `signal instanceof
   // EventTarget` holds and the listener machinery is the shared one.
@@ -26,6 +41,11 @@ type
     FTimeoutDeadlineNanoseconds: Int64;
     FAbortEventPending: Boolean;
     FAbortEventFired: Boolean;
+    FAbortAlgorithmsPending: Boolean;
+    FAbortAlgorithms: TGocciaAbortAlgorithmEntryList;
+    FNextAbortAlgorithmHandle: Integer;
+    procedure BecomeAborted(const AReason: TGocciaValue;
+      const ARunAlgorithmsNow: Boolean);
     function AbortedGetter(const AArgs: TGocciaArgumentsCollection;
       const AThisValue: TGocciaValue): TGocciaValue;
     function ReasonGetter(const AArgs: TGocciaArgumentsCollection;
@@ -39,6 +59,7 @@ type
     procedure InitializePrototype;
   public
     constructor Create(const AClass: TGocciaClassValue = nil);
+    destructor Destroy; override;
     function IsAborted: Boolean;
     function RemainingTimeoutMilliseconds: Integer;
     procedure RefreshTimeout;
@@ -46,6 +67,12 @@ type
     procedure SignalAbort(const AReason: TGocciaValue = nil);
     procedure FlushAbortEvent;
     procedure ObserveAbortState;
+    // WHATWG DOM §3.2 add/remove an algorithm. Returns 0 when the signal is
+    // already aborted, matching "if signal is aborted, then return".
+    function AddAbortAlgorithm(const ACallback: TGocciaAbortAlgorithmCallback;
+      const AToken: Int64): Integer;
+    procedure RemoveAbortAlgorithm(const AHandle: Integer);
+    procedure RunPendingAbortAlgorithms;
     function ToStringTag: string; override;
     procedure MarkReferences; override;
     class procedure ExposePrototype(const AConstructor: TGocciaValue);
@@ -130,10 +157,93 @@ begin
   FTimeoutDeadlineNanoseconds := 0;
   FAbortEventPending := False;
   FAbortEventFired := False;
+  FAbortAlgorithmsPending := False;
+  FAbortAlgorithms := TGocciaAbortAlgorithmEntryList.Create;
+  FNextAbortAlgorithmHandle := 1;
   InitializePrototype;
   Shared := GetAbortSignalShared;
   if not Assigned(AClass) and Assigned(Shared) then
     FPrototype := Shared.Prototype;
+end;
+
+destructor TGocciaAbortSignalValue.Destroy;
+begin
+  FAbortAlgorithms.Free;
+  inherited;
+end;
+
+// WHATWG DOM §3.2 add an algorithm.
+function TGocciaAbortSignalValue.AddAbortAlgorithm(
+  const ACallback: TGocciaAbortAlgorithmCallback;
+  const AToken: Int64): Integer;
+var
+  Entry: TGocciaAbortAlgorithmEntry;
+begin
+  // "If signal is aborted, then return" — an algorithm registered after the
+  // abort never runs, the same rule that governs listeners.
+  if IsAborted then
+    Exit(0);
+
+  Entry.Handle := FNextAbortAlgorithmHandle;
+  Inc(FNextAbortAlgorithmHandle);
+  Entry.Callback := ACallback;
+  Entry.Token := AToken;
+  FAbortAlgorithms.Add(Entry);
+  Result := Entry.Handle;
+end;
+
+// WHATWG DOM §3.2 remove an algorithm — the host's normal-completion path.
+procedure TGocciaAbortSignalValue.RemoveAbortAlgorithm(const AHandle: Integer);
+var
+  I: Integer;
+begin
+  if AHandle = 0 then
+    Exit;
+  for I := 0 to FAbortAlgorithms.Count - 1 do
+    if FAbortAlgorithms[I].Handle = AHandle then
+    begin
+      FAbortAlgorithms.Delete(I);
+      Exit;
+    end;
+end;
+
+// WHATWG DOM §3.2 signal abort step 3: run the abort algorithms, then empty
+// the set. The set is emptied first so an algorithm that unregisters itself
+// (the fetch cleanup path) cannot disturb the walk; adding during the run is
+// already refused because the abort reason is set by now.
+procedure TGocciaAbortSignalValue.RunPendingAbortAlgorithms;
+var
+  Snapshot: TArray<TGocciaAbortAlgorithmEntry>;
+  I: Integer;
+begin
+  if not FAbortAlgorithmsPending then
+    Exit;
+  FAbortAlgorithmsPending := False;
+
+  Snapshot := FAbortAlgorithms.ToArray;
+  FAbortAlgorithms.Clear;
+  for I := 0 to High(Snapshot) do
+    if Assigned(Snapshot[I].Callback) then
+      Snapshot[I].Callback(Snapshot[I].Token);
+end;
+
+// WHATWG DOM §3.2 signal abort steps 2-4, shared by controller aborts and by
+// lazily observed timeouts. Timeouts defer the algorithms because they are
+// detected while the fetch manager is walking its pending list; every other
+// caller runs them immediately, so no script can run between the state change
+// and the algorithms.
+procedure TGocciaAbortSignalValue.BecomeAborted(const AReason: TGocciaValue;
+  const ARunAlgorithmsNow: Boolean);
+begin
+  // Step 2: set signal's abort reason.
+  FReason := AReason;
+  FAbortAlgorithmsPending := True;
+  // Step 4 is deferred to FlushAbortEvent so the reason and the host-side
+  // cancellation are both already settled when listeners run.
+  FAbortEventPending := True;
+  // Step 3: run the abort algorithms, then empty the set.
+  if ARunAlgorithmsNow then
+    RunPendingAbortAlgorithms;
 end;
 
 procedure TGocciaAbortSignalValue.InitializePrototype;
@@ -194,28 +304,30 @@ begin
 end;
 
 // WHATWG DOM §3.2 AbortSignal.timeout(milliseconds), observed at a host checkpoint.
-// The state flip is separated from the "abort" event so that internal callers
-// (the fetch pump) can settle their own bookkeeping before any listener runs;
-// FlushAbortEvent is what actually dispatches.
+// This only flips the state: the abort algorithms and the "abort" event are
+// deferred to FlushAbortEvent, because RefreshTimeout is called while the fetch
+// manager walks its pending list and an algorithm mutates that list.
 procedure TGocciaAbortSignalValue.RefreshTimeout;
 begin
   if (FTimeoutDeadlineNanoseconds > 0) and
      (FReason is TGocciaUndefinedLiteralValue) and
      (GetNanoseconds >= FTimeoutDeadlineNanoseconds) then
-  begin
-    FReason := CreateDOMExceptionObject(TIMEOUT_ERROR_NAME,
-      TIMEOUT_ERROR_MESSAGE);
-    FAbortEventPending := True;
-  end;
+    BecomeAborted(CreateDOMExceptionObject(TIMEOUT_ERROR_NAME,
+      TIMEOUT_ERROR_MESSAGE), False);
 end;
 
-// WHATWG DOM §3.2 signal abort, step 4: fire an event named "abort" at the
-// signal. A signal aborts at most once, so this fires at most once, and a
-// listener registered after the abort never runs.
+// WHATWG DOM §3.2 signal abort, steps 3-4: any abort algorithms still pending
+// run first, then the "abort" event is fired at the signal. A signal aborts at
+// most once, so the event fires at most once, and a listener or algorithm
+// registered after the abort never runs.
 procedure TGocciaAbortSignalValue.FlushAbortEvent;
 var
   Event: TGocciaEventValue;
 begin
+  // Step 3 before step 4: host-side cancellation is complete before any
+  // listener observes the abort.
+  RunPendingAbortAlgorithms;
+
   if not FAbortEventPending then
     Exit;
   FAbortEventPending := False;
@@ -274,21 +386,24 @@ end;
 
 // WHATWG DOM §3.2 signal abort.
 procedure TGocciaAbortSignalValue.SignalAbort(const AReason: TGocciaValue);
+var
+  Reason: TGocciaValue;
 begin
   RefreshTimeout;
+  // Step 1: if signal is aborted, then return.
   if not (FReason is TGocciaUndefinedLiteralValue) then
     Exit;
 
   if not Assigned(AReason) or
      (AReason is TGocciaUndefinedLiteralValue) then
-    FReason := CreateDOMExceptionObject(ABORT_ERROR_NAME,
-      ABORT_ERROR_MESSAGE)
+    Reason := CreateDOMExceptionObject(ABORT_ERROR_NAME, ABORT_ERROR_MESSAGE)
   else
-    FReason := AReason;
+    Reason := AReason;
 
-  // Step 4 is deferred to FlushAbortEvent so the reason is already observable
-  // when listeners run, and so internal callers control the dispatch point.
-  FAbortEventPending := True;
+  // Steps 2-3 run synchronously here: the abort algorithms (fetch rejection)
+  // complete before the caller flushes the "abort" event, and no script runs
+  // in between because rejecting a promise only queues a microtask.
+  BecomeAborted(Reason, True);
 end;
 
 // WHATWG DOM §3.2 get AbortSignal.prototype.aborted.

--- a/source/units/Goccia.Values.AbortValue.pas
+++ b/source/units/Goccia.Values.AbortValue.pas
@@ -7,20 +7,32 @@ unit Goccia.Values.AbortValue;
 interface
 
 uses
+  Generics.Collections,
+
   Goccia.Arguments.Collection,
   Goccia.SharedPrototype,
   Goccia.Values.ClassValue,
+  Goccia.Values.EventTargetValue,
   Goccia.Values.ObjectValue,
   Goccia.Values.Primitives;
 
 type
-  TGocciaAbortSignalValue = class(TGocciaInstanceValue)
+  // WHATWG DOM §3.2: `interface AbortSignal : EventTarget`. The prototype chain
+  // genuinely runs through EventTarget.prototype, so `signal instanceof
+  // EventTarget` holds and the listener machinery is the shared one.
+  TGocciaAbortSignalValue = class(TGocciaEventTargetValue)
   private
     FReason: TGocciaValue;
     FTimeoutDeadlineNanoseconds: Int64;
+    FAbortEventPending: Boolean;
+    FAbortEventFired: Boolean;
     function AbortedGetter(const AArgs: TGocciaArgumentsCollection;
       const AThisValue: TGocciaValue): TGocciaValue;
     function ReasonGetter(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function OnAbortGetter(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function OnAbortSetter(const AArgs: TGocciaArgumentsCollection;
       const AThisValue: TGocciaValue): TGocciaValue;
     function ThrowIfAborted(const AArgs: TGocciaArgumentsCollection;
       const AThisValue: TGocciaValue): TGocciaValue;
@@ -32,12 +44,16 @@ type
     procedure RefreshTimeout;
     procedure SetTimeout(const AMilliseconds: Double);
     procedure SignalAbort(const AReason: TGocciaValue = nil);
+    procedure FlushAbortEvent;
+    procedure ObserveAbortState;
     function ToStringTag: string; override;
     procedure MarkReferences; override;
     class procedure ExposePrototype(const AConstructor: TGocciaValue);
 
     property Reason: TGocciaValue read FReason;
   end;
+
+  TGocciaAbortSignalList = TObjectList<TGocciaAbortSignalValue>;
 
   TGocciaAbortControllerValue = class(TGocciaInstanceValue)
   private
@@ -72,12 +88,14 @@ uses
   Goccia.Realm,
   Goccia.Values.Error,
   Goccia.Values.ErrorHelper,
+  Goccia.Values.EventValue,
   Goccia.Values.ObjectPropertyDescriptor;
 
 const
   NANOSECONDS_PER_MILLISECOND = 1000000;
   ABORT_ERROR_MESSAGE = 'This operation was aborted';
   TIMEOUT_ERROR_MESSAGE = 'The operation was aborted due to timeout';
+  ABORT_EVENT_TYPE = 'abort';
 
 var
   GAbortControllerSharedSlot: TGocciaRealmOwnedSlotId;
@@ -110,6 +128,8 @@ begin
   inherited Create(AClass);
   FReason := TGocciaUndefinedLiteralValue.UndefinedValue;
   FTimeoutDeadlineNanoseconds := 0;
+  FAbortEventPending := False;
+  FAbortEventFired := False;
   InitializePrototype;
   Shared := GetAbortSignalShared;
   if not Assigned(AClass) and Assigned(Shared) then
@@ -133,6 +153,8 @@ begin
   try
     Members.AddAccessor(PROP_ABORTED, AbortedGetter, nil, [pfConfigurable]);
     Members.AddAccessor(PROP_REASON, ReasonGetter, nil, [pfConfigurable]);
+    Members.AddAccessor(PROP_ONABORT, OnAbortGetter, OnAbortSetter,
+      [pfConfigurable]);
     Members.AddNamedMethod(PROP_THROW_IF_ABORTED, ThrowIfAborted, 0,
       gmkPrototypeMethod, [gmfNoFunctionPrototype]);
     PrototypeMembers := Members.ToDefinitions;
@@ -140,6 +162,10 @@ begin
     Members.Free;
   end;
   RegisterMemberDefinitions(Shared.Prototype, PrototypeMembers);
+  // WHATWG DOM §3.2: AbortSignal inherits from EventTarget. The base class
+  // constructor has already created EventTarget.prototype for this realm.
+  if Assigned(TGocciaEventTargetValue.SharedPrototypeObject) then
+    Shared.Prototype.Prototype := TGocciaEventTargetValue.SharedPrototypeObject;
 end;
 
 class procedure TGocciaAbortSignalValue.ExposePrototype(
@@ -168,13 +194,46 @@ begin
 end;
 
 // WHATWG DOM §3.2 AbortSignal.timeout(milliseconds), observed at a host checkpoint.
+// The state flip is separated from the "abort" event so that internal callers
+// (the fetch pump) can settle their own bookkeeping before any listener runs;
+// FlushAbortEvent is what actually dispatches.
 procedure TGocciaAbortSignalValue.RefreshTimeout;
 begin
   if (FTimeoutDeadlineNanoseconds > 0) and
      (FReason is TGocciaUndefinedLiteralValue) and
      (GetNanoseconds >= FTimeoutDeadlineNanoseconds) then
+  begin
     FReason := CreateDOMExceptionObject(TIMEOUT_ERROR_NAME,
       TIMEOUT_ERROR_MESSAGE);
+    FAbortEventPending := True;
+  end;
+end;
+
+// WHATWG DOM §3.2 signal abort, step 4: fire an event named "abort" at the
+// signal. A signal aborts at most once, so this fires at most once, and a
+// listener registered after the abort never runs.
+procedure TGocciaAbortSignalValue.FlushAbortEvent;
+var
+  Event: TGocciaEventValue;
+begin
+  if not FAbortEventPending then
+    Exit;
+  FAbortEventPending := False;
+  if FAbortEventFired then
+    Exit;
+  FAbortEventFired := True;
+
+  Event := TGocciaEventValue.Create;
+  Event.EventType := ABORT_EVENT_TYPE;
+  DispatchEventValue(Event);
+end;
+
+// Host observation checkpoint: flip a lazily-expired timeout, then deliver any
+// abort event the flip (or an earlier controller abort) left pending.
+procedure TGocciaAbortSignalValue.ObserveAbortState;
+begin
+  RefreshTimeout;
+  FlushAbortEvent;
 end;
 
 procedure TGocciaAbortSignalValue.SetTimeout(const AMilliseconds: Double);
@@ -226,16 +285,24 @@ begin
       ABORT_ERROR_MESSAGE)
   else
     FReason := AReason;
+
+  // Step 4 is deferred to FlushAbortEvent so the reason is already observable
+  // when listeners run, and so internal callers control the dispatch point.
+  FAbortEventPending := True;
 end;
 
 // WHATWG DOM §3.2 get AbortSignal.prototype.aborted.
 function TGocciaAbortSignalValue.AbortedGetter(
   const AArgs: TGocciaArgumentsCollection;
   const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Signal: TGocciaAbortSignalValue;
 begin
   if not (AThisValue is TGocciaAbortSignalValue) then
     ThrowTypeError('AbortSignal.prototype.aborted called on incompatible receiver');
-  if TGocciaAbortSignalValue(AThisValue).IsAborted then
+  Signal := TGocciaAbortSignalValue(AThisValue);
+  Signal.ObserveAbortState;
+  if Signal.IsAborted then
     Result := TGocciaBooleanLiteralValue.TrueValue
   else
     Result := TGocciaBooleanLiteralValue.FalseValue;
@@ -251,8 +318,37 @@ begin
   if not (AThisValue is TGocciaAbortSignalValue) then
     ThrowTypeError('AbortSignal.prototype.reason called on incompatible receiver');
   Signal := TGocciaAbortSignalValue(AThisValue);
-  Signal.RefreshTimeout;
+  Signal.ObserveAbortState;
   Result := Signal.Reason;
+end;
+
+// WHATWG DOM §3.2 get/set AbortSignal.prototype.onabort — an event handler IDL
+// attribute (§8.1.5.1) for the "abort" event type.
+function TGocciaAbortSignalValue.OnAbortGetter(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  if not (AThisValue is TGocciaAbortSignalValue) then
+    ThrowTypeError('AbortSignal.prototype.onabort called on incompatible receiver');
+  Result := TGocciaAbortSignalValue(AThisValue).EventHandlerValue(
+    ABORT_EVENT_TYPE);
+end;
+
+function TGocciaAbortSignalValue.OnAbortSetter(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Handler: TGocciaValue;
+begin
+  if not (AThisValue is TGocciaAbortSignalValue) then
+    ThrowTypeError('AbortSignal.prototype.onabort called on incompatible receiver');
+  if AArgs.Length > 0 then
+    Handler := AArgs.GetElement(0)
+  else
+    Handler := TGocciaUndefinedLiteralValue.UndefinedValue;
+  TGocciaAbortSignalValue(AThisValue).SetEventHandlerValue(ABORT_EVENT_TYPE,
+    Handler);
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
 
 // WHATWG DOM §3.2 AbortSignal.prototype.throwIfAborted().
@@ -266,6 +362,7 @@ begin
     ThrowTypeError(
       'AbortSignal.prototype.throwIfAborted called on incompatible receiver');
   Signal := TGocciaAbortSignalValue(AThisValue);
+  Signal.ObserveAbortState;
   if Signal.IsAborted then
     raise TGocciaThrowValue.Create(Signal.Reason);
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
@@ -358,6 +455,8 @@ begin
     Controller.Signal.SignalAbort(AArgs.GetElement(0))
   else
     Controller.Signal.SignalAbort;
+  // Step 4: fire "abort" at the signal, synchronously within abort().
+  Controller.Signal.FlushAbortEvent;
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
 

--- a/source/units/Goccia.Values.ErrorHelper.pas
+++ b/source/units/Goccia.Values.ErrorHelper.pas
@@ -70,6 +70,8 @@ begin
     Result := 20
   else if AName = TIMEOUT_ERROR_NAME then
     Result := 23
+  else if AName = INVALID_STATE_ERROR_NAME then
+    Result := 11
   else
     Result := 0;
 end;

--- a/source/units/Goccia.Values.EventTargetValue.pas
+++ b/source/units/Goccia.Values.EventTargetValue.pas
@@ -1,0 +1,568 @@
+unit Goccia.Values.EventTargetValue;
+
+// WHATWG DOM EventTarget (https://dom.spec.whatwg.org/#interface-eventtarget).
+//
+// GocciaScript has no node tree, so dispatch is always a single-target
+// invocation: the event listener list of one object, in registration order.
+// `capture` is accepted and participates in listener identity (per WHATWG DOM
+// §2.7, a listener is keyed on (type, callback, capture)) but has no ordering
+// effect, and `passive` is accepted and ignored. The `signal` member of
+// AddEventListenerOptions is not supported. See
+// docs/adr/0104-whatwg-eventtarget-base.md.
+
+{$I Goccia.inc}
+
+interface
+
+uses
+  Generics.Collections,
+
+  Goccia.Arguments.Collection,
+  Goccia.SharedPrototype,
+  Goccia.Values.ClassValue,
+  Goccia.Values.EventValue,
+  Goccia.Values.ObjectValue,
+  Goccia.Values.Primitives;
+
+type
+  // WHATWG DOM §2.7 event listener: a struct, not a JavaScript value. The
+  // callback is a GC-managed value and is marked through the owning target.
+  TGocciaEventListener = class
+  private
+    FEventType: string;
+    FCallback: TGocciaValue;
+    FCapture: Boolean;
+    FOnce: Boolean;
+    FRemoved: Boolean;
+    FEventHandler: Boolean;
+  public
+    constructor Create(const AEventType: string; const ACallback: TGocciaValue;
+      const ACapture, AOnce, AEventHandler: Boolean);
+
+    property EventType: string read FEventType;
+    property Callback: TGocciaValue read FCallback write FCallback;
+    property Capture: Boolean read FCapture;
+    property Once: Boolean read FOnce;
+    property Removed: Boolean read FRemoved write FRemoved;
+    property EventHandler: Boolean read FEventHandler;
+  end;
+
+  TGocciaEventListenerList = TObjectList<TGocciaEventListener>;
+
+  TGocciaEventTargetValue = class(TGocciaInstanceValue)
+  private
+    FListeners: TGocciaEventListenerList;
+    FDispatchDepth: Integer;
+    FHasRemovedListeners: Boolean;
+    function AddEventListenerMethod(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function RemoveEventListenerMethod(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function DispatchEventMethod(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    procedure InitializeEventTargetPrototype;
+    procedure CompactListeners;
+    function FindListener(const AEventType: string;
+      const ACallback: TGocciaValue;
+      const ACapture: Boolean): TGocciaEventListener;
+    function FindEventHandlerListener(
+      const AEventType: string): TGocciaEventListener;
+    procedure InvokeListener(const AListener: TGocciaEventListener;
+      const AEvent: TGocciaEventValue);
+  protected
+    // WHATWG DOM §8.1.5.1 event handler IDL attributes, used by subclasses that
+    // expose an `on<type>` accessor (AbortSignal.onabort).
+    function EventHandlerValue(const AEventType: string): TGocciaValue;
+    procedure SetEventHandlerValue(const AEventType: string;
+      const AValue: TGocciaValue);
+  public
+    constructor Create(const AClass: TGocciaClassValue = nil);
+    destructor Destroy; override;
+
+    procedure AddListener(const AEventType: string;
+      const ACallback: TGocciaValue; const ACapture, AOnce: Boolean);
+    procedure RemoveListener(const AEventType: string;
+      const ACallback: TGocciaValue; const ACapture: Boolean);
+    function DispatchEventValue(const AEvent: TGocciaEventValue): Boolean;
+
+    function ToStringTag: string; override;
+    procedure MarkReferences; override;
+    class procedure ExposePrototype(const AConstructor: TGocciaValue);
+    class function SharedPrototypeObject: TGocciaObjectValue;
+  end;
+
+implementation
+
+uses
+  Goccia.Constants.ConstructorNames,
+  Goccia.Constants.ErrorNames,
+  Goccia.Constants.PropertyNames,
+  Goccia.GarbageCollector,
+  Goccia.ObjectModel,
+  Goccia.Realm,
+  Goccia.Utils,
+  Goccia.Values.Error,
+  Goccia.Values.ErrorHelper;
+
+const
+  ALREADY_DISPATCHING_MESSAGE =
+    'The event is already being dispatched';
+
+var
+  GEventTargetSharedSlot: TGocciaRealmOwnedSlotId;
+
+function GetEventTargetShared: TGocciaSharedPrototype; {$IFDEF FPC}inline;{$ENDIF}
+begin
+  if CurrentRealm <> nil then
+    Result := TGocciaSharedPrototype(
+      CurrentRealm.GetOwnedSlot(GEventTargetSharedSlot))
+  else
+    Result := nil;
+end;
+
+// WHATWG DOM §2.7 flatten / flatten more: an options argument that is a
+// boolean is the capture flag; an object supplies capture/once/passive.
+function FlattenBooleanOption(const AOptions: TGocciaValue;
+  const AName: string): Boolean;
+var
+  Member: TGocciaValue;
+begin
+  if not Assigned(AOptions) then
+    Exit(False);
+  if AOptions is TGocciaObjectValue then
+  begin
+    Member := TGocciaObjectValue(AOptions).GetProperty(AName);
+    Result := Assigned(Member) and Member.ToBooleanLiteral.Value;
+  end
+  else if AName = PROP_CAPTURE then
+    Result := AOptions.ToBooleanLiteral.Value
+  else
+    Result := False;
+end;
+
+{ TGocciaEventListener }
+
+constructor TGocciaEventListener.Create(const AEventType: string;
+  const ACallback: TGocciaValue;
+  const ACapture, AOnce, AEventHandler: Boolean);
+begin
+  inherited Create;
+  FEventType := AEventType;
+  FCallback := ACallback;
+  FCapture := ACapture;
+  FOnce := AOnce;
+  FRemoved := False;
+  FEventHandler := AEventHandler;
+end;
+
+{ TGocciaEventTargetValue }
+
+constructor TGocciaEventTargetValue.Create(const AClass: TGocciaClassValue);
+var
+  Shared: TGocciaSharedPrototype;
+begin
+  inherited Create(AClass);
+  FListeners := TGocciaEventListenerList.Create(True);
+  FDispatchDepth := 0;
+  FHasRemovedListeners := False;
+  InitializeEventTargetPrototype;
+  Shared := GetEventTargetShared;
+  if not Assigned(AClass) and Assigned(Shared) then
+    FPrototype := Shared.Prototype;
+end;
+
+destructor TGocciaEventTargetValue.Destroy;
+begin
+  FListeners.Free;
+  inherited;
+end;
+
+procedure TGocciaEventTargetValue.InitializeEventTargetPrototype;
+var
+  Members: TGocciaMemberCollection;
+  Shared: TGocciaSharedPrototype;
+  PrototypeMembers: TArray<TGocciaMemberDefinition>;
+begin
+  if CurrentRealm = nil then
+    Exit;
+  if GetEventTargetShared <> nil then
+    Exit;
+
+  Shared := TGocciaSharedPrototype.Create(Self);
+  CurrentRealm.SetOwnedSlot(GEventTargetSharedSlot, Shared);
+  Members := TGocciaMemberCollection.Create;
+  try
+    Members.AddNamedMethod(PROP_ADD_EVENT_LISTENER, AddEventListenerMethod, 2,
+      gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+    Members.AddNamedMethod(PROP_REMOVE_EVENT_LISTENER,
+      RemoveEventListenerMethod, 2, gmkPrototypeMethod,
+      [gmfNoFunctionPrototype]);
+    Members.AddNamedMethod(PROP_DISPATCH_EVENT, DispatchEventMethod, 1,
+      gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+    PrototypeMembers := Members.ToDefinitions;
+  finally
+    Members.Free;
+  end;
+  RegisterMemberDefinitions(Shared.Prototype, PrototypeMembers);
+end;
+
+class procedure TGocciaEventTargetValue.ExposePrototype(
+  const AConstructor: TGocciaValue);
+var
+  Shared: TGocciaSharedPrototype;
+  Bootstrap: TGocciaEventTargetValue;
+begin
+  Shared := GetEventTargetShared;
+  if not Assigned(Shared) then
+  begin
+    Bootstrap := TGocciaEventTargetValue.Create;
+    Shared := GetEventTargetShared;
+    if not Assigned(Shared) then
+      Bootstrap.Free;
+  end;
+  if Assigned(Shared) then
+    ExposeSharedPrototypeOnConstructor(Shared, AConstructor);
+end;
+
+class function TGocciaEventTargetValue.SharedPrototypeObject: TGocciaObjectValue;
+var
+  Shared: TGocciaSharedPrototype;
+begin
+  Shared := GetEventTargetShared;
+  if Assigned(Shared) then
+    Result := Shared.Prototype
+  else
+    Result := nil;
+end;
+
+function TGocciaEventTargetValue.FindListener(const AEventType: string;
+  const ACallback: TGocciaValue;
+  const ACapture: Boolean): TGocciaEventListener;
+var
+  I: Integer;
+  Candidate: TGocciaEventListener;
+begin
+  Result := nil;
+  for I := 0 to FListeners.Count - 1 do
+  begin
+    Candidate := FListeners[I];
+    // Event handler listeners have an internal callback and never take part in
+    // addEventListener/removeEventListener identity matching.
+    if Candidate.EventHandler or Candidate.Removed then
+      Continue;
+    if (Candidate.EventType = AEventType) and
+       (Candidate.Callback = ACallback) and
+       (Candidate.Capture = ACapture) then
+      Exit(Candidate);
+  end;
+end;
+
+function TGocciaEventTargetValue.FindEventHandlerListener(
+  const AEventType: string): TGocciaEventListener;
+var
+  I: Integer;
+  Candidate: TGocciaEventListener;
+begin
+  Result := nil;
+  for I := 0 to FListeners.Count - 1 do
+  begin
+    Candidate := FListeners[I];
+    if Candidate.EventHandler and (Candidate.EventType = AEventType) then
+      Exit(Candidate);
+  end;
+end;
+
+procedure TGocciaEventTargetValue.CompactListeners;
+var
+  I: Integer;
+begin
+  if not FHasRemovedListeners then
+    Exit;
+  for I := FListeners.Count - 1 downto 0 do
+    if FListeners[I].Removed then
+      FListeners.Delete(I);
+  FHasRemovedListeners := False;
+end;
+
+// WHATWG DOM §2.7 add an event listener.
+procedure TGocciaEventTargetValue.AddListener(const AEventType: string;
+  const ACallback: TGocciaValue; const ACapture, AOnce: Boolean);
+begin
+  // Step 3: if an equivalent listener is already present, do not add again.
+  if Assigned(FindListener(AEventType, ACallback, ACapture)) then
+    Exit;
+  FListeners.Add(TGocciaEventListener.Create(AEventType, ACallback, ACapture,
+    AOnce, False));
+end;
+
+// WHATWG DOM §2.7 remove an event listener.
+procedure TGocciaEventTargetValue.RemoveListener(const AEventType: string;
+  const ACallback: TGocciaValue; const ACapture: Boolean);
+var
+  Listener: TGocciaEventListener;
+begin
+  Listener := FindListener(AEventType, ACallback, ACapture);
+  if not Assigned(Listener) then
+    Exit;
+  // Set removed first so an in-flight dispatch skips it, then compact when no
+  // dispatch is walking the list.
+  Listener.Removed := True;
+  FHasRemovedListeners := True;
+  if FDispatchDepth = 0 then
+    CompactListeners;
+end;
+
+// WHATWG DOM §8.1.5.1: the event handler's listener is registered the first
+// time a non-null handler is assigned, and setting null afterwards only clears
+// the handler value — the listener keeps its registration order.
+function TGocciaEventTargetValue.EventHandlerValue(
+  const AEventType: string): TGocciaValue;
+var
+  Listener: TGocciaEventListener;
+begin
+  Listener := FindEventHandlerListener(AEventType);
+  if Assigned(Listener) and Assigned(Listener.Callback) then
+    Result := Listener.Callback
+  else
+    Result := TGocciaNullLiteralValue.NullValue;
+end;
+
+procedure TGocciaEventTargetValue.SetEventHandlerValue(
+  const AEventType: string; const AValue: TGocciaValue);
+var
+  Listener: TGocciaEventListener;
+  Handler: TGocciaValue;
+begin
+  if Assigned(AValue) and AValue.IsCallable then
+    Handler := AValue
+  else
+    Handler := TGocciaNullLiteralValue.NullValue;
+
+  Listener := FindEventHandlerListener(AEventType);
+  if Assigned(Listener) then
+  begin
+    Listener.Callback := Handler;
+    Exit;
+  end;
+
+  if Handler is TGocciaNullLiteralValue then
+    Exit;
+  FListeners.Add(TGocciaEventListener.Create(AEventType, Handler, False, False,
+    True));
+end;
+
+procedure TGocciaEventTargetValue.InvokeListener(
+  const AListener: TGocciaEventListener; const AEvent: TGocciaEventValue);
+var
+  Callback, Handler, Receiver: TGocciaValue;
+  CallArgs: TGocciaArgumentsCollection;
+begin
+  Callback := AListener.Callback;
+  if not Assigned(Callback) or (Callback is TGocciaNullLiteralValue) or
+     (Callback is TGocciaUndefinedLiteralValue) then
+    Exit;
+
+  Handler := Callback;
+  Receiver := Self;
+  // WHATWG DOM §2.9 inner invoke: a non-callable object listener is invoked
+  // through its `handleEvent` method, with the listener object as `this`.
+  if not Callback.IsCallable then
+  begin
+    if not (Callback is TGocciaObjectValue) then
+      Exit;
+    Handler := TGocciaObjectValue(Callback).GetProperty(PROP_HANDLE_EVENT);
+    if not Assigned(Handler) or not Handler.IsCallable then
+      Exit;
+    Receiver := Callback;
+  end;
+
+  CallArgs := TGocciaArgumentsCollection.Create([AEvent]);
+  try
+    InvokeCallable(Handler, CallArgs, Receiver);
+  finally
+    CallArgs.Free;
+  end;
+end;
+
+// WHATWG DOM §2.9 dispatch, reduced to a single target: no propagation path is
+// built, so the event's listener list is invoked in registration order.
+function TGocciaEventTargetValue.DispatchEventValue(
+  const AEvent: TGocciaEventValue): Boolean;
+var
+  I, InitialCount: Integer;
+  Listener: TGocciaEventListener;
+  Rooted: Boolean;
+begin
+  Rooted := TGarbageCollector.Instance <> nil;
+  if Rooted then
+    TGarbageCollector.Instance.AddTempRoot(AEvent);
+  try
+    AEvent.DispatchFlag := True;
+    AEvent.Target := Self;
+    AEvent.CurrentTarget := Self;
+    Inc(FDispatchDepth);
+    try
+      // Listeners appended while dispatching are not invoked for this event.
+      InitialCount := FListeners.Count;
+      for I := 0 to InitialCount - 1 do
+      begin
+        if I >= FListeners.Count then
+          Break;
+        Listener := FListeners[I];
+        if Listener.Removed or (Listener.EventType <> AEvent.EventType) then
+          Continue;
+        // WHATWG DOM §2.9: a `once` listener is removed before it is invoked.
+        if Listener.Once then
+        begin
+          Listener.Removed := True;
+          FHasRemovedListeners := True;
+        end;
+        InvokeListener(Listener, AEvent);
+      end;
+    finally
+      // Unwind the dispatch state even when a listener throws, so the event
+      // stays reusable and the listener list is still compacted.
+      Dec(FDispatchDepth);
+      if FDispatchDepth = 0 then
+        CompactListeners;
+      AEvent.CurrentTarget := TGocciaNullLiteralValue.NullValue;
+      AEvent.DispatchFlag := False;
+    end;
+    Result := not (AEvent.Cancelable and AEvent.DefaultPrevented);
+  finally
+    if Rooted and (TGarbageCollector.Instance <> nil) then
+      TGarbageCollector.Instance.RemoveTempRoot(AEvent);
+  end;
+end;
+
+// WHATWG DOM §2.7 EventTarget.prototype.addEventListener(type, callback,
+// options).
+function TGocciaEventTargetValue.AddEventListenerMethod(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Target: TGocciaEventTargetValue;
+  Callback, Options: TGocciaValue;
+  EventType: string;
+begin
+  if not (AThisValue is TGocciaEventTargetValue) then
+    ThrowTypeError(
+      'EventTarget.prototype.addEventListener called on incompatible receiver');
+  Target := TGocciaEventTargetValue(AThisValue);
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+
+  if AArgs.Length < 2 then
+    ThrowTypeError(
+      'EventTarget.prototype.addEventListener requires a type and a callback');
+  EventType := AArgs.GetElement(0).ToStringLiteral.Value;
+  Callback := AArgs.GetElement(1);
+  // WebIDL EventListener?: null and undefined are a no-op, other non-objects
+  // are a TypeError.
+  if (Callback is TGocciaNullLiteralValue) or
+     (Callback is TGocciaUndefinedLiteralValue) then
+    Exit;
+  if not (Callback is TGocciaObjectValue) then
+    ThrowTypeError(
+      'EventTarget.prototype.addEventListener callback must be an object or null');
+
+  if AArgs.Length > 2 then
+    Options := AArgs.GetElement(2)
+  else
+    Options := nil;
+
+  Target.AddListener(EventType, Callback,
+    FlattenBooleanOption(Options, PROP_CAPTURE),
+    FlattenBooleanOption(Options, PROP_ONCE));
+end;
+
+// WHATWG DOM §2.7 EventTarget.prototype.removeEventListener(type, callback,
+// options).
+function TGocciaEventTargetValue.RemoveEventListenerMethod(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Target: TGocciaEventTargetValue;
+  Callback, Options: TGocciaValue;
+  EventType: string;
+begin
+  if not (AThisValue is TGocciaEventTargetValue) then
+    ThrowTypeError(
+      'EventTarget.prototype.removeEventListener called on incompatible receiver');
+  Target := TGocciaEventTargetValue(AThisValue);
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+
+  if AArgs.Length < 2 then
+    ThrowTypeError(
+      'EventTarget.prototype.removeEventListener requires a type and a callback');
+  EventType := AArgs.GetElement(0).ToStringLiteral.Value;
+  Callback := AArgs.GetElement(1);
+  if (Callback is TGocciaNullLiteralValue) or
+     (Callback is TGocciaUndefinedLiteralValue) then
+    Exit;
+  if not (Callback is TGocciaObjectValue) then
+    ThrowTypeError(
+      'EventTarget.prototype.removeEventListener callback must be an object or null');
+
+  if AArgs.Length > 2 then
+    Options := AArgs.GetElement(2)
+  else
+    Options := nil;
+
+  Target.RemoveListener(EventType, Callback,
+    FlattenBooleanOption(Options, PROP_CAPTURE));
+end;
+
+// WHATWG DOM §2.7 EventTarget.prototype.dispatchEvent(event).
+function TGocciaEventTargetValue.DispatchEventMethod(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Target: TGocciaEventTargetValue;
+  Event: TGocciaEventValue;
+begin
+  if not (AThisValue is TGocciaEventTargetValue) then
+    ThrowTypeError(
+      'EventTarget.prototype.dispatchEvent called on incompatible receiver');
+  Target := TGocciaEventTargetValue(AThisValue);
+
+  if (AArgs.Length = 0) or not (AArgs.GetElement(0) is TGocciaEventValue) then
+    ThrowTypeError(
+      'EventTarget.prototype.dispatchEvent requires an Event argument');
+  Event := TGocciaEventValue(AArgs.GetElement(0));
+  // Step 1: throw InvalidStateError when the event's dispatch flag is set.
+  if Event.DispatchFlag then
+    raise TGocciaThrowValue.Create(CreateDOMExceptionObject(
+      INVALID_STATE_ERROR_NAME, ALREADY_DISPATCHING_MESSAGE));
+
+  if Target.DispatchEventValue(Event) then
+    Result := TGocciaBooleanLiteralValue.TrueValue
+  else
+    Result := TGocciaBooleanLiteralValue.FalseValue;
+end;
+
+function TGocciaEventTargetValue.ToStringTag: string;
+begin
+  Result := CONSTRUCTOR_EVENT_TARGET;
+end;
+
+procedure TGocciaEventTargetValue.MarkReferences;
+var
+  I: Integer;
+  Callback: TGocciaValue;
+begin
+  if GCMarked then
+    Exit;
+  inherited;
+  if Assigned(FListeners) then
+    for I := 0 to FListeners.Count - 1 do
+    begin
+      Callback := FListeners[I].Callback;
+      if Assigned(Callback) then
+        Callback.MarkReferences;
+    end;
+end;
+
+initialization
+  GEventTargetSharedSlot := RegisterRealmOwnedSlot('EventTarget.shared');
+
+end.

--- a/source/units/Goccia.Values.EventTargetValue.pas
+++ b/source/units/Goccia.Values.EventTargetValue.pas
@@ -391,11 +391,14 @@ function TGocciaEventTargetValue.DispatchEventValue(
 var
   I, InitialCount: Integer;
   Listener: TGocciaEventListener;
-  Rooted: Boolean;
+  EventRoot: TGocciaTempRoot;
 begin
-  Rooted := TGarbageCollector.Instance <> nil;
-  if Rooted then
-    TGarbageCollector.Instance.AddTempRoot(AEvent);
+  // Temp roots are a set, not a refcount: the caller's frame may already have
+  // rooted this same event (the call machinery roots arguments), and a raw
+  // AddTempRoot/RemoveTempRoot pair here would tear that outer root down on
+  // exit. AddTempRootIfNeeded only adds — and only removes — what it owns.
+  InitializeTempRoot(EventRoot);
+  AddTempRootIfNeeded(EventRoot, AEvent);
   try
     AEvent.DispatchFlag := True;
     AEvent.Target := Self;
@@ -430,8 +433,7 @@ begin
     end;
     Result := not (AEvent.Cancelable and AEvent.DefaultPrevented);
   finally
-    if Rooted and (TGarbageCollector.Instance <> nil) then
-      TGarbageCollector.Instance.RemoveTempRoot(AEvent);
+    RemoveTempRootIfNeeded(EventRoot);
   end;
 end;
 
@@ -444,6 +446,7 @@ var
   Target: TGocciaEventTargetValue;
   Callback, Options: TGocciaValue;
   EventType: string;
+  Capture, Once: Boolean;
 begin
   if not (AThisValue is TGocciaEventTargetValue) then
     ThrowTypeError(
@@ -470,9 +473,15 @@ begin
   else
     Options := nil;
 
-  Target.AddListener(EventType, Callback,
-    FlattenBooleanOption(Options, PROP_CAPTURE),
-    FlattenBooleanOption(Options, PROP_ONCE));
+  // WHATWG DOM §2.7 flatten more, in declaration order: capture, then once,
+  // then passive. `passive` has no effect here (nothing this runtime dispatches
+  // has a preventable default action driven by it), but its getter is still
+  // observed so a dictionary with side-effecting accessors behaves the same.
+  Capture := FlattenBooleanOption(Options, PROP_CAPTURE);
+  Once := FlattenBooleanOption(Options, PROP_ONCE);
+  FlattenBooleanOption(Options, PROP_PASSIVE);
+
+  Target.AddListener(EventType, Callback, Capture, Once);
 end;
 
 // WHATWG DOM §2.7 EventTarget.prototype.removeEventListener(type, callback,

--- a/source/units/Goccia.Values.EventValue.pas
+++ b/source/units/Goccia.Values.EventValue.pas
@@ -1,0 +1,279 @@
+unit Goccia.Values.EventValue;
+
+// WHATWG DOM Event objects (https://dom.spec.whatwg.org/#interface-event).
+//
+// Scope: the minimal Event surface that dispatch on an EventTarget needs.
+// GocciaScript has no node tree, so the propagation-only parts of the interface
+// (eventPhase, stopPropagation, stopImmediatePropagation, composedPath,
+// composed, isTrusted, timeStamp) are deliberately absent. `bubbles` and
+// `cancelable` are recorded from EventInit and reported faithfully, but no
+// propagation follows from `bubbles` because there is no tree to propagate
+// through. See docs/adr/0104-whatwg-eventtarget-base.md.
+
+{$I Goccia.inc}
+
+interface
+
+uses
+  Goccia.Arguments.Collection,
+  Goccia.SharedPrototype,
+  Goccia.Values.ClassValue,
+  Goccia.Values.ObjectValue,
+  Goccia.Values.Primitives;
+
+type
+  TGocciaEventValue = class(TGocciaInstanceValue)
+  private
+    FEventType: string;
+    FTarget: TGocciaValue;
+    FCurrentTarget: TGocciaValue;
+    FBubbles: Boolean;
+    FCancelable: Boolean;
+    FDefaultPrevented: Boolean;
+    FDispatchFlag: Boolean;
+    function TypeGetter(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function TargetGetter(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function CurrentTargetGetter(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function BubblesGetter(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function CancelableGetter(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function DefaultPreventedGetter(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function PreventDefault(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    procedure InitializePrototype;
+  public
+    constructor Create(const AClass: TGocciaClassValue = nil);
+    function ToStringTag: string; override;
+    procedure MarkReferences; override;
+    class procedure ExposePrototype(const AConstructor: TGocciaValue);
+    class function SharedPrototypeObject: TGocciaObjectValue;
+
+    property EventType: string read FEventType write FEventType;
+    property Target: TGocciaValue read FTarget write FTarget;
+    property CurrentTarget: TGocciaValue read FCurrentTarget
+      write FCurrentTarget;
+    property Bubbles: Boolean read FBubbles write FBubbles;
+    property Cancelable: Boolean read FCancelable write FCancelable;
+    property DefaultPrevented: Boolean read FDefaultPrevented;
+    property DispatchFlag: Boolean read FDispatchFlag write FDispatchFlag;
+  end;
+
+implementation
+
+uses
+  Goccia.Constants.ConstructorNames,
+  Goccia.Constants.PropertyNames,
+  Goccia.ObjectModel,
+  Goccia.Realm,
+  Goccia.Values.ErrorHelper,
+  Goccia.Values.ObjectPropertyDescriptor;
+
+var
+  GEventSharedSlot: TGocciaRealmOwnedSlotId;
+
+function GetEventShared: TGocciaSharedPrototype; {$IFDEF FPC}inline;{$ENDIF}
+begin
+  if CurrentRealm <> nil then
+    Result := TGocciaSharedPrototype(
+      CurrentRealm.GetOwnedSlot(GEventSharedSlot))
+  else
+    Result := nil;
+end;
+
+{ TGocciaEventValue }
+
+constructor TGocciaEventValue.Create(const AClass: TGocciaClassValue);
+var
+  Shared: TGocciaSharedPrototype;
+begin
+  inherited Create(AClass);
+  FEventType := '';
+  FTarget := TGocciaNullLiteralValue.NullValue;
+  FCurrentTarget := TGocciaNullLiteralValue.NullValue;
+  FBubbles := False;
+  FCancelable := False;
+  FDefaultPrevented := False;
+  FDispatchFlag := False;
+  InitializePrototype;
+  Shared := GetEventShared;
+  if not Assigned(AClass) and Assigned(Shared) then
+    FPrototype := Shared.Prototype;
+end;
+
+procedure TGocciaEventValue.InitializePrototype;
+var
+  Members: TGocciaMemberCollection;
+  Shared: TGocciaSharedPrototype;
+  PrototypeMembers: TArray<TGocciaMemberDefinition>;
+begin
+  if CurrentRealm = nil then
+    Exit;
+  if GetEventShared <> nil then
+    Exit;
+
+  Shared := TGocciaSharedPrototype.Create(Self);
+  CurrentRealm.SetOwnedSlot(GEventSharedSlot, Shared);
+  Members := TGocciaMemberCollection.Create;
+  try
+    Members.AddAccessor(PROP_TYPE, TypeGetter, nil, [pfConfigurable]);
+    Members.AddAccessor(PROP_TARGET, TargetGetter, nil, [pfConfigurable]);
+    Members.AddAccessor(PROP_CURRENT_TARGET, CurrentTargetGetter, nil,
+      [pfConfigurable]);
+    Members.AddAccessor(PROP_BUBBLES, BubblesGetter, nil, [pfConfigurable]);
+    Members.AddAccessor(PROP_CANCELABLE, CancelableGetter, nil,
+      [pfConfigurable]);
+    Members.AddAccessor(PROP_DEFAULT_PREVENTED, DefaultPreventedGetter, nil,
+      [pfConfigurable]);
+    Members.AddNamedMethod(PROP_PREVENT_DEFAULT, PreventDefault, 0,
+      gmkPrototypeMethod, [gmfNoFunctionPrototype]);
+    PrototypeMembers := Members.ToDefinitions;
+  finally
+    Members.Free;
+  end;
+  RegisterMemberDefinitions(Shared.Prototype, PrototypeMembers);
+end;
+
+class procedure TGocciaEventValue.ExposePrototype(
+  const AConstructor: TGocciaValue);
+var
+  Shared: TGocciaSharedPrototype;
+  Bootstrap: TGocciaEventValue;
+begin
+  Shared := GetEventShared;
+  if not Assigned(Shared) then
+  begin
+    Bootstrap := TGocciaEventValue.Create;
+    Shared := GetEventShared;
+    if not Assigned(Shared) then
+      Bootstrap.Free;
+  end;
+  if Assigned(Shared) then
+    ExposeSharedPrototypeOnConstructor(Shared, AConstructor);
+end;
+
+class function TGocciaEventValue.SharedPrototypeObject: TGocciaObjectValue;
+var
+  Shared: TGocciaSharedPrototype;
+begin
+  Shared := GetEventShared;
+  if Assigned(Shared) then
+    Result := Shared.Prototype
+  else
+    Result := nil;
+end;
+
+// WHATWG DOM §2.2 get Event.prototype.type.
+function TGocciaEventValue.TypeGetter(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  if not (AThisValue is TGocciaEventValue) then
+    ThrowTypeError('Event.prototype.type called on incompatible receiver');
+  Result := TGocciaStringLiteralValue.Create(
+    TGocciaEventValue(AThisValue).EventType);
+end;
+
+// WHATWG DOM §2.2 get Event.prototype.target.
+function TGocciaEventValue.TargetGetter(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  if not (AThisValue is TGocciaEventValue) then
+    ThrowTypeError('Event.prototype.target called on incompatible receiver');
+  Result := TGocciaEventValue(AThisValue).Target;
+end;
+
+// WHATWG DOM §2.2 get Event.prototype.currentTarget.
+function TGocciaEventValue.CurrentTargetGetter(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  if not (AThisValue is TGocciaEventValue) then
+    ThrowTypeError(
+      'Event.prototype.currentTarget called on incompatible receiver');
+  Result := TGocciaEventValue(AThisValue).CurrentTarget;
+end;
+
+// WHATWG DOM §2.2 get Event.prototype.bubbles.
+function TGocciaEventValue.BubblesGetter(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  if not (AThisValue is TGocciaEventValue) then
+    ThrowTypeError('Event.prototype.bubbles called on incompatible receiver');
+  if TGocciaEventValue(AThisValue).Bubbles then
+    Result := TGocciaBooleanLiteralValue.TrueValue
+  else
+    Result := TGocciaBooleanLiteralValue.FalseValue;
+end;
+
+// WHATWG DOM §2.2 get Event.prototype.cancelable.
+function TGocciaEventValue.CancelableGetter(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  if not (AThisValue is TGocciaEventValue) then
+    ThrowTypeError(
+      'Event.prototype.cancelable called on incompatible receiver');
+  if TGocciaEventValue(AThisValue).Cancelable then
+    Result := TGocciaBooleanLiteralValue.TrueValue
+  else
+    Result := TGocciaBooleanLiteralValue.FalseValue;
+end;
+
+// WHATWG DOM §2.2 get Event.prototype.defaultPrevented.
+function TGocciaEventValue.DefaultPreventedGetter(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  if not (AThisValue is TGocciaEventValue) then
+    ThrowTypeError(
+      'Event.prototype.defaultPrevented called on incompatible receiver');
+  if TGocciaEventValue(AThisValue).DefaultPrevented then
+    Result := TGocciaBooleanLiteralValue.TrueValue
+  else
+    Result := TGocciaBooleanLiteralValue.FalseValue;
+end;
+
+// WHATWG DOM §2.2 Event.prototype.preventDefault().
+function TGocciaEventValue.PreventDefault(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Event: TGocciaEventValue;
+begin
+  if not (AThisValue is TGocciaEventValue) then
+    ThrowTypeError(
+      'Event.prototype.preventDefault called on incompatible receiver');
+  Event := TGocciaEventValue(AThisValue);
+  // WHATWG DOM §2.2: set the canceled flag only when the event is cancelable.
+  if Event.Cancelable then
+    Event.FDefaultPrevented := True;
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+end;
+
+function TGocciaEventValue.ToStringTag: string;
+begin
+  Result := CONSTRUCTOR_EVENT;
+end;
+
+procedure TGocciaEventValue.MarkReferences;
+begin
+  if GCMarked then
+    Exit;
+  inherited;
+  if Assigned(FTarget) then
+    FTarget.MarkReferences;
+  if Assigned(FCurrentTarget) then
+    FCurrentTarget.MarkReferences;
+end;
+
+initialization
+  GEventSharedSlot := RegisterRealmOwnedSlot('Event.shared');
+
+end.

--- a/tests/built-ins/AbortController/prototype/abort.js
+++ b/tests/built-ins/AbortController/prototype/abort.js
@@ -29,6 +29,28 @@ describe("AbortController.prototype.abort", () => {
     expect(controller.signal.reason.name).toBe("AbortError");
   });
 
+  test("fires the abort event synchronously within abort()", () => {
+    const controller = new AbortController();
+    const order = [];
+    controller.signal.addEventListener("abort", () => order.push("listener"));
+
+    order.push("before");
+    controller.abort();
+    order.push("after");
+    expect(order).toEqual(["before", "listener", "after"]);
+  });
+
+  test("aborts before the listener observes the signal state", () => {
+    const controller = new AbortController();
+    let abortedDuringDispatch = null;
+    controller.signal.addEventListener("abort", () => {
+      abortedDuringDispatch = controller.signal.aborted;
+    });
+
+    controller.abort();
+    expect(abortedDuringDispatch).toBe(true);
+  });
+
   test("rejects incompatible receivers", () => {
     expect(() => AbortController.prototype.abort.call({})).toThrow(TypeError);
   });

--- a/tests/built-ins/AbortSignal/prototype/addEventListener.js
+++ b/tests/built-ins/AbortSignal/prototype/addEventListener.js
@@ -87,6 +87,27 @@ describe("AbortSignal abort event", () => {
     expect(onceCalls).toBe(1);
   });
 
+  test("exposes settled abort state to a re-entrant abort listener", () => {
+    const controller = new AbortController();
+    let fired = 0;
+    let abortedDuringDispatch = null;
+    let reasonDuringDispatch = null;
+
+    controller.signal.addEventListener("abort", () => {
+      fired += 1;
+      abortedDuringDispatch = controller.signal.aborted;
+      reasonDuringDispatch = controller.signal.reason;
+      // Re-entrant abort must be a no-op: the signal already aborted.
+      controller.abort("second");
+    });
+
+    controller.abort("first");
+    expect(fired).toBe(1);
+    expect(abortedDuringDispatch).toBe(true);
+    expect(reasonDuringDispatch).toBe("first");
+    expect(controller.signal.reason).toBe("first");
+  });
+
   test("does not fire for other event types", () => {
     const controller = new AbortController();
     let calls = 0;

--- a/tests/built-ins/AbortSignal/prototype/addEventListener.js
+++ b/tests/built-ins/AbortSignal/prototype/addEventListener.js
@@ -1,0 +1,100 @@
+/*---
+description: AbortSignal abort event dispatch
+features: [AbortSignal, AbortController, EventTarget, Event]
+---*/
+
+describe("AbortSignal abort event", () => {
+  test("fires exactly once no matter how often abort is called", () => {
+    const controller = new AbortController();
+    let calls = 0;
+    controller.signal.addEventListener("abort", () => {
+      calls += 1;
+    });
+
+    controller.abort();
+    controller.abort();
+    expect(calls).toBe(1);
+  });
+
+  test("delivers an abort event targeted at the signal", () => {
+    const controller = new AbortController();
+    let received = null;
+    controller.signal.addEventListener("abort", (event) => {
+      received = event;
+    });
+
+    controller.abort();
+    expect(received instanceof Event).toBe(true);
+    expect(received.type).toBe("abort");
+    expect(received.target).toBe(controller.signal);
+    expect(received.currentTarget).toBe(null);
+  });
+
+  test("exposes the abort reason while the listener runs", () => {
+    const controller = new AbortController();
+    const reason = { kind: "cancelled" };
+    let observed = null;
+    controller.signal.addEventListener("abort", (event) => {
+      observed = event.target.reason;
+    });
+
+    controller.abort(reason);
+    expect(observed).toBe(reason);
+  });
+
+  test("never fires for a listener added after the abort", () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    let fired = false;
+    controller.signal.addEventListener("abort", () => {
+      fired = true;
+    });
+    expect(fired).toBe(false);
+    expect(controller.signal.aborted).toBe(true);
+  });
+
+  test("never fires on an already-aborted AbortSignal.abort signal", () => {
+    const signal = AbortSignal.abort();
+    let fired = false;
+    signal.addEventListener("abort", () => {
+      fired = true;
+    });
+    expect(fired).toBe(false);
+  });
+
+  test("honors once and removeEventListener", () => {
+    const removedController = new AbortController();
+    let removedCalls = 0;
+    const listener = () => {
+      removedCalls += 1;
+    };
+    removedController.signal.addEventListener("abort", listener);
+    removedController.signal.removeEventListener("abort", listener);
+    removedController.abort();
+    expect(removedCalls).toBe(0);
+
+    const onceController = new AbortController();
+    let onceCalls = 0;
+    onceController.signal.addEventListener(
+      "abort",
+      () => {
+        onceCalls += 1;
+      },
+      { once: true }
+    );
+    onceController.abort();
+    expect(onceCalls).toBe(1);
+  });
+
+  test("does not fire for other event types", () => {
+    const controller = new AbortController();
+    let calls = 0;
+    controller.signal.addEventListener("cancel", () => {
+      calls += 1;
+    });
+
+    controller.abort();
+    expect(calls).toBe(0);
+  });
+});

--- a/tests/built-ins/AbortSignal/prototype/onabort.js
+++ b/tests/built-ins/AbortSignal/prototype/onabort.js
@@ -1,0 +1,90 @@
+/*---
+description: AbortSignal.prototype.onabort event handler attribute
+features: [AbortSignal, AbortController, Event]
+---*/
+
+describe("AbortSignal.prototype.onabort", () => {
+  test("defaults to null", () => {
+    const controller = new AbortController();
+    expect(controller.signal.onabort).toBe(null);
+  });
+
+  test("returns the assigned handler", () => {
+    const controller = new AbortController();
+    const handler = () => {};
+    controller.signal.onabort = handler;
+    expect(controller.signal.onabort).toBe(handler);
+  });
+
+  test("fires with the abort event", () => {
+    const controller = new AbortController();
+    let received = null;
+    controller.signal.onabort = (event) => {
+      received = event;
+    };
+
+    controller.abort();
+    expect(received.type).toBe("abort");
+    expect(received.target).toBe(controller.signal);
+  });
+
+  test("fires at most once", () => {
+    const controller = new AbortController();
+    let calls = 0;
+    controller.signal.onabort = () => {
+      calls += 1;
+    };
+
+    controller.abort();
+    controller.abort();
+    expect(calls).toBe(1);
+  });
+
+  test("clears the handler when set to null", () => {
+    const controller = new AbortController();
+    let calls = 0;
+    controller.signal.onabort = () => {
+      calls += 1;
+    };
+    controller.signal.onabort = null;
+    expect(controller.signal.onabort).toBe(null);
+
+    controller.abort();
+    expect(calls).toBe(0);
+  });
+
+  test("replaces a previously assigned handler", () => {
+    const controller = new AbortController();
+    const order = [];
+    controller.signal.onabort = () => order.push("first");
+    controller.signal.onabort = () => order.push("second");
+
+    controller.abort();
+    expect(order).toEqual(["second"]);
+  });
+
+  test("ignores non-callable assignments", () => {
+    const controller = new AbortController();
+    controller.signal.onabort = 42;
+    expect(controller.signal.onabort).toBe(null);
+  });
+
+  test("runs alongside addEventListener listeners in registration order", () => {
+    const controller = new AbortController();
+    const order = [];
+    controller.signal.onabort = () => order.push("handler");
+    controller.signal.addEventListener("abort", () => order.push("listener"));
+
+    controller.abort();
+    expect(order).toEqual(["handler", "listener"]);
+  });
+
+  test("rejects incompatible receivers", () => {
+    const descriptor = Object.getOwnPropertyDescriptor(
+      AbortSignal.prototype,
+      "onabort"
+    );
+    expect(() => descriptor.get.call({})).toThrow(TypeError);
+    expect(() => descriptor.set.call({}, () => {})).toThrow(TypeError);
+  });
+});

--- a/tests/built-ins/AbortSignal/prototype/onabort.js
+++ b/tests/built-ins/AbortSignal/prototype/onabort.js
@@ -63,6 +63,19 @@ describe("AbortSignal.prototype.onabort", () => {
     expect(order).toEqual(["second"]);
   });
 
+  test("keeps its registration position when reassigned", () => {
+    const controller = new AbortController();
+    const order = [];
+    controller.signal.addEventListener("abort", () => order.push("listener"));
+    controller.signal.onabort = () => order.push("handler1");
+    controller.signal.onabort = () => order.push("handler2");
+
+    controller.abort();
+    // The handler's listener slot was claimed at the first assignment, so it
+    // still runs after the earlier addEventListener listener.
+    expect(order).toEqual(["listener", "handler2"]);
+  });
+
   test("ignores non-callable assignments", () => {
     const controller = new AbortController();
     controller.signal.onabort = 42;

--- a/tests/built-ins/AbortSignal/timeout.js
+++ b/tests/built-ins/AbortSignal/timeout.js
@@ -15,6 +15,39 @@ describe("AbortSignal.timeout", () => {
     expect(() => AbortSignal.timeout()).toThrow(TypeError);
   });
 
+  // GocciaScript has no timer task queue (ADR 0031, ADR 0104): an expired
+  // timeout signal aborts at the moment the host observes it, and its abort
+  // event is delivered at that same observation point.
+  test("fires the abort event when the expired timeout is first observed", () => {
+    const signal = AbortSignal.timeout(0);
+    let calls = 0;
+    let reasonDuringDispatch = null;
+    signal.addEventListener("abort", (event) => {
+      calls += 1;
+      reasonDuringDispatch = event.target.reason.name;
+    });
+
+    expect(calls).toBe(0);
+    expect(signal.aborted).toBe(true);
+    expect(calls).toBe(1);
+    expect(reasonDuringDispatch).toBe("TimeoutError");
+
+    expect(signal.aborted).toBe(true);
+    expect(signal.reason.name).toBe("TimeoutError");
+    expect(calls).toBe(1);
+  });
+
+  test("never fires for a listener added after the timeout was observed", () => {
+    const signal = AbortSignal.timeout(0);
+    expect(signal.aborted).toBe(true);
+
+    let fired = false;
+    signal.addEventListener("abort", () => {
+      fired = true;
+    });
+    expect(fired).toBe(false);
+  });
+
   test("rejects invalid unsigned long long values", () => {
     expect(() => AbortSignal.timeout(NaN)).toThrow(TypeError);
     expect(() => AbortSignal.timeout(-1)).toThrow(TypeError);

--- a/tests/built-ins/Event/constructor.js
+++ b/tests/built-ins/Event/constructor.js
@@ -1,0 +1,80 @@
+/*---
+description: Event constructor and instance state
+features: [Event, EventTarget]
+---*/
+
+describe("Event constructor", () => {
+  test("is exposed as a runtime global", () => {
+    expect(typeof Event).toBe("function");
+    expect(Goccia.runtimeGlobals.includes("Event")).toBe(true);
+  });
+
+  test("creates an Event with the supplied type", () => {
+    const event = new Event("ping");
+    expect(event instanceof Event).toBe(true);
+    expect(event.type).toBe("ping");
+    expect(Object.prototype.toString.call(event)).toBe("[object Event]");
+  });
+
+  test("defaults bubbles, cancelable and defaultPrevented to false", () => {
+    const event = new Event("ping");
+    expect(event.bubbles).toBe(false);
+    expect(event.cancelable).toBe(false);
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  test("reads bubbles and cancelable from the init dictionary", () => {
+    const event = new Event("ping", { bubbles: true, cancelable: true });
+    expect(event.bubbles).toBe(true);
+    expect(event.cancelable).toBe(true);
+  });
+
+  test("starts with a null target and currentTarget", () => {
+    const event = new Event("ping");
+    expect(event.target).toBe(null);
+    expect(event.currentTarget).toBe(null);
+  });
+
+  test("coerces the type argument to a string", () => {
+    expect(new Event(42).type).toBe("42");
+  });
+
+  test("requires a type argument", () => {
+    expect(() => new Event()).toThrow(TypeError);
+  });
+
+  test("requires construction with new", () => {
+    expect(() => Event("ping")).toThrow(TypeError);
+  });
+
+  test("supports subclassing with class syntax", () => {
+    class ReadyEvent extends Event {
+      constructor(type) {
+        super(type);
+        this.detail = "ready";
+      }
+    }
+
+    const target = new EventTarget();
+    let received = null;
+    target.addEventListener("ready", (event) => {
+      received = event;
+    });
+
+    const event = new ReadyEvent("ready");
+    target.dispatchEvent(event);
+    expect(received).toBe(event);
+    expect(received instanceof ReadyEvent).toBe(true);
+    expect(received instanceof Event).toBe(true);
+    expect(received.type).toBe("ready");
+    expect(received.detail).toBe("ready");
+  });
+
+  test("rejects incompatible receivers on its accessors", () => {
+    const descriptor = Object.getOwnPropertyDescriptor(
+      Event.prototype,
+      "type"
+    );
+    expect(() => descriptor.get.call({})).toThrow(TypeError);
+  });
+});

--- a/tests/built-ins/Event/constructor.js
+++ b/tests/built-ins/Event/constructor.js
@@ -43,6 +43,16 @@ describe("Event constructor", () => {
     expect(() => new Event()).toThrow(TypeError);
   });
 
+  test("treats null and undefined init as an absent dictionary", () => {
+    expect(new Event("ping", null).bubbles).toBe(false);
+    expect(new Event("ping", undefined).bubbles).toBe(false);
+  });
+
+  test("rejects a non-object init dictionary", () => {
+    expect(() => new Event("ping", 42)).toThrow(TypeError);
+    expect(() => new Event("ping", "init")).toThrow(TypeError);
+  });
+
   test("requires construction with new", () => {
     expect(() => Event("ping")).toThrow(TypeError);
   });

--- a/tests/built-ins/Event/prototype/preventDefault.js
+++ b/tests/built-ins/Event/prototype/preventDefault.js
@@ -1,0 +1,30 @@
+/*---
+description: Event.prototype.preventDefault cancellation semantics
+features: [Event, EventTarget]
+---*/
+
+describe("Event.prototype.preventDefault", () => {
+  test("sets defaultPrevented on a cancelable event", () => {
+    const event = new Event("ping", { cancelable: true });
+    event.preventDefault();
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  test("is a no-op on a non-cancelable event", () => {
+    const event = new Event("ping");
+    event.preventDefault();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  test("makes dispatchEvent report cancellation", () => {
+    const target = new EventTarget();
+    target.addEventListener("ping", (event) => event.preventDefault());
+    expect(target.dispatchEvent(new Event("ping", { cancelable: true }))).toBe(
+      false
+    );
+  });
+
+  test("rejects incompatible receivers", () => {
+    expect(() => Event.prototype.preventDefault.call({})).toThrow(TypeError);
+  });
+});

--- a/tests/built-ins/EventTarget/constructor.js
+++ b/tests/built-ins/EventTarget/constructor.js
@@ -1,0 +1,58 @@
+/*---
+description: EventTarget constructor behavior
+features: [EventTarget, AbortSignal]
+---*/
+
+describe("EventTarget constructor", () => {
+  test("is exposed as a runtime global", () => {
+    expect(typeof EventTarget).toBe("function");
+    expect(Goccia.runtimeGlobals.includes("EventTarget")).toBe(true);
+  });
+
+  test("creates an EventTarget instance", () => {
+    const target = new EventTarget();
+    expect(target instanceof EventTarget).toBe(true);
+    expect(Object.prototype.toString.call(target)).toBe("[object EventTarget]");
+  });
+
+  test("requires construction with new", () => {
+    expect(() => EventTarget()).toThrow(TypeError);
+  });
+
+  test("exposes the listener methods on its prototype", () => {
+    expect(typeof EventTarget.prototype.addEventListener).toBe("function");
+    expect(typeof EventTarget.prototype.removeEventListener).toBe("function");
+    expect(typeof EventTarget.prototype.dispatchEvent).toBe("function");
+  });
+
+  test("supports subclassing with class syntax", () => {
+    class Emitter extends EventTarget {
+      constructor() {
+        super();
+        this.tag = "emitter";
+      }
+    }
+
+    const emitter = new Emitter();
+    expect(emitter instanceof Emitter).toBe(true);
+    expect(emitter instanceof EventTarget).toBe(true);
+    expect(emitter.tag).toBe("emitter");
+
+    let calls = 0;
+    emitter.addEventListener("go", () => {
+      calls += 1;
+    });
+    expect(emitter.dispatchEvent(new Event("go"))).toBe(true);
+    expect(calls).toBe(1);
+  });
+
+  test("AbortSignal inherits from EventTarget", () => {
+    const controller = new AbortController();
+    expect(controller.signal instanceof EventTarget).toBe(true);
+    expect(AbortSignal.prototype instanceof EventTarget).toBe(true);
+    expect(Object.getPrototypeOf(AbortSignal.prototype)).toBe(
+      EventTarget.prototype
+    );
+    expect(Object.getPrototypeOf(AbortSignal)).toBe(EventTarget);
+  });
+});

--- a/tests/built-ins/EventTarget/prototype/addEventListener.js
+++ b/tests/built-ins/EventTarget/prototype/addEventListener.js
@@ -1,0 +1,150 @@
+/*---
+description: EventTarget.prototype.addEventListener registration semantics
+features: [EventTarget, Event]
+---*/
+
+describe("EventTarget.prototype.addEventListener", () => {
+  test("invokes the listener for a matching type only", () => {
+    const target = new EventTarget();
+    let calls = 0;
+    target.addEventListener("ping", () => {
+      calls += 1;
+    });
+
+    target.dispatchEvent(new Event("ping"));
+    target.dispatchEvent(new Event("pong"));
+    expect(calls).toBe(1);
+  });
+
+  test("does not add the same type, callback and capture twice", () => {
+    const target = new EventTarget();
+    let calls = 0;
+    const listener = () => {
+      calls += 1;
+    };
+
+    target.addEventListener("ping", listener);
+    target.addEventListener("ping", listener);
+    target.addEventListener("ping", listener, { capture: false });
+    target.dispatchEvent(new Event("ping"));
+    expect(calls).toBe(1);
+  });
+
+  test("treats capture as part of listener identity", () => {
+    const target = new EventTarget();
+    let calls = 0;
+    const listener = () => {
+      calls += 1;
+    };
+
+    target.addEventListener("ping", listener, true);
+    target.addEventListener("ping", listener, false);
+    target.dispatchEvent(new Event("ping"));
+    expect(calls).toBe(2);
+  });
+
+  test("removes a once listener before invoking it", () => {
+    const target = new EventTarget();
+    let calls = 0;
+    target.addEventListener(
+      "ping",
+      () => {
+        calls += 1;
+      },
+      { once: true }
+    );
+
+    target.dispatchEvent(new Event("ping"));
+    target.dispatchEvent(new Event("ping"));
+    expect(calls).toBe(1);
+  });
+
+  test("invokes the listener in registration order", () => {
+    const target = new EventTarget();
+    const order = [];
+    target.addEventListener("ping", () => order.push("first"));
+    target.addEventListener("ping", () => order.push("second"));
+
+    target.dispatchEvent(new Event("ping"));
+    expect(order).toEqual(["first", "second"]);
+  });
+
+  test("does not invoke listeners added during dispatch", () => {
+    const target = new EventTarget();
+    let inner = 0;
+    target.addEventListener("ping", () => {
+      target.addEventListener("ping", () => {
+        inner += 1;
+      });
+    });
+
+    target.dispatchEvent(new Event("ping"));
+    expect(inner).toBe(0);
+  });
+
+  test("invokes a non-callable object listener through handleEvent", () => {
+    const target = new EventTarget();
+    let received = null;
+    const listener = {
+      handleEvent(event) {
+        received = event;
+      },
+    };
+
+    target.addEventListener("ping", listener);
+    const event = new Event("ping");
+    target.dispatchEvent(event);
+    expect(received).toBe(event);
+  });
+
+  test("ignores null and undefined callbacks", () => {
+    const target = new EventTarget();
+    target.addEventListener("ping", null);
+    target.addEventListener("ping", undefined);
+    expect(target.dispatchEvent(new Event("ping"))).toBe(true);
+  });
+
+  test("rejects non-object callbacks and missing arguments", () => {
+    const target = new EventTarget();
+    expect(() => target.addEventListener("ping", 5)).toThrow(TypeError);
+    expect(() => target.addEventListener("ping", "listener")).toThrow(TypeError);
+    expect(() => target.addEventListener("ping")).toThrow(TypeError);
+  });
+
+  test("rejects a symbol type", () => {
+    const target = new EventTarget();
+    expect(() => target.addEventListener(Symbol("ping"), () => {})).toThrow(
+      TypeError
+    );
+  });
+
+  test("keeps many listeners independent across removals", () => {
+    const target = new EventTarget();
+    const listeners = [];
+    let calls = 0;
+
+    Array.from({ length: 200 }).forEach(() => {
+      const listener = () => {
+        calls += 1;
+      };
+      listeners.push(listener);
+      target.addEventListener("many", listener);
+    });
+
+    target.dispatchEvent(new Event("many"));
+    expect(calls).toBe(200);
+
+    listeners.forEach((listener, index) => {
+      if (index % 2 === 0) target.removeEventListener("many", listener);
+    });
+    calls = 0;
+    target.dispatchEvent(new Event("many"));
+    expect(calls).toBe(100);
+  });
+
+  test("rejects incompatible receivers", () => {
+    expect(() =>
+      EventTarget.prototype.addEventListener.call({}, "ping", () => {})
+    ).toThrow(TypeError);
+  });
+});

--- a/tests/built-ins/EventTarget/prototype/addEventListener.js
+++ b/tests/built-ins/EventTarget/prototype/addEventListener.js
@@ -97,6 +97,83 @@ describe("EventTarget.prototype.addEventListener", () => {
     expect(received).toBe(event);
   });
 
+  test("uses the listener object as the handleEvent receiver", () => {
+    const target = new EventTarget();
+    let receiverIsListener = null;
+    const listener = {
+      handleEvent() {
+        receiverIsListener = this === listener;
+      },
+    };
+
+    target.addEventListener("ping", listener);
+    target.dispatchEvent(new Event("ping"));
+    expect(receiverIsListener).toBe(true);
+  });
+
+  test("invokes a listener added during dispatch on the next dispatch", () => {
+    const target = new EventTarget();
+    let inner = 0;
+    let added = false;
+    target.addEventListener("ping", () => {
+      if (added) return;
+      added = true;
+      target.addEventListener("ping", () => {
+        inner += 1;
+      });
+    });
+
+    target.dispatchEvent(new Event("ping"));
+    expect(inner).toBe(0);
+    target.dispatchEvent(new Event("ping"));
+    expect(inner).toBe(1);
+  });
+
+  test("does not invoke a listener removed and re-added during dispatch", () => {
+    const target = new EventTarget();
+    let calls = 0;
+    let mutated = false;
+    const listener = () => {
+      calls += 1;
+    };
+
+    target.addEventListener("ping", () => {
+      if (mutated) return;
+      mutated = true;
+      target.removeEventListener("ping", listener);
+      target.addEventListener("ping", listener);
+    });
+    target.addEventListener("ping", listener);
+
+    // The re-added listener is appended, so it is outside this dispatch.
+    target.dispatchEvent(new Event("ping"));
+    expect(calls).toBe(0);
+    target.dispatchEvent(new Event("ping"));
+    expect(calls).toBe(1);
+  });
+
+  test("reads the options dictionary in capture, once, passive order", () => {
+    const target = new EventTarget();
+    const seen = [];
+    const options = {
+      get capture() {
+        seen.push("capture");
+        return false;
+      },
+      get once() {
+        seen.push("once");
+        return false;
+      },
+      get passive() {
+        seen.push("passive");
+        return false;
+      },
+    };
+
+    target.addEventListener("ping", () => {}, options);
+    expect(seen).toEqual(["capture", "once", "passive"]);
+  });
+
   test("ignores null and undefined callbacks", () => {
     const target = new EventTarget();
     target.addEventListener("ping", null);

--- a/tests/built-ins/EventTarget/prototype/dispatchEvent.js
+++ b/tests/built-ins/EventTarget/prototype/dispatchEvent.js
@@ -1,0 +1,130 @@
+/*---
+description: EventTarget.prototype.dispatchEvent dispatch semantics
+features: [EventTarget, Event, DOMException]
+---*/
+
+describe("EventTarget.prototype.dispatchEvent", () => {
+  test("delivers the same event object to the listener", () => {
+    const target = new EventTarget();
+    let received = null;
+    target.addEventListener("ping", (event) => {
+      received = event;
+    });
+
+    const event = new Event("ping");
+    expect(target.dispatchEvent(event)).toBe(true);
+    expect(received).toBe(event);
+    expect(received.type).toBe("ping");
+  });
+
+  test("sets target for the dispatch and clears currentTarget after it", () => {
+    const target = new EventTarget();
+    let currentDuringDispatch = null;
+    target.addEventListener("ping", (event) => {
+      currentDuringDispatch = event.currentTarget;
+    });
+
+    const event = new Event("ping");
+    expect(event.target).toBe(null);
+    target.dispatchEvent(event);
+    expect(currentDuringDispatch).toBe(target);
+    expect(event.target).toBe(target);
+    expect(event.currentTarget).toBe(null);
+  });
+
+  test("returns false when a cancelable event is canceled", () => {
+    const target = new EventTarget();
+    target.addEventListener("ping", (event) => event.preventDefault());
+
+    expect(target.dispatchEvent(new Event("ping", { cancelable: true }))).toBe(
+      false
+    );
+    expect(target.dispatchEvent(new Event("ping"))).toBe(true);
+  });
+
+  test("returns true when no listener is registered", () => {
+    const target = new EventTarget();
+    expect(target.dispatchEvent(new Event("ping"))).toBe(true);
+  });
+
+  test("throws InvalidStateError while the event is being dispatched", () => {
+    const target = new EventTarget();
+    let thrown = null;
+    target.addEventListener("ping", (event) => {
+      try {
+        target.dispatchEvent(event);
+      } catch (error) {
+        thrown = error;
+      }
+    });
+
+    target.dispatchEvent(new Event("ping"));
+    expect(thrown instanceof DOMException).toBe(true);
+    expect(thrown.name).toBe("InvalidStateError");
+    expect(thrown.code).toBe(11);
+  });
+
+  test("allows the same event object to be dispatched again afterwards", () => {
+    const target = new EventTarget();
+    let calls = 0;
+    target.addEventListener("ping", () => {
+      calls += 1;
+    });
+
+    const event = new Event("ping");
+    target.dispatchEvent(event);
+    target.dispatchEvent(event);
+    expect(calls).toBe(2);
+  });
+
+  test("supports nested dispatch of a different event type", () => {
+    const target = new EventTarget();
+    const order = [];
+    target.addEventListener("outer", () => {
+      order.push("outer");
+      target.dispatchEvent(new Event("inner"));
+      order.push("outer-end");
+    });
+    target.addEventListener("inner", () => order.push("inner"));
+
+    target.dispatchEvent(new Event("outer"));
+    expect(order).toEqual(["outer", "inner", "outer-end"]);
+  });
+
+  // GocciaScript deviation (ADR 0104): WHATWG reports a listener exception to a
+  // global error handler, which this runtime does not have, so it propagates.
+  test("propagates an exception thrown by a listener", () => {
+    const target = new EventTarget();
+    target.addEventListener("boom", () => {
+      throw new RangeError("listener failed");
+    });
+
+    expect(() => target.dispatchEvent(new Event("boom"))).toThrow(RangeError);
+  });
+
+  test("unwinds dispatch state when a listener throws", () => {
+    const target = new EventTarget();
+    target.addEventListener("boom", () => {
+      throw new RangeError("listener failed");
+    });
+
+    const event = new Event("boom");
+    expect(() => target.dispatchEvent(event)).toThrow(RangeError);
+    expect(event.currentTarget).toBe(null);
+    // The dispatch flag was cleared, so the event is still reusable.
+    expect(() => target.dispatchEvent(event)).toThrow(RangeError);
+  });
+
+  test("rejects arguments that are not events", () => {
+    const target = new EventTarget();
+    expect(() => target.dispatchEvent()).toThrow(TypeError);
+    expect(() => target.dispatchEvent({})).toThrow(TypeError);
+    expect(() => target.dispatchEvent("ping")).toThrow(TypeError);
+  });
+
+  test("rejects incompatible receivers", () => {
+    expect(() =>
+      EventTarget.prototype.dispatchEvent.call({}, new Event("ping"))
+    ).toThrow(TypeError);
+  });
+});

--- a/tests/built-ins/EventTarget/prototype/dispatchEvent.js
+++ b/tests/built-ins/EventTarget/prototype/dispatchEvent.js
@@ -93,6 +93,42 @@ describe("EventTarget.prototype.dispatchEvent", () => {
 
   // GocciaScript deviation (ADR 0104): WHATWG reports a listener exception to a
   // global error handler, which this runtime does not have, so it propagates.
+  test("supports nested dispatch of the same event type", () => {
+    const target = new EventTarget();
+    const order = [];
+    let depth = 0;
+    target.addEventListener("ping", () => {
+      depth += 1;
+      order.push("enter" + depth);
+      // A distinct Event object: re-dispatching the in-flight one is an error.
+      if (depth === 1) target.dispatchEvent(new Event("ping"));
+      order.push("exit" + depth);
+      depth -= 1;
+    });
+
+    target.dispatchEvent(new Event("ping"));
+    expect(order).toEqual(["enter1", "enter2", "exit2", "exit1"]);
+  });
+
+  test("still removes a once listener that throws", () => {
+    const target = new EventTarget();
+    let calls = 0;
+    target.addEventListener(
+      "boom",
+      () => {
+        calls += 1;
+        throw new RangeError("listener failed");
+      },
+      { once: true }
+    );
+
+    expect(() => target.dispatchEvent(new Event("boom"))).toThrow(RangeError);
+    expect(calls).toBe(1);
+    // The once listener was removed before it ran, so it is gone despite the throw.
+    target.dispatchEvent(new Event("boom"));
+    expect(calls).toBe(1);
+  });
+
   test("propagates an exception thrown by a listener", () => {
     const target = new EventTarget();
     target.addEventListener("boom", () => {

--- a/tests/built-ins/EventTarget/prototype/removeEventListener.js
+++ b/tests/built-ins/EventTarget/prototype/removeEventListener.js
@@ -1,0 +1,75 @@
+/*---
+description: EventTarget.prototype.removeEventListener removal semantics
+features: [EventTarget, Event]
+---*/
+
+describe("EventTarget.prototype.removeEventListener", () => {
+  test("stops a registered listener from being invoked", () => {
+    const target = new EventTarget();
+    let calls = 0;
+    const listener = () => {
+      calls += 1;
+    };
+
+    target.addEventListener("ping", listener);
+    target.dispatchEvent(new Event("ping"));
+    target.removeEventListener("ping", listener);
+    target.dispatchEvent(new Event("ping"));
+    expect(calls).toBe(1);
+  });
+
+  test("only removes the listener with a matching capture flag", () => {
+    const target = new EventTarget();
+    let calls = 0;
+    const listener = () => {
+      calls += 1;
+    };
+
+    target.addEventListener("ping", listener, true);
+    target.removeEventListener("ping", listener, false);
+    target.dispatchEvent(new Event("ping"));
+    expect(calls).toBe(1);
+
+    target.removeEventListener("ping", listener, true);
+    target.dispatchEvent(new Event("ping"));
+    expect(calls).toBe(1);
+  });
+
+  test("is respected when a listener is removed during dispatch", () => {
+    const target = new EventTarget();
+    let removedCalls = 0;
+    const removed = () => {
+      removedCalls += 1;
+    };
+
+    target.addEventListener("ping", () => {
+      target.removeEventListener("ping", removed);
+    });
+    target.addEventListener("ping", removed);
+
+    target.dispatchEvent(new Event("ping"));
+    expect(removedCalls).toBe(0);
+  });
+
+  test("ignores unknown listeners", () => {
+    const target = new EventTarget();
+    target.removeEventListener("ping", () => {});
+    expect(target.dispatchEvent(new Event("ping"))).toBe(true);
+  });
+
+  test("ignores null and undefined callbacks", () => {
+    const target = new EventTarget();
+    target.removeEventListener("ping", null);
+    target.removeEventListener("ping", undefined);
+    expect(target.dispatchEvent(new Event("ping"))).toBe(true);
+  });
+
+  test("rejects non-object callbacks and incompatible receivers", () => {
+    const target = new EventTarget();
+    expect(() => target.removeEventListener("ping", 5)).toThrow(TypeError);
+    expect(() => target.removeEventListener("ping")).toThrow(TypeError);
+    expect(() =>
+      EventTarget.prototype.removeEventListener.call({}, "ping", () => {})
+    ).toThrow(TypeError);
+  });
+});

--- a/tests/built-ins/fetch/fetch-signal.js
+++ b/tests/built-ins/fetch/fetch-signal.js
@@ -29,6 +29,55 @@ describe("fetch signal option", () => {
     expect(rejected).toBe("cancelled");
   });
 
+  // WHATWG DOM §3.2 signal abort runs the abort algorithms (step 3) before it
+  // fires the "abort" event (step 4). fetch registers its rejection as an abort
+  // algorithm, so controller.abort() must settle the request synchronously
+  // rather than leaving it for the next completion pump. See ADR 0104.
+  test("rejects the request inside abort(), before the abort event", async () => {
+    const controller = new AbortController();
+    const request = fetch("http://0.0.0.0:1/", {
+      signal: controller.signal,
+    });
+    request.catch(() => {});
+
+    controller.abort("cancelled");
+
+    // Race the request itself against a promise resolved afterwards. Racing an
+    // already-settled promise queues its reaction first, so the request wins;
+    // had the rejection waited for the next pump, the request would still be
+    // pending here and "later-microtask" would win. (Adding a `.then` hop to
+    // either arm makes this race non-decisive, so keep it hop-free.)
+    const winner = await Promise.race([
+      request,
+      Promise.resolve("later-microtask"),
+    ]).then(
+      () => "later-microtask",
+      () => "fetch-rejected"
+    );
+
+    expect(winner).toBe("fetch-rejected");
+  });
+
+  test("settles the request before an abort listener observes it", async () => {
+    const controller = new AbortController();
+    const order = [];
+    const request = fetch("http://0.0.0.0:1/", {
+      signal: controller.signal,
+    });
+    request.catch(() => order.push("rejection-reaction"));
+
+    controller.signal.addEventListener("abort", () => {
+      order.push("abort-event");
+    });
+    controller.abort("cancelled");
+
+    await request.catch(() => {});
+    // The abort event runs synchronously inside abort(); the promise reaction
+    // is a microtask, so it necessarily lands afterwards.
+    expect(order[0]).toBe("abort-event");
+    expect(order).toContain("rejection-reaction");
+  });
+
   test("uses TimeoutError for AbortSignal.timeout", async () => {
     let rejected;
     await fetch("http://0.0.0.0:1/", {


### PR DESCRIPTION
## Summary

- Implements WHATWG-shaped `EventTarget` and `Event` as runtime globals (gated with the fetch runtime extension — the core realm stays ECMA-262-only) and makes `AbortSignal` genuinely inherit from `EventTarget`: `addEventListener`/`removeEventListener` with (type, callback, capture) identity, `once`, `onabort`, and abort dispatch in spec order — the signal carries a real abort-algorithms set, so fetch's rejection runs before the abort event fires, exactly once (handover finding F3).
- ADR 0104 records the narrowed supersession of ADR 0031's "no EventTarget events" non-goal (0031 itself unedited; its no-event-loop decision stands) and the documented deviations: listener exceptions propagate (no global reporting channel), no propagation tree, no `timeStamp`/`isTrusted`, no `AbortSignal.any()`; lazily-observed timeout signals dispatch on first observation.
- Dispatch matches WHATWG §2.9 on mutation-during-dispatch, once-remove-before-invoke, re-entrancy (`InvalidStateError`), and unwind-after-throw; GC rooting uses the nest-safe idiom.

Part of the 0.11.0 adversarial-findings stacked-PR train (8 layers, each PR targets the layer below; merge bottom-up). Mini-spec: fix the differential-testing findings F1–F13/G4/G5 — JSX-transformer hang, toThrow semantics, Vitest matcher parity, coverage consistency, TS type-syntax gaps, AbortSignal events — and land the goccia-vs-bun differential battery harness as a CI gate, green at every layer.

## Testing

- [x] End-to-end tests — 100 EventTarget/Event/Abort cases incl. 12 re-entrancy/mutation edges cross-checked against bun (bun's only divergences: swallowed listener exceptions, Node-style recursion error where the spec requires `InvalidStateError` — goccia follows the spec); ordering test proven decisive by disabling the algorithm registration; full suite green both modes
- [x] Updated documentation — ADR 0104, `docs/built-ins-fetch.md`, `docs/built-ins.md`, `docs/language-tables.md`
- [x] Optional: native Pascal tests — n/a beyond existing patterns; new value classes follow the MarkReferences house idiom (review-verified)
- [ ] Optional: benchmarks — n/a

Review: fresh-context review confirmed the dispatch algorithm on every probed edge; its three "fix-first" items (abort-algorithm ordering, dead keep-alive block with a false comment, nest-unsafe temp-root pair) resolved in the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
