### PR TITLE
ci(testing): differential suites gate goccia against bun

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1312,6 +1312,9 @@ jobs:
       - name: Check Intl taint robustness under lazy materialization
         run: bun run scripts/test-cli-intl-taint.ts
 
+      - name: Check differential batteries against bun
+        run: bun run scripts/test-cli-differential.ts
+
       - name: Check benchmark comparison logic
         run: bun run scripts/test-benchmark-compare.ts
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -775,6 +775,9 @@ jobs:
       - name: Check Intl taint robustness under lazy materialization
         run: bun run scripts/test-cli-intl-taint.ts
 
+      - name: Check differential batteries against bun
+        run: bun run scripts/test-cli-differential.ts
+
       - name: Check benchmark comparison logic
         run: bun run scripts/test-benchmark-compare.ts
 

--- a/docs/differential-testing.md
+++ b/docs/differential-testing.md
@@ -1,0 +1,78 @@
+# Differential Testing
+
+*Three-runtime battery comparison: goccia interpreted, goccia bytecode, and bun as the ECMAScript oracle.*
+
+## Executive Summary
+
+- **Three runtimes per file** — every battery under `scripts/differential/` runs under `GocciaTestRunner`, `GocciaTestRunner --mode=bytecode`, and `bun test`
+- **Two invariants** — mode parity on pass/fail counts, and equality of the *failed-test name sets* between goccia and bun
+- **Names, not counts** — two runtimes can fail the same number of different tests, so the oracle comparison diffs names
+- **A timeout is a divergence** — a hang is a finding, never an infrastructure error
+- **Run with**: `bun run scripts/test-cli-differential.ts`
+
+## The two invariants
+
+Each battery file produces three verdicts. A file is reported as divergent when
+either invariant breaks.
+
+**1. Mode parity.** The interpreter and the bytecode VM must report identical
+pass and fail counts for the same file. A break here means the two execution
+paths disagree with each other, independent of what the correct answer is.
+
+**2. Bun as oracle.** The set of *failed test names* under goccia must equal the
+set under `bun test`. Bun stands in for ECMAScript/Vitest semantics: whatever it
+fails, goccia should fail, and nothing more. Comparing counts alone would let a
+goccia-only failure and a bun-only failure cancel out, so the harness diffs the
+names and reports the two directions separately as `goccia-only fails:` and
+`bun-only fails:`.
+
+The oracle comparison is skipped for a battery named `*.goccia.test.js`. Those
+files use goccia-only globals such as `mock` and `spyOn` that bun's runner does
+not provide, so only mode parity is enforced for them.
+
+## Timeout as divergence
+
+Each file gets a per-runtime timeout of `DIFFRUN_TIMEOUT` seconds (default 60).
+A runtime that exceeds it reports `TIMEOUT` and counts as a divergence rather
+than as a harness error. This is deliberate: a parser or executor that never
+terminates on input the other runtimes complete is exactly the class of defect
+this lane exists to surface, and treating it as infrastructure noise would hide
+it. The counterpart is that the timeout must stay generous enough that a slow
+but healthy run is never mistaken for a hang.
+
+## Battery layout
+
+Batteries live in `scripts/differential/`, alongside the harness that drives
+them, with shared import fixtures in `scripts/differential/mods/`. They are
+deliberately outside `tests/`: `GocciaTestRunner` scans only the paths it is
+given on the command line, so batteries that assert not-yet-fixed behavior — or
+that hang the engine — never join the main suite run. The same placement keeps
+them out of `scripts/check-test-structure.ts` and the vitest configuration,
+both of which are scoped to `tests/`.
+
+A battery uses only the `describe`/`test`/`expect` globals that all three
+runtimes inject. A `.test.ts` battery works in both because bun transpiles
+TypeScript natively while goccia parses annotations as types-as-comments.
+
+## Running the lane
+
+```bash
+./build.pas testrunner
+bun run scripts/test-cli-differential.ts
+```
+
+Divergent files print a `<<<` marker naming the disagreement, the run ends with
+a divergence count, and the process exits 1 when any file diverged.
+
+| Control | Effect |
+|---|---|
+| `DIFFRUN_TIMEOUT=<seconds>` | Per-file, per-runtime timeout (default `60`) |
+| `GOCCIA_BIN=<path>` | Goccia binary to test (default `./build/GocciaTestRunner`) |
+| trailing file paths | Restrict the run to the named batteries instead of the whole directory |
+
+```bash
+DIFFRUN_TIMEOUT=25 bun run scripts/test-cli-differential.ts scripts/differential/b-modules.test.js
+```
+
+The `cli` job in both workflows runs the lane with its defaults on every pull
+request and on pushes to `main`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -559,6 +559,7 @@ The CLI behaviour tests are standalone bun scripts under `scripts/test-cli-*.ts`
 | Global injection | `--global`, `--globals` file/module injection, collision detection |
 | Stdin smoke tests | Piped input executes correctly in interpreter mode and bytecode mode |
 | GocciaBenchmarkRunner output | `--format=json` produces valid JSON with benchmark structure |
