### PR TITLE
fix(coverage): imply bytecode mode, sum parallel merges, register declaration lines

### DIFF
--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -132,7 +132,7 @@ Useful test-runner forms:
 
 ### Bytecode Mode
 
-All execution tools support `--mode=bytecode` to compile and run via the Goccia bytecode VM instead of the tree-walk interpreter:
+All execution tools support `--mode=bytecode` to compile and run via the Goccia bytecode VM instead of the tree-walk interpreter. `--profile` (see [Profiling](profiling.md)) and `--coverage` (see [Testing — Coverage](testing.md#coverage)) select bytecode on their own and ignore `--mode`.
 
 ```bash
 # Execute via bytecode VM

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -15,7 +15,7 @@
 
 The `--profile` option on GocciaScriptLoader enables language-level profiling of the bytecode VM. It operates inside the dispatch loop, providing data that external profilers (like `sample` or `callgrind`) cannot see — which opcodes execute, which JS functions are hot, and where the VM allocates.
 
-Profiling implies `--mode=bytecode` automatically. Near-zero overhead when disabled (boolean guard on the dispatch loop, same pattern as `--coverage`). The guard branches are consistently not-taken and well-predicted, but they are present in the compiled binary.
+Profiling implies `--mode=bytecode` automatically, as does `--coverage` (see [Testing — Coverage](testing.md#coverage)). Near-zero overhead when disabled (boolean guard on the dispatch loop, same pattern as `--coverage`). The guard branches are consistently not-taken and well-predicted, but they are present in the compiled binary.
 
 ## CLI Usage
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -743,6 +743,10 @@ The runner clones test262 into a tempdir on first use, or accepts an existing ch
 
 The GocciaTestRunner and GocciaScriptLoader support JavaScript source-level coverage reporting via the `--coverage` flag. Coverage tracks which lines, branches, and functions of JavaScript source code are executed at runtime.
 
+### Coverage implies `--mode=bytecode`
+
+Enabling coverage — via `--coverage`, `--coverage-format`, or `--coverage-output` — switches the engine to bytecode mode automatically, overriding any `--mode` from the command line or a config file, exactly as [`--profile`](profiling.md) does. The implication is silent: `--mode=interpreted --coverage` is not an error, it simply produces the bytecode report, and no flag combination yields an interpreter-mode one. The reason is that the interpreter's coverage path is structurally incomplete and unmaintained — it instruments only the entry file (imported modules run with coverage disabled, so their lines, branches, and functions never appear) and counts a statement hit per executed AST node rather than per executed source line, so its counts are not comparable to bytecode's. Coverage therefore always reports through the bytecode path, over the entry file and every module it imports. The switch is applied in each application's `Validate` (`TTestRunnerApp.Validate`, `TScriptLoaderApp.Validate`), after config-file application and before the tracker is initialized.
+
 ### Usage
 
 ```bash
@@ -761,7 +765,7 @@ The GocciaTestRunner and GocciaScriptLoader support JavaScript source-level cove
 
 ### What is Tracked
 
-**Line coverage:** Which source lines were executed and how many times. Instrumented in both the tree-walk interpreter (`EvaluateStatement`/`EvaluateExpression`) and the bytecode VM (main dispatch loop with line-change deduplication).
+**Line coverage:** Which source lines were executed and how many times. Instrumented in the bytecode VM's main dispatch loop, with per-frame line-change deduplication so several instructions on one source line count as one hit.
 
 **Branch coverage:** Which branch arms were taken at:
 
@@ -770,7 +774,9 @@ The GocciaTestRunner and GocciaScriptLoader support JavaScript source-level cove
 - Short-circuit operators (`&&`, `||`, `??`)
 - `switch` statement case clauses
 
-**Function coverage:** Which user-defined functions were created and called. A function is registered when its definition is evaluated; created-but-uncalled functions are retained with zero hits, and repeated calls increment the function hit count. Definitions inside untaken control flow are not created and therefore do not appear in either execution mode.
+**Function coverage:** Which user-defined functions were created and called. A function is registered when its definition is evaluated and is reported at its declaration line (what LCOV's `FN:` means), not at the first line of its body; created-but-uncalled functions are retained with zero hits, and repeated calls increment the function hit count. Definitions inside untaken control flow are never created and therefore do not appear.
+
+**Parallel runs:** `--jobs=N` does not change any of these numbers. Each worker collects into its own tracker and the counts are added together at the end, so line, branch, and function hit counts for a given run are identical whatever `--jobs` is set to.
 
 ### Output Formats
 
@@ -788,6 +794,6 @@ The source map is registered with `TGocciaCoverageTracker` during file registrat
 
 ### Architecture
 
-Coverage uses a runtime boolean check (`CoverageEnabled` on `TGocciaEvaluationContext` for the interpreter, `FCoverageEnabled` on `TGocciaVM` for bytecode). When `--coverage` is not passed, the boolean is `False` and branch prediction makes the check effectively free — no separate build is needed.
+Coverage uses a runtime boolean check (`FCoverageEnabled` on `TGocciaVM`). When `--coverage` is not passed, the boolean is `False` and branch prediction makes the check effectively free — no separate build is needed.
 
-Data is collected by `TGocciaCoverageTracker` (`Goccia.Coverage.pas`), a per-thread tracker that follows the same Initialize/Shutdown pattern as `TGarbageCollector` and `TGocciaCallStack`. During parallel test runs each worker thread initializes its own thread-local instance; after all workers complete, `TGocciaThreadPool.MergeCoverageInto` merges their data into the main thread's tracker via `TGocciaCoverageTracker.MergeFrom`. Output formatting is in `Goccia.Coverage.Report.pas`. When a JSX source map is available for a file, `BuildTranslatedLineHits` translates transformed line hits back to original coordinates, and branch positions are translated via `TGocciaSourceMap.Translate` during report emission.
+Data is collected by `TGocciaCoverageTracker` (`Goccia.Coverage.pas`), a per-thread tracker that follows the same Initialize/Shutdown pattern as `TGarbageCollector` and `TGocciaCallStack`. During parallel test runs each worker thread initializes its own thread-local instance; after all workers complete, `TGocciaThreadPool.MergeCoverageInto` merges their data into the main thread's tracker via `TGocciaCoverageTracker.MergeFrom`, which adds the source hit *counts* into the destination (via `AddLineHits` / `AddBranchHits`) rather than registering a single hit per covered entry. Output formatting is in `Goccia.Coverage.Report.pas`. When a JSX source map is available for a file, `BuildTranslatedLineHits` translates transformed line hits back to original coordinates, and branch positions are translated via `TGocciaSourceMap.Translate` during report emission.

--- a/scripts/test-cli-apps.ts
+++ b/scripts/test-cli-apps.ts
@@ -2324,7 +2324,7 @@ console.log("Loader: coverage --output=json not corrupted...");
     const jsonCov = readFileSync(jsonCovPath, "utf-8");
     if (!jsonCov.includes('"path":')) throw new Error('JSON coverage should contain "path":');
 
-    console.log("Loader: function coverage (interpreted + bytecode)...");
+    console.log("Loader: function coverage (--coverage implies bytecode, so --mode is a no-op)...");
     const functionSourcePath = join(tmp, "function-coverage.js");
     writeFileSync(
       functionSourcePath,
@@ -2336,7 +2336,7 @@ console.log("Loader: coverage --output=json not corrupted...");
       ].join("\n"),
     );
     for (const modeArgs of [[], ["--mode=bytecode"]]) {
-      const modeName = modeArgs.length === 0 ? "interpreted" : "bytecode";
+      const modeName = modeArgs.length === 0 ? "default" : "explicit-bytecode";
       const functionLcovPath = join(tmp, `function-${modeName}.lcov`);
       await $`${LOADER} ${modeArgs} --coverage --coverage-format=lcov --coverage-output=${functionLcovPath} ${functionSourcePath}`.quiet();
       const functionLcov = readFileSync(functionLcovPath, "utf-8");
@@ -2369,7 +2369,7 @@ console.log("Loader: coverage --output=json not corrupted...");
       throw new Error("JSON f should retain neverCalled with zero hits");
     }
 
-    console.log("Loader: generator function coverage (interpreted + bytecode)...");
+    console.log("Loader: generator function coverage (--mode is a no-op under --coverage)...");
     const generatorSourcePath = join(tmp, "generator-function-coverage.js");
     writeFileSync(
       generatorSourcePath,
@@ -2405,7 +2405,7 @@ console.log("Loader: coverage --output=json not corrupted...");
       ].join("\n"),
     );
     for (const modeArgs of [[], ["--mode=bytecode"]]) {
-      const modeName = modeArgs.length === 0 ? "interpreted" : "bytecode";
+      const modeName = modeArgs.length === 0 ? "default" : "explicit-bytecode";
       const generatorLcovPath = join(tmp, `generator-function-${modeName}.lcov`);
       await $`${LOADER} ${modeArgs} --compat-function --coverage --coverage-format=lcov --coverage-output=${generatorLcovPath} ${generatorSourcePath}`.quiet();
       const generatorLcov = readFileSync(generatorLcovPath, "utf-8");
@@ -2436,7 +2436,7 @@ console.log("Loader: coverage --output=json not corrupted...");
       ].join("\n"),
     );
     for (const modeArgs of [[], ["--mode=bytecode"]]) {
-      const modeName = modeArgs.length === 0 ? "interpreted" : "bytecode";
+      const modeName = modeArgs.length === 0 ? "default" : "explicit-bytecode";
       const declarationLcovPath = join(tmp, `function-declaration-${modeName}.lcov`);
       await $`${LOADER} ${modeArgs} --compat-function --coverage --coverage-format=lcov --coverage-output=${declarationLcovPath} ${declarationSourcePath}`.quiet();
       const declarationLcov = readFileSync(declarationLcovPath, "utf-8");
@@ -2451,15 +2451,17 @@ console.log("Loader: coverage --output=json not corrupted...");
     const escapedFunctionNameSourcePath = join(tmp, "escaped-function-name.js");
     writeFileSync(
       escapedFunctionNameSourcePath,
+      // Static string-literal keys, not computed ones: coverage always runs in
+      // bytecode mode, where a computed method key is not known at compile time
+      // and the function is named "<method>@<line>:<column>". Literal keys carry
+      // the real CR/LF and backslash characters this escaping check needs.
       [
-        'const newlineKey = "line" + String.fromCharCode(13, 10) + "break";',
-        'const literalKey = "line\\\\r\\\\nbreak";',
         "const holder = {",
-        "  [newlineKey]() { return 1; },",
-        "  [literalKey]() { return 2; },",
+        '  "line\\r\\nbreak"() { return 1; },',
+        '  "line\\\\r\\\\nbreak"() { return 2; },',
         "};",
-        "holder[newlineKey]();",
-        "holder[literalKey]();",
+        'holder["line\\r\\nbreak"]();',
+        'holder["line\\\\r\\\\nbreak"]();',
         "",
       ].join("\n"),
     );
@@ -2503,6 +2505,170 @@ console.log("Loader: coverage --output=json not corrupted...");
     await $`echo 'const x = 1 + 2; x;' | ${LOADER} --mode=bytecode --coverage-format=lcov --coverage-output=${bcLcovPath}`.quiet();
     if (!existsSync(bcLcovPath)) throw new Error("Bytecode LCOV should exist");
     if (!readFileSync(bcLcovPath, "utf-8").includes("DA:")) throw new Error("Bytecode LCOV should contain DA:");
+
+    console.log("Loader: coverage implies bytecode and reports imported modules...");
+    const implyDir = join(tmp, "coverage-imply");
+    mkdirSync(implyDir, { recursive: true });
+    const implyHelperPath = join(implyDir, "helper.js");
+    const implyEntryPath = join(implyDir, "entry.js");
+    writeFileSync(
+      implyHelperPath,
+      [
+        "export const classify = (n) => {",
+        "  if (n > 10) {",
+        "    return 'big';",
+        "  }",
+        "  return 'small';",
+        "};",
+        "",
+        "export const unused = (n) => n - 1;",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      implyEntryPath,
+      [
+        "import { classify } from './helper.js';",
+        "",
+        "const labels = [1, 42].map((v) => classify(v));",
+        "globalThis.__labels = labels.join(',');",
+        "",
+      ].join("\n"),
+    );
+    // Normalize to basenames: the entry is keyed by the path as typed while
+    // imported modules are keyed by their resolved absolute path.
+    const readCoverageByBasename = (path: string) => {
+      const raw = JSON.parse(readFileSync(path, "utf-8"));
+      return Object.fromEntries(
+        Object.entries(raw).map(([file, entry]) => [file.split("/").pop(), entry]),
+      ) as Record<string, any>;
+    };
+    const implyReports: Record<string, Record<string, any>> = {};
+    for (const [label, modeArgs] of [
+      ["default", []],
+      ["interpreted", ["--mode=interpreted"]],
+      ["bytecode", ["--mode=bytecode"]],
+    ] as [string, string[]][]) {
+      const implyJsonPath = join(implyDir, `coverage-${label}.json`);
+      await $`${LOADER} ${modeArgs} --coverage --coverage-format=json --coverage-output=${implyJsonPath} ${implyEntryPath}`.quiet();
+      const report = readCoverageByBasename(implyJsonPath);
+      implyReports[label] = report;
+      const helper = report["helper.js"];
+      if (!helper) {
+        throw new Error(`Coverage (${label}) should report the imported module helper.js`);
+      }
+      const helperFunctionNames = Object.values(helper.fnMap)
+        .map((fn: any) => fn.name)
+        .sort();
+      if (!helperFunctionNames.includes("classify") || !helperFunctionNames.includes("unused")) {
+        throw new Error(
+          `Coverage (${label}) should report imported-module functions, got ${helperFunctionNames.join(", ")}`,
+        );
+      }
+      if (Object.keys(helper.branchMap).length === 0) {
+        throw new Error(`Coverage (${label}) should report imported-module branches`);
+      }
+      if (!report["entry.js"]) {
+        throw new Error(`Coverage (${label}) should still report the entry file`);
+      }
+    }
+    // --coverage forces bytecode, so --mode is irrelevant to the report.
+    for (const label of ["default", "interpreted"]) {
+      if (JSON.stringify(implyReports[label]) !== JSON.stringify(implyReports.bytecode)) {
+        throw new Error(`Coverage with --mode=${label} should match the --mode=bytecode report`);
+      }
+    }
+
+    console.log("Loader: coverage reports functions at their declaration line...");
+    // LCOV FN: records where a function is declared. The bytecode VM used to
+    // report the first executed instruction instead, which lands on the body's
+    // first line for any function whose body starts on a later line.
+    const declLinePath = join(tmp, "declaration-line.js");
+    writeFileSync(
+      declLinePath,
+      [
+        "const oneLine = () => 1;",
+        "const multi = (a) => {",
+        "  const b = a + 1;",
+        "  return b;",
+        "};",
+        "oneLine();",
+        "multi(1);",
+        "",
+      ].join("\n"),
+    );
+    const declLineLcovPath = join(tmp, "declaration-line.lcov");
+    await $`${LOADER} --coverage --coverage-format=lcov --coverage-output=${declLineLcovPath} ${declLinePath}`.quiet();
+    const declLineRecords = readFileSync(declLineLcovPath, "utf-8").split(/\r?\n/);
+    for (const expected of ["FN:1,oneLine", "FN:2,multi", "FNDA:1,oneLine", "FNDA:1,multi"]) {
+      if (!declLineRecords.includes(expected)) {
+        throw new Error(
+          `LCOV should report ${expected}, got ${declLineRecords.filter((l) => l.startsWith("FN")).join(" ")}`,
+        );
+      }
+    }
+    // The per-call line hit still belongs to the first executed body line.
+    if (!declLineRecords.includes("DA:3,1")) {
+      throw new Error("Function body's first line should still record a line hit");
+    }
+
+    console.log("TestRunner: coverage hit counts are identical across --jobs...");
+    const jobsDir = join(tmp, "coverage-jobs");
+    mkdirSync(jobsDir, { recursive: true });
+    writeFileSync(
+      join(jobsDir, "shared.js"),
+      [
+        "export const step = (n) => {",
+        "  const doubled = n * 2;",
+        "  return doubled > 4 ? 'high' : 'low';",
+        "};",
+        "",
+      ].join("\n"),
+    );
+    // Asymmetric arm usage: a merge that records one hit per covered entry
+    // instead of summing counts collapses these totals.
+    writeFileSync(
+      join(jobsDir, "a.test.js"),
+      [
+        "import { step } from './shared.js';",
+        'test("a", () => {',
+        "  expect(step(1)).toBe('low');",
+        "  expect(step(2)).toBe('low');",
+        "  expect(step(5)).toBe('high');",
+        "});",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(jobsDir, "b.test.js"),
+      [
+        "import { step } from './shared.js';",
+        'test("b", () => {',
+        "  expect(step(2)).toBe('low');",
+        "  expect(step(9)).toBe('high');",
+        "});",
+        "",
+      ].join("\n"),
+    );
+    const jobsCounts: Record<string, string> = {};
+    for (const jobs of ["1", "2", "4"]) {
+      const jobsJsonPath = join(jobsDir, `coverage-jobs-${jobs}.json`);
+      await $`${TESTRUNNER} ${join(jobsDir, "a.test.js")} ${join(jobsDir, "b.test.js")} --jobs=${jobs} --no-progress --coverage --coverage-format=json --coverage-output=${jobsJsonPath}`.quiet();
+      const shared = readCoverageByBasename(jobsJsonPath)["shared.js"];
+      if (!shared) throw new Error(`--jobs=${jobs} coverage should report the shared module`);
+      jobsCounts[jobs] = JSON.stringify({ s: shared.s, b: shared.b, f: shared.f });
+    }
+    // A statement executed 5 times must report 5, not "2 workers touched it".
+    if (JSON.parse(jobsCounts["1"]).s["2"] !== 5) {
+      throw new Error(`--jobs=1 should count the shared statement 5 times, got ${jobsCounts["1"]}`);
+    }
+    for (const jobs of ["2", "4"]) {
+      if (jobsCounts[jobs] !== jobsCounts["1"]) {
+        throw new Error(
+          `--jobs=${jobs} coverage counts should equal --jobs=1: ${jobsCounts[jobs]} vs ${jobsCounts["1"]}`,
+        );
+      }
+    }
 
     console.log("Loader: branch coverage via TestRunner...");
     const branchLcovPath = join(tmp, "branch.lcov");

--- a/source/app/GocciaScriptLoader.dpr
+++ b/source/app/GocciaScriptLoader.dpr
@@ -360,6 +360,13 @@ begin
   if ProfilerOptions.Mode.Present then
     EngineOptions.Mode.Apply('bytecode');
 
+  // Coverage requires bytecode mode regardless of the --mode option: the
+  // interpreter only instruments the entry file and counts statements per
+  // AST node instead of per executed line.
+  if CoverageOptions.Enabled.Present or CoverageOptions.Format.Present or
+     CoverageOptions.OutputPath.Present then
+    EngineOptions.Mode.Apply('bytecode');
+
   if ProfilerOptions.OutputPath.Present and not ProfilerOptions.Mode.Present then
     raise TParseError.Create(
       '--profile-output requires --profile=opcodes|functions|all.');

--- a/source/app/GocciaTestRunner.dpr
+++ b/source/app/GocciaTestRunner.dpr
@@ -348,8 +348,16 @@ end;
 
 procedure TTestRunnerApp.Validate;
 begin
+  inherited Validate;
+
   if CoverageOptions.Format.Present or CoverageOptions.OutputPath.Present then
     CoverageOptions.Enabled.Apply('');
+
+  // Coverage requires bytecode mode regardless of the --mode option: the
+  // interpreter only instruments the entry file and counts statements per
+  // AST node instead of per executed line.
+  if CoverageOptions.Enabled.Present then
+    EngineOptions.Mode.Apply('bytecode');
 end;
 
 function TTestRunnerApp.IsJsonOutput: Boolean;

--- a/source/units/Goccia.Bytecode.Binary.pas
+++ b/source/units/Goccia.Bytecode.Binary.pas
@@ -488,6 +488,8 @@ begin
   if Assigned(AProto.DebugInfo) then
   begin
     WriteString(AProto.DebugInfo.SourceFile);
+    WriteUInt32(AProto.DebugInfo.DeclarationLine);
+    WriteUInt16(AProto.DebugInfo.DeclarationColumn);
     WriteUInt32(UInt32(AProto.DebugInfo.LineMapCount));
     for I := 0 to AProto.DebugInfo.LineMapCount - 1 do
     begin
@@ -669,6 +671,8 @@ var
   DebugInfo: TGocciaDebugInfo;
   SourceFile, RegExpPattern, RegExpFlags: string;
   LineMapCount, LocalCount: UInt32;
+  DeclarationLine: UInt32;
+  DeclarationColumn: UInt16;
   CookedStrings, RawStrings: TGocciaBytecodeStringArray;
   CookedValid: TGocciaBytecodeTemplateCookedValid;
 begin
@@ -787,7 +791,11 @@ begin
   if HasDebug then
   begin
     SourceFile := ReadString;
-    DebugInfo := TGocciaDebugInfo.Create(SourceFile);
+    RequireRemaining(6, 'debug declaration position');
+    DeclarationLine := ReadUInt32;
+    DeclarationColumn := ReadUInt16;
+    DebugInfo := TGocciaDebugInfo.Create(SourceFile, DeclarationLine,
+      DeclarationColumn);
 
     LineMapCount := ReadUInt32;
     RequireRemaining(Int64(LineMapCount) * 10, 'debug line mappings');

--- a/source/units/Goccia.Bytecode.Debug.pas
+++ b/source/units/Goccia.Bytecode.Debug.pas
@@ -25,8 +25,17 @@ type
     FLineMapCount: Integer;
     FLocals: array of TGocciaLocalInfo;
     FLocalCount: Integer;
+    FDeclarationLine: UInt32;
+    FDeclarationColumn: UInt16;
   public
-    constructor Create(const ASourceFile: string);
+    { ADeclarationLine/ADeclarationColumn locate the function's declaration
+      (`const f = () => {`), which is what LCOV's FN: record means. They are
+      distinct from the first line-map entry, which locates the first executed
+      instruction of the body and drives per-call line hits. Zero means
+      "not recorded" — the module-level template has no declaration site. }
+    constructor Create(const ASourceFile: string;
+      const ADeclarationLine: UInt32 = 0;
+      const ADeclarationColumn: UInt16 = 0);
 
     procedure AddLineMapping(const APC: UInt32; const ALine: UInt32;
       const AColumn: UInt16);
@@ -39,19 +48,53 @@ type
     function GetLineMapEntry(const AIndex: Integer): TGocciaLineMapEntry;
     function GetLocalInfo(const AIndex: Integer): TGocciaLocalInfo;
 
+    { Declaration position, falling back to the first line-map entry when the
+      declaration site was not recorded, so callers always get a usable
+      position. }
+    function CoverageLine: UInt32;
+    function CoverageColumn: UInt16;
+
     property SourceFile: string read FSourceFile;
     property LineMapCount: Integer read FLineMapCount;
     property LocalCount: Integer read FLocalCount;
+    property DeclarationLine: UInt32 read FDeclarationLine
+      write FDeclarationLine;
+    property DeclarationColumn: UInt16 read FDeclarationColumn
+      write FDeclarationColumn;
   end;
 
 implementation
 
-constructor TGocciaDebugInfo.Create(const ASourceFile: string);
+constructor TGocciaDebugInfo.Create(const ASourceFile: string;
+  const ADeclarationLine: UInt32 = 0;
+  const ADeclarationColumn: UInt16 = 0);
 begin
   inherited Create;
   FSourceFile := ASourceFile;
   FLineMapCount := 0;
   FLocalCount := 0;
+  FDeclarationLine := ADeclarationLine;
+  FDeclarationColumn := ADeclarationColumn;
+end;
+
+function TGocciaDebugInfo.CoverageLine: UInt32;
+begin
+  if FDeclarationLine > 0 then
+    Result := FDeclarationLine
+  else if FLineMapCount > 0 then
+    Result := FLineMap[0].Line
+  else
+    Result := 0;
+end;
+
+function TGocciaDebugInfo.CoverageColumn: UInt16;
+begin
+  if FDeclarationLine > 0 then
+    Result := FDeclarationColumn
+  else if FLineMapCount > 0 then
+    Result := FLineMap[0].Column
+  else
+    Result := 0;
 end;
 
 procedure TGocciaDebugInfo.AddLineMapping(const APC: UInt32;

--- a/source/units/Goccia.Bytecode.pas
+++ b/source/units/Goccia.Bytecode.pas
@@ -166,7 +166,10 @@ const
   //   v75 -> v76: added the VALIDATE_OP_REQUIRE_OBJECT_FOR_MEMBER validation
   //               mode, which rejects a nullish computed-member base before the
   //               key is coerced and carries the key register in operand C.
-  GOCCIA_FORMAT_VERSION = 76;
+  //   v76 -> v77: debug info carries each function's declaration line and
+  //               column, so coverage reports a function at the line it is
+  //               declared on rather than at its first executed instruction.
+  GOCCIA_FORMAT_VERSION = 77;
   GOCCIA_BINARY_MAGIC: array[0..3] of Byte = (Ord('G'), Ord('B'), Ord('C'), 0);
   GOCCIA_NULLISH_MATCH_UNDEFINED = 0;
   GOCCIA_NULLISH_MATCH_NULL = 1;

--- a/source/units/Goccia.Compiler.Expressions.pas
+++ b/source/units/Goccia.Compiler.Expressions.pas
@@ -3683,7 +3683,8 @@ begin
   OldDerivedGuard := ACtx.DerivedConstructorThisGuard;
 
   ChildTemplate := TGocciaFunctionTemplate.Create('<arrow>');
-  ChildTemplate.DebugInfo := TGocciaDebugInfo.Create(ACtx.SourcePath);
+  ChildTemplate.DebugInfo := TGocciaDebugInfo.Create(ACtx.SourcePath,
+    UInt32(AExpr.Line), UInt16(AExpr.Column));
   ChildTemplate.IsAsync := AExpr.IsAsync;
   ChildTemplate.IsArrow := True;
   ChildTemplate.StrictCode := ChildBodyIsStrictCode(ACtx, AExpr.Body);
@@ -4893,7 +4894,8 @@ begin
   OldScope := ACtx.Scope;
 
   ChildTemplate := TGocciaFunctionTemplate.Create('get ' + AKey);
-  ChildTemplate.DebugInfo := TGocciaDebugInfo.Create(ACtx.SourcePath);
+  ChildTemplate.DebugInfo := TGocciaDebugInfo.Create(ACtx.SourcePath,
+    UInt32(AGetter.Line), UInt16(AGetter.Column));
   ChildTemplate.StrictCode := ChildBodyIsStrictCode(ACtx, AGetter.Body);
   ChildTemplate.StrictThis := ChildTemplate.StrictCode;
   ChildTemplate.SourceText := AGetter.SourceText;
@@ -4960,7 +4962,8 @@ begin
   OldScope := ACtx.Scope;
 
   ChildTemplate := TGocciaFunctionTemplate.Create('set ' + AKey);
-  ChildTemplate.DebugInfo := TGocciaDebugInfo.Create(ACtx.SourcePath);
+  ChildTemplate.DebugInfo := TGocciaDebugInfo.Create(ACtx.SourcePath,
+    UInt32(ASetter.Line), UInt16(ASetter.Column));
   ChildTemplate.StrictCode := ChildBodyIsStrictCode(ACtx, ASetter.Body);
   ChildTemplate.StrictThis := ChildTemplate.StrictCode;
   ChildTemplate.SourceText := ASetter.SourceText;
@@ -5049,7 +5052,8 @@ begin
   OldScope := ACtx.Scope;
 
   ChildTemplate := TGocciaFunctionTemplate.Create('get [computed]');
-  ChildTemplate.DebugInfo := TGocciaDebugInfo.Create(ACtx.SourcePath);
+  ChildTemplate.DebugInfo := TGocciaDebugInfo.Create(ACtx.SourcePath,
+    UInt32(AGetter.Line), UInt16(AGetter.Column));
   ChildTemplate.StrictCode := ChildBodyIsStrictCode(ACtx, AGetter.Body);
   ChildTemplate.StrictThis := ChildTemplate.StrictCode;
   ChildTemplate.SourceText := AGetter.SourceText;
@@ -5119,7 +5123,8 @@ begin
   OldScope := ACtx.Scope;
 
   ChildTemplate := TGocciaFunctionTemplate.Create('set [computed]');
-  ChildTemplate.DebugInfo := TGocciaDebugInfo.Create(ACtx.SourcePath);
+  ChildTemplate.DebugInfo := TGocciaDebugInfo.Create(ACtx.SourcePath,
+    UInt32(ASetter.Line), UInt16(ASetter.Column));
   ChildTemplate.StrictCode := ChildBodyIsStrictCode(ACtx, ASetter.Body);
   ChildTemplate.StrictThis := ChildTemplate.StrictCode;
   ChildTemplate.SourceText := ASetter.SourceText;
@@ -5785,7 +5790,8 @@ begin
   end;
 
   ChildTemplate := TGocciaFunctionTemplate.Create(ATemplateName);
-  ChildTemplate.DebugInfo := TGocciaDebugInfo.Create(ACtx.SourcePath);
+  ChildTemplate.DebugInfo := TGocciaDebugInfo.Create(ACtx.SourcePath,
+    UInt32(AExpr.Line), UInt16(AExpr.Column));
   ChildTemplate.IsAsync := AExpr.IsAsync;
   ChildTemplate.IsGenerator := AExpr.IsGenerator;
   ChildTemplate.HasOwnPrototype := AExpr.HasOwnPrototype;

--- a/source/units/Goccia.Compiler.Statements.pas
+++ b/source/units/Goccia.Compiler.Statements.pas
@@ -4919,7 +4919,8 @@ begin
   DisplayName := DisplayClassElementName(AMethodName);
 
   ChildTemplate := TGocciaFunctionTemplate.Create(DisplayName);
-  ChildTemplate.DebugInfo := TGocciaDebugInfo.Create(ACtx.SourcePath);
+  ChildTemplate.DebugInfo := TGocciaDebugInfo.Create(ACtx.SourcePath,
+    UInt32(AMethod.Line), UInt16(AMethod.Column));
   ChildTemplate.IsAsync := AMethod.IsAsync;
   ChildTemplate.IsGenerator := AMethod.IsGenerator;
   ChildTemplate.HasOwnPrototype := AMethod.IsGenerator;
@@ -5041,7 +5042,8 @@ begin
   DisplayName := DisplayClassElementName(AName);
 
   ChildTemplate := TGocciaFunctionTemplate.Create('get ' + DisplayName);
-  ChildTemplate.DebugInfo := TGocciaDebugInfo.Create(ACtx.SourcePath);
+  ChildTemplate.DebugInfo := TGocciaDebugInfo.Create(ACtx.SourcePath,
+    UInt32(AGetter.Line), UInt16(AGetter.Column));
   ChildTemplate.SourceText := AGetter.SourceText;
   ChildTemplate.ParameterCount := 0;
   ChildScope := TGocciaCompilerScope.Create(OldScope, 0);
@@ -5114,7 +5116,8 @@ begin
   DisplayName := DisplayClassElementName(AName);
 
   ChildTemplate := TGocciaFunctionTemplate.Create('set ' + DisplayName);
-  ChildTemplate.DebugInfo := TGocciaDebugInfo.Create(ACtx.SourcePath);
+  ChildTemplate.DebugInfo := TGocciaDebugInfo.Create(ACtx.SourcePath,
+    UInt32(ASetter.Line), UInt16(ASetter.Column));
   ChildTemplate.SourceText := ASetter.SourceText;
   SetterParams := ASetter.Parameters;
   if Length(SetterParams) = 0 then
@@ -5209,7 +5212,8 @@ begin
   OldScope := ACtx.Scope;
 
   ChildTemplate := TGocciaFunctionTemplate.Create('<get [computed]>');
-  ChildTemplate.DebugInfo := TGocciaDebugInfo.Create(ACtx.SourcePath);
+  ChildTemplate.DebugInfo := TGocciaDebugInfo.Create(ACtx.SourcePath,
+    UInt32(AGetter.Line), UInt16(AGetter.Column));
   // Propagate the accessor source so DeclareArgumentsObjectLocal below can elide
   // the arguments object when the body never references it, matching the other
   // (non-computed) accessor and method body builders.
@@ -5283,7 +5287,8 @@ begin
   OldScope := ACtx.Scope;
 
   ChildTemplate := TGocciaFunctionTemplate.Create('<set [computed]>');
-  ChildTemplate.DebugInfo := TGocciaDebugInfo.Create(ACtx.SourcePath);
+  ChildTemplate.DebugInfo := TGocciaDebugInfo.Create(ACtx.SourcePath,
+    UInt32(ASetter.Line), UInt16(ASetter.Column));
   // Propagate the accessor source so DeclareArgumentsObjectLocal below can elide
   // the arguments object when the body never references it, matching the other
   // (non-computed) accessor and method body builders.
@@ -5381,7 +5386,8 @@ begin
   OldScope := ACtx.Scope;
 
   ChildTemplate := TGocciaFunctionTemplate.Create('<method [computed]>');
-  ChildTemplate.DebugInfo := TGocciaDebugInfo.Create(ACtx.SourcePath);
+  ChildTemplate.DebugInfo := TGocciaDebugInfo.Create(ACtx.SourcePath,
+    UInt32(AMethod.Line), UInt16(AMethod.Column));
   ChildTemplate.IsAsync := AMethod.IsAsync;
   ChildTemplate.IsGenerator := AMethod.IsGenerator;
   ChildTemplate.HasOwnPrototype := AMethod.IsGenerator;

--- a/source/units/Goccia.Compiler.Test.pas
+++ b/source/units/Goccia.Compiler.Test.pas
@@ -80,6 +80,7 @@ type
     procedure TestBinaryRoundTrip;
     procedure TestBinaryRoundTripClosedNumericSelfCall;
     procedure TestBinaryRoundTripUpvalueNames;
+    procedure TestBinaryRoundTripFunctionDeclarationPosition;
     procedure TestBinaryLittleEndian;
     procedure TestBinaryRoundTripConstants;
     procedure TestBinaryRejectsMalformedArtifacts;
@@ -143,6 +144,8 @@ begin
   Test('Binary round-trip closed numeric self-call',
     TestBinaryRoundTripClosedNumericSelfCall);
   Test('Binary round-trip upvalue names', TestBinaryRoundTripUpvalueNames);
+  Test('Binary round-trip function declaration position',
+    TestBinaryRoundTripFunctionDeclarationPosition);
   Test('Binary little-endian format', TestBinaryLittleEndian);
   Test('Binary round-trip constants', TestBinaryRoundTripConstants);
   Test('Binary loader rejects malformed artifacts',
@@ -716,6 +719,71 @@ begin
       Expect<Integer>(LoadedFunc.UpvalueCount).ToBe(1);
       LoadedDesc := LoadedFunc.GetUpvalueDescriptor(0);
       Expect<string>(LoadedDesc.Name).ToBe(OriginalDesc.Name);
+    finally
+      Loaded.Free;
+    end;
+  finally
+    Original.Free;
+    DeleteFile(TempFile);
+  end;
+end;
+
+{ Coverage reports a function at its declaration site (LCOV FN:), which is a
+  different position from the first executed instruction of its body. The
+  declaration position must therefore be carried on the template and survive a
+  .gbc round-trip, so precompiled bytecode reports the same lines as source. }
+function FindTemplateByDeclarationLine(
+  const AParent: TGocciaFunctionTemplate;
+  const ALine: UInt32): TGocciaFunctionTemplate;
+var
+  I: Integer;
+begin
+  Result := nil;
+  for I := 0 to AParent.FunctionCount - 1 do
+    if Assigned(AParent.GetFunction(I).DebugInfo) and
+       (AParent.GetFunction(I).DebugInfo.DeclarationLine = ALine) then
+    begin
+      Result := AParent.GetFunction(I);
+      Exit;
+    end;
+end;
+
+procedure TTestCompiler.TestBinaryRoundTripFunctionDeclarationPosition;
+var
+  Original, Loaded: TGocciaBytecodeModule;
+  OriginalFunc, LoadedFunc: TGocciaFunctionTemplate;
+  TempFile: string;
+begin
+  // `multi` is declared on line 2; its body's first statement is on line 3.
+  Original := CompileSource(
+    'const oneLine = () => 1;'#10 +
+    'const multi = (a) => {'#10 +
+    '  const b = a + 1;'#10 +
+    '  return b;'#10 +
+    '};'#10,
+    False, False, False, False, False, False);
+  TempFile := GetTempFileName + '.gbc';
+  try
+    Expect<Integer>(Original.TopLevel.FunctionCount).ToBe(2);
+    Expect<Boolean>(Assigned(
+      FindTemplateByDeclarationLine(Original.TopLevel, 1))).ToBe(True);
+
+    OriginalFunc := FindTemplateByDeclarationLine(Original.TopLevel, 2);
+    Expect<Boolean>(Assigned(OriginalFunc)).ToBe(True);
+    // The body's first instruction is on a later line than the declaration,
+    // so the two positions cannot be conflated.
+    Expect<Integer>(
+      Integer(OriginalFunc.DebugInfo.GetLineMapEntry(0).Line)).ToBe(3);
+    Expect<Integer>(Integer(OriginalFunc.DebugInfo.CoverageLine)).ToBe(2);
+
+    SaveModuleToFile(Original, TempFile);
+    Loaded := LoadModuleFromFile(TempFile);
+    try
+      LoadedFunc := FindTemplateByDeclarationLine(Loaded.TopLevel, 2);
+      Expect<Boolean>(Assigned(LoadedFunc)).ToBe(True);
+      Expect<Integer>(Integer(LoadedFunc.DebugInfo.DeclarationColumn)).ToBe(
+        Integer(OriginalFunc.DebugInfo.DeclarationColumn));
+      Expect<Integer>(Integer(LoadedFunc.DebugInfo.CoverageLine)).ToBe(2);
     finally
       Loaded.Free;
     end;

--- a/source/units/Goccia.Coverage.Test.pas
+++ b/source/units/Goccia.Coverage.Test.pas
@@ -1,0 +1,224 @@
+program Goccia.Coverage.Test;
+
+{$I Goccia.inc}
+
+uses
+  SysUtils,
+
+  TestingPascalLibrary,
+
+  Goccia.Coverage,
+  Goccia.TestSetup;
+
+type
+  TTestCoverage = class(TTestSuite)
+  private
+    function MakeWorker(const AFilePath: string;
+      const AExecutableLines: Integer): TGocciaCoverageTracker;
+  public
+    procedure SetupTests; override;
+
+    procedure TestMergeSumsLineHitCounts;
+    procedure TestMergeSumsBranchHitCounts;
+    procedure TestMergeSumsFunctionHitCounts;
+    procedure TestMergeRetainsZeroHitBranchesAndFunctions;
+    procedure TestMergeAdoptsUnknownFilesAndExecutableLines;
+  end;
+
+const
+  WORKER_FILE = 'shared.js';
+
+procedure TTestCoverage.SetupTests;
+begin
+  Test('MergeFrom sums line hit counts', TestMergeSumsLineHitCounts);
+  Test('MergeFrom sums branch hit counts', TestMergeSumsBranchHitCounts);
+  Test('MergeFrom sums function hit counts', TestMergeSumsFunctionHitCounts);
+  Test('MergeFrom retains zero-hit branches and functions',
+    TestMergeRetainsZeroHitBranchesAndFunctions);
+  Test('MergeFrom adopts unknown files and executable line counts',
+    TestMergeAdoptsUnknownFilesAndExecutableLines);
+end;
+
+function TTestCoverage.MakeWorker(const AFilePath: string;
+  const AExecutableLines: Integer): TGocciaCoverageTracker;
+begin
+  Result := TGocciaCoverageTracker.Create;
+  Result.RegisterSourceFile(AFilePath, AExecutableLines);
+end;
+
+{ Each worker records the same line several times. A merge that records one
+  hit per covered line collapses the totals to "number of workers that touched
+  the line", which is the parallel-run regression this guards. }
+procedure TTestCoverage.TestMergeSumsLineHitCounts;
+var
+  Main, WorkerOne, WorkerTwo: TGocciaCoverageTracker;
+  Merged: TGocciaFileCoverage;
+  I: Integer;
+begin
+  Main := MakeWorker(WORKER_FILE, 10);
+  try
+    WorkerOne := MakeWorker(WORKER_FILE, 10);
+    try
+      WorkerTwo := MakeWorker(WORKER_FILE, 10);
+      try
+        for I := 1 to 4 do
+          WorkerOne.GetFileCoverage(WORKER_FILE).RecordLineHit(3);
+        for I := 1 to 7 do
+          WorkerTwo.GetFileCoverage(WORKER_FILE).RecordLineHit(3);
+        WorkerTwo.GetFileCoverage(WORKER_FILE).RecordLineHit(9);
+
+        Main.MergeFrom(WorkerOne);
+        Main.MergeFrom(WorkerTwo);
+
+        Merged := Main.GetFileCoverage(WORKER_FILE);
+        Expect<Integer>(Merged.GetLineHitCount(3)).ToBe(11);
+        Expect<Integer>(Merged.GetLineHitCount(9)).ToBe(1);
+        Expect<Integer>(Merged.GetLineHitCount(4)).ToBe(0);
+        Expect<Integer>(Merged.LinesHit).ToBe(2);
+      finally
+        WorkerTwo.Free;
+      end;
+    finally
+      WorkerOne.Free;
+    end;
+  finally
+    Main.Free;
+  end;
+end;
+
+procedure TTestCoverage.TestMergeSumsBranchHitCounts;
+var
+  Main, WorkerOne, WorkerTwo: TGocciaCoverageTracker;
+  Merged: TGocciaFileCoverage;
+  I: Integer;
+begin
+  Main := MakeWorker(WORKER_FILE, 10);
+  try
+    WorkerOne := MakeWorker(WORKER_FILE, 10);
+    try
+      WorkerTwo := MakeWorker(WORKER_FILE, 10);
+      try
+        for I := 1 to 3 do
+          WorkerOne.RecordBranchHit(WORKER_FILE, 2, 5, 0);
+        WorkerOne.RecordBranchHit(WORKER_FILE, 2, 5, 1);
+        for I := 1 to 2 do
+          WorkerTwo.RecordBranchHit(WORKER_FILE, 2, 5, 0);
+
+        Main.MergeFrom(WorkerOne);
+        Main.MergeFrom(WorkerTwo);
+
+        Merged := Main.GetFileCoverage(WORKER_FILE);
+        Expect<Integer>(Merged.BranchesFound).ToBe(2);
+        Expect<Integer>(Merged.BranchesHit).ToBe(2);
+        for I := 0 to Merged.Branches.Count - 1 do
+          if Merged.Branches[I].BranchIndex = 0 then
+            Expect<Integer>(Merged.Branches[I].HitCount).ToBe(5)
+          else
+            Expect<Integer>(Merged.Branches[I].HitCount).ToBe(1);
+      finally
+        WorkerTwo.Free;
+      end;
+    finally
+      WorkerOne.Free;
+    end;
+  finally
+    Main.Free;
+  end;
+end;
+
+procedure TTestCoverage.TestMergeSumsFunctionHitCounts;
+var
+  Main, WorkerOne, WorkerTwo: TGocciaCoverageTracker;
+  Merged: TGocciaFileCoverage;
+  I: Integer;
+begin
+  Main := MakeWorker(WORKER_FILE, 10);
+  try
+    WorkerOne := MakeWorker(WORKER_FILE, 10);
+    try
+      WorkerTwo := MakeWorker(WORKER_FILE, 10);
+      try
+        for I := 1 to 3 do
+          WorkerOne.RecordFunctionHit(WORKER_FILE, 'step', 1, 0);
+        for I := 1 to 4 do
+          WorkerTwo.RecordFunctionHit(WORKER_FILE, 'step', 1, 0);
+
+        Main.MergeFrom(WorkerOne);
+        Main.MergeFrom(WorkerTwo);
+
+        Merged := Main.GetFileCoverage(WORKER_FILE);
+        Expect<Integer>(Merged.FunctionsFound).ToBe(1);
+        Expect<Integer>(Merged.FunctionsHit).ToBe(1);
+        Expect<Integer>(Merged.Functions[0].HitCount).ToBe(7);
+      finally
+        WorkerTwo.Free;
+      end;
+    finally
+      WorkerOne.Free;
+    end;
+  finally
+    Main.Free;
+  end;
+end;
+
+{ Uncalled functions and untaken branch arms must survive the merge with zero
+  hits so the report keeps its shape. }
+procedure TTestCoverage.TestMergeRetainsZeroHitBranchesAndFunctions;
+var
+  Main, Worker: TGocciaCoverageTracker;
+  Merged: TGocciaFileCoverage;
+begin
+  Main := MakeWorker(WORKER_FILE, 10);
+  try
+    Worker := MakeWorker(WORKER_FILE, 10);
+    try
+      Worker.RegisterFunction(WORKER_FILE, 'neverCalled', 4, 0);
+      Worker.RecordBranchHit(WORKER_FILE, 2, 5, 0);
+
+      Main.MergeFrom(Worker);
+
+      Merged := Main.GetFileCoverage(WORKER_FILE);
+      Expect<Integer>(Merged.FunctionsFound).ToBe(1);
+      Expect<Integer>(Merged.FunctionsHit).ToBe(0);
+      Expect<Integer>(Merged.BranchesFound).ToBe(2);
+      Expect<Integer>(Merged.BranchesHit).ToBe(1);
+    finally
+      Worker.Free;
+    end;
+  finally
+    Main.Free;
+  end;
+end;
+
+procedure TTestCoverage.TestMergeAdoptsUnknownFilesAndExecutableLines;
+var
+  Main, Worker: TGocciaCoverageTracker;
+  Merged: TGocciaFileCoverage;
+begin
+  Main := TGocciaCoverageTracker.Create;
+  try
+    Worker := MakeWorker('imported.js', 12);
+    try
+      Worker.GetFileCoverage('imported.js').RecordLineHit(2);
+      Worker.GetFileCoverage('imported.js').RecordLineHit(2);
+
+      Main.MergeFrom(Worker);
+
+      Merged := Main.GetFileCoverage('imported.js');
+      Expect<Boolean>(Merged <> nil).ToBe(True);
+      Expect<Integer>(Merged.ExecutableLines).ToBe(12);
+      Expect<Integer>(Merged.GetLineHitCount(2)).ToBe(2);
+    finally
+      Worker.Free;
+    end;
+  finally
+    Main.Free;
+  end;
+end;
+
+begin
+  TestRunnerProgram.AddSuite(TTestCoverage.Create('Coverage'));
+  RunGocciaTests;
+
+  ExitCode := TestResultToExitCode;
+end.

--- a/source/units/Goccia.Coverage.pas
+++ b/source/units/Goccia.Coverage.pas
@@ -48,8 +48,11 @@ type
     constructor Create(const AFileName: string; const AExecutableLines: Integer);
     destructor Destroy; override;
 
+    procedure AddLineHits(const ALine, ACount: Integer); {$IFDEF FPC}inline;{$ENDIF}
     procedure RecordLineHit(const ALine: Integer); {$IFDEF FPC}inline;{$ENDIF}
     procedure RecordBranchHit(const ALine, AColumn, ABranchIndex: Integer);
+    procedure AddBranchHits(const ALine, AColumn, ABranchIndex,
+      ACount: Integer);
     procedure EnsureBranchExists(const ALine, AColumn, ABranchIndex: Integer);
     procedure RegisterFunction(const AName: string;
       const ALine, AColumn: Integer);
@@ -108,8 +111,10 @@ type
     function GetSourceMap(const AFilePath: string): TGocciaSourceMap;
 
     { Merge all coverage data from ASource into this tracker.
-      Line, branch, and function hits are summed. Files present in ASource
-      but not in this tracker are created with 0 executable lines. }
+      Line, branch, and function hit *counts* are added together, so merging
+      N workers yields the same totals a single-threaded run would produce.
+      Files present in ASource but not in this tracker are created with
+      0 executable lines. }
     procedure MergeFrom(const ASource: TGocciaCoverageTracker);
 
     property Files: TGocciaCoverageFileMap read FFiles;
@@ -376,11 +381,11 @@ begin
     end;
 end;
 
-procedure TGocciaFileCoverage.RecordLineHit(const ALine: Integer);
+procedure TGocciaFileCoverage.AddLineHits(const ALine, ACount: Integer);
 var
   NewLength, I: Integer;
 begin
-  if ALine <= 0 then Exit;
+  if (ALine <= 0) or (ACount <= 0) then Exit;
   if ALine >= Length(FLineHits) then
   begin
     NewLength := Length(FLineHits);
@@ -396,21 +401,38 @@ begin
       Inc(I);
     end;
   end;
-  Inc(FLineHits[ALine]);
+  Inc(FLineHits[ALine], ACount);
+end;
+
+procedure TGocciaFileCoverage.RecordLineHit(const ALine: Integer);
+begin
+  AddLineHits(ALine, 1);
 end;
 
 procedure TGocciaFileCoverage.RecordBranchHit(const ALine, AColumn,
   ABranchIndex: Integer);
+begin
+  AddBranchHits(ALine, AColumn, ABranchIndex, 1);
+end;
+
+procedure TGocciaFileCoverage.AddBranchHits(const ALine, AColumn,
+  ABranchIndex, ACount: Integer);
 var
   I: Integer;
   Branch: TGocciaCoverageBranch;
 begin
+  if ACount <= 0 then
+  begin
+    EnsureBranchExists(ALine, AColumn, ABranchIndex);
+    Exit;
+  end;
+
   for I := 0 to FBranches.Count - 1 do
     if (FBranches[I].Line = ALine) and (FBranches[I].Column = AColumn) and
        (FBranches[I].BranchIndex = ABranchIndex) then
     begin
       Branch := FBranches[I];
-      Inc(Branch.HitCount);
+      Inc(Branch.HitCount, ACount);
       FBranches[I] := Branch;
       // Ensure the opposite arm exists for binary branches (if/ternary/short-circuit)
       if ABranchIndex <= 1 then
@@ -421,7 +443,7 @@ begin
   Branch.Line := ALine;
   Branch.Column := AColumn;
   Branch.BranchIndex := ABranchIndex;
-  Branch.HitCount := 1;
+  Branch.HitCount := ACount;
   FBranches.Add(Branch);
 
   // Ensure the opposite arm exists for binary branches
@@ -650,19 +672,17 @@ begin
     if (DstFile.ExecutableLines = 0) and (SrcFile.ExecutableLines > 0) then
       DstFile.FExecutableLines := SrcFile.ExecutableLines;
 
-    { Merge line hits — sum counts for each line. }
+    { Merge line hits — sum the source counts, not one hit per covered line. }
     for I := 1 to SrcFile.LineHitCount - 1 do
-      if SrcFile.GetLineHitCount(I) > 0 then
-        DstFile.RecordLineHit(I);
+      DstFile.AddLineHits(I, SrcFile.GetLineHitCount(I));
 
-    { Merge branch hits. }
+    { Merge branch hits — sum the source counts; zero-hit arms are still
+      registered so the branch map keeps its shape. }
     for I := 0 to SrcFile.Branches.Count - 1 do
     begin
       Branch := SrcFile.Branches[I];
-      if Branch.HitCount > 0 then
-        DstFile.RecordBranchHit(Branch.Line, Branch.Column, Branch.BranchIndex)
-      else
-        DstFile.EnsureBranchExists(Branch.Line, Branch.Column, Branch.BranchIndex);
+      DstFile.AddBranchHits(Branch.Line, Branch.Column, Branch.BranchIndex,
+        Branch.HitCount);
     end;
 
     { Merge function definitions and hit counts by source position. }

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -5536,8 +5536,8 @@ begin
     Template.DebugInfo.GetLineMapEntry(0).Line);
   TGocciaCoverageTracker.Instance.RecordFunctionHit(
     Template.DebugInfo.SourceFile, Template.Name,
-    Template.DebugInfo.GetLineMapEntry(0).Line,
-    Template.DebugInfo.GetLineMapEntry(0).Column);
+    Template.DebugInfo.CoverageLine,
+    Template.DebugInfo.CoverageColumn);
 end;
 
 function TGocciaBytecodeFunctionValue.GetSourceText: string;
@@ -13116,8 +13116,8 @@ begin
     if ATemplate.Name <> '<module>' then
       TGocciaCoverageTracker.Instance.RecordFunctionHit(
         ATemplate.DebugInfo.SourceFile, ATemplate.Name,
-        ATemplate.DebugInfo.GetLineMapEntry(0).Line,
-        ATemplate.DebugInfo.GetLineMapEntry(0).Column);
+        ATemplate.DebugInfo.CoverageLine,
+        ATemplate.DebugInfo.CoverageColumn);
   end;
 
   if FProfilingFunctions and (TGocciaProfiler.Instance <> nil) then
@@ -13312,8 +13312,8 @@ begin
     if ATemplate.Name <> '<module>' then
       TGocciaCoverageTracker.Instance.RecordFunctionHit(
         ATemplate.DebugInfo.SourceFile, ATemplate.Name,
-        ATemplate.DebugInfo.GetLineMapEntry(0).Line,
-        ATemplate.DebugInfo.GetLineMapEntry(0).Column);
+        ATemplate.DebugInfo.CoverageLine,
+        ATemplate.DebugInfo.CoverageColumn);
   end;
 
   if FProfilingFunctions and (TGocciaProfiler.Instance <> nil) then
@@ -15715,8 +15715,8 @@ begin
            (ChildTemplate.DebugInfo.LineMapCount > 0) then
           TGocciaCoverageTracker.Instance.RegisterFunction(
             ChildTemplate.DebugInfo.SourceFile, ChildTemplate.Name,
-            ChildTemplate.DebugInfo.GetLineMapEntry(0).Line,
-            ChildTemplate.DebugInfo.GetLineMapEntry(0).Column);
+            ChildTemplate.DebugInfo.CoverageLine,
+            ChildTemplate.DebugInfo.CoverageColumn);
         ChildClosure := TGocciaBytecodeClosure.Create(
           ChildTemplate, ChildTemplate.UpvalueCount);
         ChildClosure.GlobalScope := FGlobalScope;