+| Differential batteries | `test-cli-differential.ts` runs each `scripts/differential/` battery under interpreter, bytecode, and `bun test`, requiring mode parity on pass/fail counts and equality of failed-test **name** sets against bun; a per-file timeout counts as a divergence. See [Differential Testing](differential-testing.md) |
 
 This table is non-exhaustive — the `scripts/test-cli-*.ts` scripts that the `cli` job runs are the source of truth. The intent is to check all CLI options, all parser/lexer error paths, and all output-format correctness. To add a new check, add a case to the matching `scripts/test-cli-*.ts` (parser/lexer rejection → `test-cli-parser.ts` / `test-cli-lexer.ts`; CLI flags/output → `test-cli.ts` / `test-cli-apps.ts`); the `cli` job already invokes these scripts, so no workflow change is needed.
 

--- a/scripts/differential/a-typesyntax.test.ts
+++ b/scripts/differential/a-typesyntax.test.ts
@@ -1,0 +1,113 @@
+// Battery A — type-annotation parser edges around the 0.11.0 fixes.
+// Runs under goccia (types-as-comments) and bun (TS transpile) identically.
+
+type Pair = { a: string; b: number };
+type Cond<T> = T extends string ? "s" : "n";
+type Keys = keyof Pair;
+type Mapped = { [K in keyof Pair]: Pair[K] | null };
+type Tuple = [string, number, boolean?];
+
+const nestedGenericNew = new Map<string, Map<string, number[]>>();
+nestedGenericNew.set("outer", new Map([["inner", [1, 2]]]));
+
+const tripleNested = new Map<string, Map<string, Map<string, number>>>();
+
+function unionReturn(flag: boolean): string | { a: number } {
+  return flag ? "s" : { a: 1 };
+}
+
+function intersectionReturn(): { a: string } & { b: number } {
+  return { a: "x", b: 1 };
+}
+
+function genericConstraint<T extends { id: string }>(v: T): T["id"] {
+  return v.id;
+}
+
+const genericFnType: <T>(x: T) => T = (x) => x;
+
+const withDefault = <T = string,>(v: T): T => v;
+
+const satisfiesNested = {
+  outer: { inner: [1, 2, 3] },
+} as const satisfies { outer: { inner: readonly number[] } };
+
+const tup: Tuple = ["x", 1];
+const indexSig: { [key: string]: number } = { a: 1 };
+const templateLit: `id-${number}` = "id-42" as `id-${number}`;
+let definite!: number;
+definite = 5;
+
+const maybe: { v?: string } = {};
+const nonNull = { v: "x" as string | undefined };
+
+describe("type-syntax edges", () => {
+  test("nested generic new — >> disambiguation", () => {
+    expect(nestedGenericNew.get("outer")?.get("inner")).toEqual([1, 2]);
+  });
+
+  test("triple-nested generic new — >>> disambiguation", () => {
+    expect(tripleNested.size).toBe(0);
+  });
+
+  test("union return type on function declaration", () => {
+    expect(unionReturn(true)).toBe("s");
+    const o = unionReturn(false);
+    expect(typeof o).toBe("object");
+  });
+
+  test("intersection return type", () => {
+    expect(intersectionReturn().b).toBe(1);
+  });
+
+  test("generic constraint with indexed-access return type", () => {
+    expect(genericConstraint({ id: "abc" })).toBe("abc");
+  });
+
+  test("generic function-type annotation on const", () => {
+    expect(genericFnType(7)).toBe(7);
+  });
+
+  test("generic arrow with default type param", () => {
+    expect(withDefault("hi")).toBe("hi");
+  });
+
+  test("satisfies with nested readonly shape", () => {
+    expect(satisfiesNested.outer.inner[2]).toBe(3);
+  });
+
+  test("tuple / index-signature / template-literal / definite assignment", () => {
+    expect(tup[1]).toBe(1);
+    expect(indexSig.a).toBe(1);
+    expect(templateLit).toBe("id-42");
+    expect(definite).toBe(5);
+  });
+
+  test("optional property and non-null assertion", () => {
+    expect(maybe.v).toBeUndefined();
+    expect(nonNull.v!.length).toBe(1);
+  });
+
+  test("legitimate comparison a < b > c still comparison", () => {
+    const a = 1;
+    const b = 2;
+    const c = false;
+    // (1 < 2) => true; true > false => true
+    expect(a < b > c).toBe(true);
+  });
+
+  test("legitimate less-than before parenthesised expression", () => {
+    const f = 3;
+    const g = 5;
+    expect(f < (g + 1)).toBe(true);
+  });
+
+  test("conditional/mapped/keyof types accepted as annotations", () => {
+    const k: Keys = "a";
+    const c: Cond<string> = "s";
+    const m: Mapped = { a: null, b: 2 };
+    expect(k).toBe("a");
+    expect(c).toBe("s");
+    expect(m.b).toBe(2);
+  });
+});

--- a/scripts/differential/b-modules.test.js
+++ b/scripts/differential/b-modules.test.js
@@ -1,0 +1,49 @@
+// Battery B — module-linking edges around the §2 TDZ fix.
+import { viaB, fromA } from "./mods/circA.js";
+import { viaA } from "./mods/circB.js";
+import readSecret, { counter, bump } from "./mods/live.js";
+import { Tagger, asyncReader, outer } from "./mods/klass.js";
+import { reFromA, Tagger as ReTagger } from "./mods/rex.js";
+
+describe("module linking edges", () => {
+  test("circular imports: A -> B -> A both resolve", () => {
+    expect(viaB()).toBe(101);
+    expect(viaA()).toBe(12);
+    expect(fromA()).toBe(10);
+  });
+
+  test("default-export function reads module const", () => {
+    expect(readSecret()).toBe("s3cret");
+  });
+
+  test("live binding: importer sees exported let update", () => {
+    const before = counter;
+    bump();
+    bump();
+    expect(counter).toBe(before + 2);
+  });
+
+  test("class declaration: methods, private fields, static from module consts", () => {
+    const t = new Tagger();
+    expect(t.next()).toBe("id-1");
+    expect(t.next()).toBe("id-2");
+    expect(Tagger.max).toBe(3);
+    expect(t.atLimit).toBe(false);
+    t.next();
+    expect(t.atLimit).toBe(true);
+  });
+
+  test("async function declaration reads module const", async () => {
+    expect(await asyncReader()).toBe("id-async");
+  });
+
+  test("hoisted function calls file-local non-exported hoisted function", () => {
+    expect(outer()).toBe(6);
+  });
+
+  test("named re-export and export * both link", () => {
+    expect(reFromA()).toBe(10);
+    const t = new ReTagger();
+    expect(t.next()).toBe("id-1");
+  });
+});