### PR DESCRIPTION
## Summary

- `--coverage` now implies `--mode=bytecode` in both apps (same mechanism as profiling): the interpreter's coverage path omitted imported modules entirely, recorded branch data for only six source constructs, and counted statements under a different rule than the VM (handover finding F4). Reports are now identical regardless of the requested mode.
- Fixes the `--jobs` parallel merge, which didn't sum line/branch hit counts (they degraded to worker-touch counts while the doc comment claimed summing); `--jobs=1/2/4` now produce identical reports.
- Function templates carry their declaration position through compilation and `.gbc` serialization (format v76→v77) so LCOV `FN:` records point at declaration lines per LCOV semantics — the pre-existing `FN:2,Greet` assertion passes unmodified; per-call line hits stay on the first executed instruction.
- Follow-ups (deliberately not in this PR): coverage path-key normalization for entry+import files (changes emitted report paths for Codecov consumers — needs its own decision); the now-redundant `--mode=bytecode` coverage matrix leg in pr.yml.

Part of the 0.11.0 adversarial-findings stacked-PR train (8 layers, each PR targets the layer below; merge bottom-up). Mini-spec: fix the differential-testing findings F1–F13/G4/G5 — JSX-transformer hang, toThrow semantics, Vitest matcher parity, coverage consistency, TS type-syntax gaps, AbortSignal events — and land the goccia-vs-bun differential battery harness as a CI gate, green at every layer.

## Testing

- [x] End-to-end tests — CLI tests assert imported modules appear with function+branch data with no `--mode`, default/interpreted/bytecode reports byte-identical, `--jobs=1/2/4` counts equal, declaration-line `FN:` with body-line hits; full suite green both modes
- [x] Updated documentation — `docs/testing.md` coverage section rewritten (drops stale mode-parity claims), `docs/build-system.md`/`docs/profiling.md` cross-links
- [x] Optional: native Pascal tests — new `Goccia.Coverage.Test.pas` (5 MergeFrom sum tests) and a compiler binary round-trip test pinning declaration vs first-instruction positions; 64/64 unit-test binaries pass
- [ ] Optional: benchmarks — merge hot path unchanged (`RecordLineHit` delegates with count 1, inline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