--- a/scripts/differential/c-builtins.test.js
+++ b/scripts/differential/c-builtins.test.js
@@ -1,0 +1,85 @@
+// Battery C — real semantics of the 0.11.0 built-ins, not just typeof checks.
+
+describe("AbortController semantics", () => {
+  test("fresh signal is not aborted", () => {
+    const c = new AbortController();
+    expect(c.signal.aborted).toBe(false);
+  });
+
+  test("abort() flips aborted and sets a default reason", () => {
+    const c = new AbortController();
+    c.abort();
+    expect(c.signal.aborted).toBe(true);
+    expect(c.signal.reason).toBeDefined();
+    expect(c.signal.reason.name).toBe("AbortError");
+  });
+
+  test("abort(customReason) preserves the reason", () => {
+    const c = new AbortController();
+    c.abort(new Error("stop now"));
+    expect(c.signal.reason.message).toBe("stop now");
+  });
+
+  test("throwIfAborted throws the reason after abort", () => {
+    const c = new AbortController();
+    expect(() => c.signal.throwIfAborted()).not.toThrow();
+    c.abort(new Error("gone"));
+    expect(() => c.signal.throwIfAborted()).toThrow("gone");
+  });
+
+  test("abort event fires listeners exactly once", () => {
+    const c = new AbortController();
+    let calls = 0;
+    c.signal.addEventListener("abort", () => {
+      calls += 1;
+    });
+    c.abort();
+    c.abort();
+    expect(calls).toBe(1);
+  });
+
+  test("AbortSignal.abort() static returns pre-aborted signal", () => {
+    const s = AbortSignal.abort(new Error("static"));
+    expect(s.aborted).toBe(true);
+    expect(s.reason.message).toBe("static");
+  });
+
+  test("AbortSignal.timeout returns a live signal", () => {
+    const s = AbortSignal.timeout(10_000);
+    expect(s.aborted).toBe(false);
+  });
+});
+
+describe("modern built-ins", () => {
+  test("structuredClone deep-clones Map and Set", () => {
+    const src = { m: new Map([["k", { v: 1 }]]), s: new Set([1, 2]) };
+    const c = structuredClone(src);
+    c.m.get("k").v = 99;
+    expect(src.m.get("k").v).toBe(1);
+    expect(c.s.has(2)).toBe(true);
+  });
+
+  test("Object.groupBy groups", () => {
+    const g = Object.groupBy([1, 2, 3, 4], (n) => (n % 2 === 0 ? "even" : "odd"));
+    expect(g.even).toEqual([2, 4]);
+    expect(g.odd).toEqual([1, 3]);
+  });
+
+  test("Promise.withResolvers", () => {
+    const { promise, resolve } = Promise.withResolvers();
+    resolve(42);
+    return promise.then((v) => {
+      expect(v).toBe(42);
+    });
+  });
+
+  test("Error cause chains", () => {
+    const e = new Error("outer", { cause: new Error("inner") });
+    expect(e.cause.message).toBe("inner");
+  });
+
+  test("RegExp named groups", () => {
+    const m = "2026-08-05".match(/(?<y>\d{4})-(?<mo>\d{2})/);
+    expect(m.groups.y).toBe("2026");
+  });
+});

--- a/scripts/differential/d-matchers.test.js
+++ b/scripts/differential/d-matchers.test.js
@@ -1,0 +1,120 @@
+// Battery D — matcher semantics vs Vitest/Jest. Bun's expect is the ground truth here.
+
+describe("deep equality semantics", () => {
+  test("toEqual ignores explicit-undefined properties", () => {
+    expect({ a: 1, b: undefined }).toEqual({ a: 1 });
+  });
+
+  test("toStrictEqual distinguishes explicit-undefined properties", () => {
+    expect({ a: 1, b: undefined }).not.toStrictEqual({ a: 1 });
+  });
+
+  test("toEqual on Map and Set contents", () => {
+    expect(new Map([["k", [1, 2]]])).toEqual(new Map([["k", [1, 2]]]));
+    expect(new Set([1, 2])).toEqual(new Set([2, 1]));
+  });
+
+  test("toEqual distinguishes Map from plain object", () => {
+    expect(new Map([["a", 1]])).not.toEqual({ a: 1 });
+  });
+
+  test("toEqual distinguishes -0 from 0", () => {
+    expect([-0]).not.toEqual([0]);
+  });
+
+  test("toEqual on NaN", () => {
+    expect({ v: NaN }).toEqual({ v: NaN });
+  });
+
+  test("toEqual across class instances vs literals", () => {
+    class P {
+      constructor(x) {
+        this.x = x;
+      }
+    }
+    expect(new P(1)).toEqual({ x: 1 });
+    expect(new P(1)).not.toStrictEqual({ x: 1 });
+  });
+
+  test("sparse vs dense arrays under toStrictEqual", () => {
+    // eslint-disable-next-line no-sparse-arrays
+    expect([1, , 3]).not.toStrictEqual([1, undefined, 3]);
+  });
+});
+
+describe("asymmetric matchers", () => {
+  test("expect.any / expect.anything", () => {
+    expect({ id: "x", n: 3 }).toEqual({ id: expect.any(String), n: expect.any(Number) });
+    expect({ v: 0 }).toEqual({ v: expect.anything() });
+  });
+
+  test("objectContaining / arrayContaining / stringMatching", () => {
+    expect({ a: 1, b: 2 }).toEqual(expect.objectContaining({ a: 1 }));
+    expect([1, 2, 3]).toEqual(expect.arrayContaining([3, 1]));
+    expect("hello world").toEqual(expect.stringMatching(/world$/));
+  });
+
+  test("stringContaining and nested asymmetric", () => {
+    expect({ msg: "abc-def", list: [5, 6] }).toEqual({
+      msg: expect.stringContaining("def"),
+      list: expect.arrayContaining([6]),
+    });
+  });
+});
+
+describe("toThrow forms", () => {
+  test("regex matches Error message", () => {
+    expect(() => {
+      throw new Error("expected an items array in the response");
+    }).toThrow(/items array/);
+  });
+
+  test("regex matches Error subclass message", () => {
+    class DriftError extends Error {}
+    expect(() => {
+      throw new DriftError("drift detected");
+    }).toThrow(/drift/);
+  });
+
+  test("Error-instance argument matches by message", () => {
+    expect(() => {
+      throw new Error("exact text");
+    }).toThrow(new Error("exact text"));
+  });
+
+  test("constructor + not-throwing negation", () => {
+    expect(() => {
+      throw new TypeError("t");
+    }).toThrow(TypeError);
+    expect(() => 42).not.toThrow();
+  });
+});
+
+describe("property and containment matchers", () => {
+  test("toHaveProperty with dotted path and array index", () => {
+    const o = { a: { b: [{ c: 7 }] } };
+    expect(o).toHaveProperty("a.b");
+    expect(o).toHaveProperty(["a", "b", 0, "c"], 7);
+  });
+
+  test("toContainEqual with objects", () => {
+    expect([{ x: 1 }, { x: 2 }]).toContainEqual({ x: 2 });
+  });
+
+  test("toMatchObject with nested arrays", () => {
+    expect({ list: [{ a: 1, b: 2 }, { a: 3 }] }).toMatchObject({ list: [{ a: 1 }, { a: 3 }] });
+  });
+});
+
+describe("promise matchers", () => {
+  test("resolves chains through matchers", async () => {
+    await expect(Promise.resolve({ ok: true })).resolves.toEqual({ ok: true });
+  });
+
+  test("rejects.toThrow with regex", async () => {
+    const failing = async () => {
+      throw new Error("async boom");
+    };
+    await expect(failing()).rejects.toThrow(/boom/);
+  });
+});

--- a/scripts/differential/e-mocks.goccia.test.js
+++ b/scripts/differential/e-mocks.goccia.test.js
@@ -1,0 +1,32 @@
+describe("mock semantics (vitest-documented behavior)", () => {
+  test("mockResolvedValueOnce ordering with mockResolvedValue", async () => {
+    const m = mock();
+    m.mockResolvedValue("base").mockResolvedValueOnce("first").mockResolvedValueOnce("second");
+    expect(await m()).toBe("first");
+    expect(await m()).toBe("second");
+    expect(await m()).toBe("base");
+  });
+  test("mockRejectedValue produces rejection", async () => {
+    const m = mock();
+    m.mockRejectedValue(new Error("nope"));
+    await expect(m()).rejects.toThrow(/nope/);
+  });
+  test("mixing sync Once with resolved base", async () => {
+    const m = mock();
+    m.mockResolvedValue("async").mockReturnValueOnce("sync");
+    expect(m()).toBe("sync");
+    expect(await m()).toBe("async");
+  });
+  test("spy restore chain", () => {
+    const o = { f: () => "orig" };
+    const s = spyOn(o, "f").mockImplementation(() => "fake");
+    expect(o.f()).toBe("fake");
+    s.mockRestore();
+    expect(o.f()).toBe("orig");
+  });
+  test("asymmetric matcher inside toHaveBeenCalledWith", () => {
+    const m = mock();
+    m({ id: "abc", n: 7 });
+    expect(m).toHaveBeenCalledWith(expect.objectContaining({ id: expect.any(String) }));
+  });
+});

--- a/scripts/differential/mods/circA.js
+++ b/scripts/differential/mods/circA.js
@@ -1,0 +1,11 @@
+import { fromB } from "./circB.js";
+
+const baseA = 10;
+
+export function fromA() {
+  return baseA;
+}
+
+export function viaB() {
+  return fromB() + 1;
+}

--- a/scripts/differential/mods/circB.js
+++ b/scripts/differential/mods/circB.js
@@ -1,0 +1,11 @@
+import { fromA } from "./circA.js";
+
+const baseB = 100;
+
+export function fromB() {
+  return baseB;
+}
+
+export function viaA() {
+  return fromA() + 2;
+}

--- a/scripts/differential/mods/klass.js
+++ b/scripts/differential/mods/klass.js
@@ -1,0 +1,30 @@
+const PREFIX = "id-";
+const LIMIT = 3;
+
+export class Tagger {
+  static max = LIMIT;
+
+  #n = 0;
+
+  next() {
+    this.#n += 1;
+    return PREFIX + this.#n;
+  }
+
+  get atLimit() {
+    return this.#n >= LIMIT;
+  }
+}
+
+export async function asyncReader() {
+  await Promise.resolve();
+  return PREFIX + "async";
+}
+
+export function outer() {
+  return inner() * 2;
+}
+
+function inner() {
+  return LIMIT;
+}

--- a/scripts/differential/mods/live.js
+++ b/scripts/differential/mods/live.js
@@ -1,0 +1,11 @@
+export let counter = 0;
+
+export function bump() {
+  counter += 1;
+}
+
+const secret = "s3cret";
+
+export default function readSecret() {
+  return secret;
+}

--- a/scripts/differential/mods/rex.js
+++ b/scripts/differential/mods/rex.js
@@ -1,0 +1,2 @@
+export { fromA as reFromA } from "./circA.js";
+export * from "./klass.js";

--- a/scripts/test-cli-differential.ts
+++ b/scripts/test-cli-differential.ts
@@ -1,0 +1,168 @@
+#!/usr/bin/env bun
+/**
+ * test-cli-differential.ts
+ *
+ * Differential battery runner: goccia-interpreted vs goccia-bytecode vs bun.
+ *
+ * Each battery file under `scripts/differential/` runs under all three
+ * runtimes; per-file pass/fail counts and failed-test name sets are diffed.
+ * Any disagreement is a divergence and the process exits 1 (0 when everything
+ * agrees), so this gates CI directly.
+ *
+ * Two invariants:
+ * 1. **Mode parity** — interpreter and bytecode must report the same
+ *    pass/fail counts for the same file.
+ * 2. **Bun as oracle** — the set of *failed test names* under goccia must
+ *    equal the set under `bun test`. Counts alone are not enough: two
+ *    runtimes can fail the same number of different tests.
+ *
+ * Conventions:
+ * - Battery files use only the `describe`/`test`/`expect` globals all three
+ *   runtimes inject. `.test.ts` batteries work because bun transpiles TS
+ *   natively while goccia parses annotations as types-as-comments.
+ * - A battery named `*.goccia.test.js` uses goccia-only globals (`mock`,
+ *   `spyOn`): bun is skipped for it and only interp-vs-bytecode parity is
+ *   checked.
+ * - The goccia binary defaults to the built `GocciaTestRunner`; set GOCCIA_BIN
+ *   to point somewhere else.
+ * - A runtime that exceeds the per-file timeout (DIFFRUN_TIMEOUT seconds,
+ *   default 60) reports as TIMEOUT and counts as a divergence — this is
+ *   deliberate: a parser or executor hang is a finding, not an infrastructure
+ *   error.
+ */
+
+import { readFileSync, readdirSync, rmSync } from "fs";
+import { basename, join } from "path";
+
+import { TESTRUNNER } from "./test-cli/binaries";
+import { clean, mkdtemp } from "./test-cli/tmpdir";
+
+const BATTERY_DIR = join(import.meta.dir, "differential");
+const GOCCIA_BIN = process.env.GOCCIA_BIN ?? TESTRUNNER;
+const TIMEOUT_MS = Number.parseInt(process.env.DIFFRUN_TIMEOUT ?? "60", 10) * 1000;
+const GFLAGS = ["--source-type=module", "--compat-function", "--no-progress"];
+
+type Verdict = { passed: number; failed: number; failedNames: Set<string> };
+type Run = { verdict: Verdict | null; error: string | null };
+
+const scratch = mkdtemp("goccia-differential-");
+
+/** Runs one file under goccia and reads back its JSON result envelope. */
+function gocciaResults(path: string, bytecode: boolean): Run {
+  const mode = bytecode ? ["--mode=bytecode"] : [];
+  const outPath = join(scratch, `${basename(path)}${bytecode ? ".bc" : ".it"}.json`);
+  const proc = Bun.spawnSync([GOCCIA_BIN, path, `--output=${outPath}`, ...GFLAGS, ...mode], {
+    stdout: "pipe",
+    stderr: "pipe",
+    timeout: TIMEOUT_MS,
+  });
+  if (proc.exitedDueToTimeout) return { verdict: null, error: "TIMEOUT" };
+
+  let envelope: any;
+  try {
+    envelope = JSON.parse(readFileSync(outPath, "utf8"));
+  } catch (e: any) {
+    // Any unreadable envelope is the same finding.
+    return { verdict: null, error: `NO-JSON (${e.message})` };
+  } finally {
+    rmSync(outPath, { force: true });
+  }
+
+  const file = envelope.files?.[0];
+  if (!file) return { verdict: null, error: "NO-JSON (envelope has no files[0])" };
+  if (file.errorMessage) {
+    return { verdict: null, error: `LOAD-FAIL: ${file.errorMessage.split("\n")[0].slice(0, 100)}` };
+  }
+
+  const failedNames = new Set<string>();
+  for (const entry of file.failedTests ?? []) {
+    const m = /^Test "(.*?)" in suite/.exec(entry);
+    failedNames.add(m ? m[1] : entry);
+  }
+  return { verdict: { passed: file.passed, failed: file.failed, failedNames }, error: null };
+}
+
+/** Runs one file under `bun test`; parses the human summary for verdicts. */
+function bunResults(path: string): Run {
+  const proc = Bun.spawnSync(["bun", "test", path], {
+    stdout: "pipe",
+    stderr: "pipe",
+    timeout: TIMEOUT_MS,
+  });
+  if (proc.exitedDueToTimeout) return { verdict: null, error: "TIMEOUT" };
+
+  const out = proc.stdout.toString() + proc.stderr.toString();
+  const lines = out.split("\n");
+  let passed = 0;
+  let failed = 0;
+  const failedNames = new Set<string>();
+  for (const line of lines) {
+    const mp = /^\s*(\d+) pass/.exec(line);
+    if (mp) passed = Number.parseInt(mp[1], 10);
+    const mf = /^\s*(\d+) fail/.exec(line);
+    if (mf) failed = Number.parseInt(mf[1], 10);
+    const mfn = /^\(fail\) (?:.+? > )?(.+?)(?: \[[\d.]+m?s\])?$/.exec(line.trim());
+    if (mfn) failedNames.add(mfn[1]);
+  }
+  if (passed === 0 && failed === 0) {
+    const tail = lines.length > 0 ? lines[lines.length - 1].slice(0, 100) : "EMPTY";
+    return { verdict: null, error: `NO-TESTS: ${tail}` };
+  }
+  return { verdict: { passed, failed, failedNames }, error: null };
+}
+
+const fmt = (run: Run): string =>
+  run.error ?? `${run.verdict!.passed}p/${run.verdict!.failed}f`;
+
+const difference = (a: Set<string>, b: Set<string>): string[] =>
+  [...a].filter((v) => !b.has(v)).sort();
+
+const sameNames = (a: Set<string>, b: Set<string>): boolean =>
+  a.size === b.size && [...a].every((v) => b.has(v));
+
+const cliFiles = process.argv.slice(2);
+const files =
+  cliFiles.length > 0
+    ? cliFiles
+    : readdirSync(BATTERY_DIR)
+        .filter((f) => f.endsWith(".test.js") || f.endsWith(".test.ts"))
+        .sort()
+        .map((f) => join(BATTERY_DIR, f));
+
+const findings: string[] = [];
+
+for (const path of files) {
+  const name = basename(path);
+  const gocciaOnly = name.includes(".goccia.");
+  const it = gocciaResults(path, false);
+  const bc = gocciaResults(path, true);
+  const bn: Run = gocciaOnly ? { verdict: null, error: "SKIPPED" } : bunResults(path);
+
+  const disagree: string[] = [];
+  if (it.error || bc.error) {
+    disagree.push("goccia load/exec failure");
+  } else if (it.verdict!.passed !== bc.verdict!.passed || it.verdict!.failed !== bc.verdict!.failed) {
+    disagree.push("MODE-PARITY BROKEN");
+  }
+  if (!gocciaOnly && disagree.length === 0) {
+    if (bn.error) {
+      disagree.push("bun load/exec failure");
+    } else if (!sameNames(it.verdict!.failedNames, bn.verdict!.failedNames)) {
+      const onlyGoccia = difference(it.verdict!.failedNames, bn.verdict!.failedNames);
+      const onlyBun = difference(bn.verdict!.failedNames, it.verdict!.failedNames);
+      if (onlyGoccia.length > 0) disagree.push(`goccia-only fails: ${JSON.stringify(onlyGoccia)}`);
+      if (onlyBun.length > 0) disagree.push(`bun-only fails: ${JSON.stringify(onlyBun)}`);
+    }
+  }
+
+  const marker = disagree.length > 0 ? `  <<< ${disagree.join("; ")}` : "";
+  console.log(
+    `${name.padEnd(42)} interp=${fmt(it)}  bytecode=${fmt(bc)}  bun=${fmt(bn)}${marker}`,
+  );
+  if (disagree.length > 0) findings.push(name);
+}
+
+clean(scratch);
+
+console.log(`\n${findings.length} file(s) with divergence`);
+process.exit(findings.length > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

- Lands the differential battery harness that found every bug fixed below this layer, as a CI gate: `scripts/test-cli-differential.ts` (bun-native port of the handover's python harness) runs each battery in `scripts/differential/` under goccia-interpreted, goccia-bytecode, and `bun test` (Vitest-semantics oracle), comparing mode parity on pass/fail counts and failed-test name sets against bun. A per-runtime timeout counts as a divergence by design — a hang is a finding (that is how the JSX-transformer DoS was caught).
- Batteries live outside `tests/` so the main suite never executes them (verified by file count); `*.goccia.test.js` batteries (goccia-only globals) skip bun and enforce only mode parity.
- Wired into the `cli` job of ci.yml and pr.yml after the other test-cli steps — green only with the seven layers below merged, which is the point of the stack ordering. With this branch: **all five batteries agree, 0 divergences, exit 0** — including battery A, which hung the 0.11.0 parser forever.
- Follow-ups from the stack's reviews, for issue filing after merge: Error-object deep-equality vs bun; `Object.create(Array.prototype)` strict-equality class-identity edge; iterator-snapshot GC exposure in Set/Map comparison; coverage path-key normalization; pr.yml redundant coverage matrix leg; `docs/testing.md` near its length limit.

Part of the 0.11.0 adversarial-findings stacked-PR train (8 layers, each PR targets the layer below; merge bottom-up). Mini-spec: fix the differential-testing findings F1–F13/G4/G5 — JSX-transformer hang, toThrow semantics, Vitest matcher parity, coverage consistency, TS type-syntax gaps, AbortSignal events — and land the goccia-vs-bun differential battery harness as a CI gate, green at every layer.

## Testing

- [x] End-to-end tests — harness reproduces the original 3-file divergence table exactly against a 0.11.0 build (exit 1) and exits 0 on this branch (verified: 13p+7p+12p+20p+5p, 0 divergences); main suite green both modes and does not execute the batteries
- [x] Updated documentation — `docs/differential-testing.md` (with executive summary) + pointer row in `docs/testing.md`
- [ ] Optional: native Pascal tests — n/a
- [ ] Optional: benchmarks — n/a (~2s wall-clock when nothing hangs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
