### PR TITLE
fix(testing): compare Error objects by value in deep equality

### DIFF
--- a/docs/testing-api.md
+++ b/docs/testing-api.md
@@ -104,6 +104,22 @@ When `.toMatch()` receives a `RegExp`, the matcher uses regex semantics but does
 
 Under `.toStrictEqual()`, a class instance matches only an instance of the same class. Every object that is not a class instance counts as plain, including a null-prototype object and one built with `Object.create(proto)`. Only trailing `undefined` items are forgiven by `.toEqual()`, and only past the shorter length: `[1, undefined, 2]` does not equal `[1, 2]`.
 
+**Errors** are the one shape both matchers treat identically. An error's `name` and `message` are inherited or non-enumerable, so comparing visible properties alone would make every error equal to every other one and to `{}`. Both matchers therefore compare `name`, `message`, `cause`, and the error's own enumerable properties, and an error is never equal to a plain object:
+
+```javascript
+expect(new Error("a")).toEqual(new Error("a"));
+expect(new Error("a")).not.toEqual(new Error("b"));
+expect(new TypeError("m")).not.toEqual(new Error("m"));
+expect(new Error("a")).not.toEqual({ name: "Error", message: "a" });
+expect(new Error("m", { cause: "c" })).not.toEqual(new Error("m"));
+```
+
+What counts as an error is the internal slot an error constructor installs, not the prototype chain: `Object.create(Error.prototype)` is a plain object and equals `{}`. An error is then identified by its `name`, not by its class, and this is the one place `.toStrictEqual()` adds no class check: `class MyError extends Error {}` that leaves `name` alone inherits `"Error"` and equals a plain `Error` with the same message under both matchers. Assigning `this.name` makes it distinct.
+
+`name`, `message`, and `cause` are compared by value and are never stringified, so a `name` whose `toString` throws does not turn an assertion into a raised error. A `cause` that is present but `undefined` reads as absent to `.toEqual()`, like any other undefined-valued property, while `.toStrictEqual()` keeps them apart; a `cause` chain that loops back on itself terminates rather than recursing. `stack` never participates, and neither does `AggregateError`'s `errors` — matching bun, which diverges from the Vitest documentation here. `.toMatchObject()` is unaffected: it keeps subset semantics, so `{ e: new Error("x") }` matches `{ e: {} }`.
+
+One known divergence: a `DOMException` carries `name`, `message`, and `code` as ordinary enumerable properties in this engine, so the plain object walk distinguishes two DOMExceptions whose messages differ, where bun equates them.
+
 #### Property paths
 
 `.toHaveProperty()` accepts a path rather than a flat key. A string path splits on dots and understands bracket indices, so `"items[0].type"` and `"a.b"` both walk into nested values; an array path (`["a", "b", 0, "c"]`) takes each segment verbatim, which is also how you reach a key that itself contains a dot. Each segment resolves the way a normal property read would, so inherited members and the members of a boxed primitive (`"name.length"`) are found. A second argument is compared with `.toEqual()` semantics. Walking into `null` or `undefined` reports a normal assertion failure rather than raising.

--- a/scripts/differential/d-matchers.test.js
+++ b/scripts/differential/d-matchers.test.js
@@ -42,6 +42,136 @@ describe("deep equality semantics", () => {
   });
 });
 
+describe("error equality", () => {
+  test("errors compare on name and message", () => {
+    expect(new Error("a")).toEqual(new Error("a"));
+    expect(new Error("a")).not.toEqual(new Error("b"));
+    expect(new TypeError("m")).not.toEqual(new Error("m"));
+  });
+
+  test("errors compare on own enumerable properties", () => {
+    const withCode = new Error("m");
+    withCode.code = 1;
+    const sameCode = new Error("m");
+    sameCode.code = 1;
+    const otherCode = new Error("m");
+    otherCode.code = 2;
+
+    expect(withCode).toEqual(sameCode);
+    expect(withCode).not.toEqual(otherCode);
+    expect(withCode).not.toEqual(new Error("m"));
+  });
+
+  test("an error never equals a plain object", () => {
+    expect(new Error("a")).not.toEqual({});
+    expect(new Error("a")).not.toEqual({ message: "a" });
+    expect(new Error("a")).not.toEqual({ name: "Error", message: "a" });
+    expect({}).not.toEqual(new Error("a"));
+  });
+
+  test("error subclasses key on name, not on the class", () => {
+    class CustomError extends Error {}
+    class NamedError extends Error {
+      constructor(message) {
+        super(message);
+        this.name = "NamedError";
+      }
+    }
+
+    expect(new CustomError("m")).toEqual(new Error("m"));
+    expect(new CustomError("m")).toStrictEqual(new Error("m"));
+    expect(new NamedError("m")).not.toEqual(new Error("m"));
+    expect(new TypeError("m")).not.toStrictEqual(new Error("m"));
+  });
+
+  test("cause participates in equality", () => {
+    expect(new Error("m", { cause: "c" })).toEqual(new Error("m", { cause: "c" }));
+    expect(new Error("m", { cause: "c" })).not.toEqual(new Error("m", { cause: "d" }));
+    expect(new Error("m", { cause: "c" })).not.toEqual(new Error("m"));
+    expect(new Error("m", { cause: { a: 1 } })).toEqual(
+      new Error("m", { cause: { a: 1 } }),
+    );
+  });
+
+  test("a cyclic cause chain terminates", () => {
+    const left = new Error("m");
+    left.cause = left;
+    const right = new Error("m");
+    right.cause = right;
+
+    expect(left).toEqual(right);
+  });
+
+  test("errors nested in containers", () => {
+    expect([new Error("x")]).toEqual([new Error("x")]);
+    expect([new Error("x")]).not.toEqual([new Error("y")]);
+    expect(new Set([new Error("x")])).toEqual(new Set([new Error("x")]));
+    expect(new Map([["k", new Error("x")]])).toEqual(
+      new Map([["k", new Error("x")]]),
+    );
+    expect([new Error("x")]).toContainEqual(new Error("x"));
+  });
+
+  test("error-ness comes from the error slot, not the prototype chain", () => {
+    expect(Object.create(Error.prototype)).toEqual({});
+    expect(Object.setPrototypeOf({}, Error.prototype)).toEqual({});
+    expect(Object.create(Error.prototype)).not.toEqual(new Error(""));
+  });
+
+  test("a present-but-undefined cause reads as absent to toEqual", () => {
+    expect(new Error("m", { cause: undefined })).toEqual(new Error("m"));
+    expect(new Error("m")).toEqual(new Error("m", { cause: undefined }));
+    expect(new Error("m", { cause: undefined })).not.toStrictEqual(
+      new Error("m"),
+    );
+  });
+
+  test("name is compared by value, never stringified", () => {
+    const undefinedName = new Error("m");
+    Object.setPrototypeOf(
+      undefinedName,
+      Object.create(Error.prototype, { name: { value: undefined } }),
+    );
+    const emptyName = new Error("m");
+    Object.setPrototypeOf(
+      emptyName,
+      Object.create(Error.prototype, { name: { value: "" } }),
+    );
+    expect(undefinedName).not.toEqual(emptyName);
+
+    let calls = 0;
+    const shared = Object.create(Error.prototype, {
+      name: {
+        value: {
+          toString: () => {
+            calls = calls + 1;
+            throw new RangeError("boom");
+          },
+        },
+      },
+    });
+    const left = new Error("m");
+    Object.setPrototypeOf(left, shared);
+    const right = new Error("m");
+    Object.setPrototypeOf(right, shared);
+    expect(left).toEqual(right);
+    expect(calls).toBe(0);
+  });
+
+  test("an AggregateError nested inside a cause", () => {
+    expect(
+      new Error("m", { cause: new AggregateError([new Error("x")], "agg") }),
+    ).toEqual(
+      new Error("m", { cause: new AggregateError([new Error("y")], "agg") }),
+    );
+  });
+
+  test("toMatchObject keeps subset semantics for errors", () => {
+    expect({ e: new Error("x") }).toMatchObject({ e: new Error("y") });
+    expect({ e: new Error("x") }).toMatchObject({ e: {} });
+  });
+});
+
 describe("asymmetric matchers", () => {
   test("expect.any / expect.anything", () => {
     expect({ id: "x", n: 3 }).toEqual({ id: expect.any(String), n: expect.any(Number) });

--- a/source/units/Goccia.Evaluator.Comparison.pas
+++ b/source/units/Goccia.Evaluator.Comparison.pas
@@ -17,6 +17,7 @@ implementation
 
 uses
   Goccia.Arithmetic,
+  Goccia.Constants.PropertyNames,
   Goccia.Values.ArrayValue,
   Goccia.Values.AsymmetricMatcher,
   Goccia.Values.ClassValue,
@@ -99,6 +100,18 @@ begin
     ExpectedClass := nil;
 
   Result := ActualClass = ExpectedClass;
+end;
+
+{ Reads a property the comparison needs but the enumerable-key walk cannot
+  see, normalizing a missing property to undefined. The value is returned raw:
+  stringifying it here would both collapse distinct values and run user code
+  inside the matcher. }
+function ErrorFieldValue(const AObject: TGocciaObjectValue;
+  const AName: string): TGocciaValue;
+begin
+  Result := AObject.GetProperty(AName);
+  if Result = nil then
+    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
 
 { An asymmetric matcher accepts a whole family of values, so it has to be
@@ -192,6 +205,9 @@ var
   Used: TArray<Boolean>;
   Claimed: TArray<Boolean>;
   Pass: Integer;
+  BothErrors: Boolean;
+  ActualIsError, ExpectedIsError: Boolean;
+  ActualHasCause, ExpectedHasCause: Boolean;
   TrialPairs: TComparedValuePairArray;
 begin
   // Vitest/Jest asymmetric matchers participate in every equality-based
@@ -491,7 +507,25 @@ begin
     ActualObj := TGocciaObjectValue(AActual);
     ExpectedObj := TGocciaObjectValue(AExpected);
 
-    if AStrict and not HasSameObjectType(AActual, AExpected) then
+    ActualIsError := IsErrorObject(AActual);
+    ExpectedIsError := IsErrorObject(AExpected);
+    BothErrors := ActualIsError and ExpectedIsError;
+
+    { An error is never equal to a plain object, however similar their visible
+      properties are: name and message are not enumerable, so without this the
+      key walk below would call every error equal to every other one and to an
+      empty object. }
+    if ActualIsError <> ExpectedIsError then
+    begin
+      Result := False;
+      Exit;
+    end;
+
+    { The strict matcher's class check does not apply to errors: a
+      `class MyError extends Error` instance that leaves `name` alone is equal
+      to a plain Error with the same message under both matchers. }
+    if AStrict and not BothErrors and
+       not HasSameObjectType(AActual, AExpected) then
     begin
       Result := False;
       Exit;
@@ -515,6 +549,56 @@ begin
       Exit;
     end;
     AddComparedPair(AComparedPairs, AActual, AExpected);
+
+    { An error's identity is its name, message and cause, none of which the
+      enumerable-key walk below can see. Comparing them after the pair is
+      registered lets a chain that loops back on itself terminate. }
+    if BothErrors then
+    begin
+      if not IsDeepEqualInternal(ErrorFieldValue(ActualObj, PROP_NAME),
+        ErrorFieldValue(ExpectedObj, PROP_NAME), AComparedPairs, AStrict) or
+         not IsDeepEqualInternal(ErrorFieldValue(ActualObj, PROP_MESSAGE),
+        ErrorFieldValue(ExpectedObj, PROP_MESSAGE), AComparedPairs,
+        AStrict) then
+      begin
+        Result := False;
+        Exit;
+      end;
+
+      ActualHasCause := ActualObj.HasOwnProperty(PROP_CAUSE);
+      ExpectedHasCause := ExpectedObj.HasOwnProperty(PROP_CAUSE);
+      if ActualHasCause <> ExpectedHasCause then
+      begin
+        { A cause that is present but undefined reads the same as no cause at
+          all to the loose matcher, exactly like any other undefined-valued
+          property. The strict matcher keeps them apart. }
+        if AStrict then
+        begin
+          Result := False;
+          Exit;
+        end;
+        if ActualHasCause and
+           not IsUndefinedLike(ErrorFieldValue(ActualObj, PROP_CAUSE)) then
+        begin
+          Result := False;
+          Exit;
+        end;
+        if ExpectedHasCause and
+           not IsUndefinedLike(ErrorFieldValue(ExpectedObj, PROP_CAUSE)) then
+        begin
+          Result := False;
+          Exit;
+        end;
+      end
+      else if ActualHasCause and
+         not IsDeepEqualInternal(ErrorFieldValue(ActualObj, PROP_CAUSE),
+           ErrorFieldValue(ExpectedObj, PROP_CAUSE), AComparedPairs,
+           AStrict) then
+      begin
+        Result := False;
+        Exit;
+      end;
+    end;
 
     // Check if all keys exist in both objects and values are deeply equal
     for I := 0 to High(ActualKeys) do

--- a/source/units/Goccia.Values.ErrorHelper.pas
+++ b/source/units/Goccia.Values.ErrorHelper.pas
@@ -6,11 +6,18 @@ interface
 
 uses
   Goccia.Realm,
-  Goccia.Values.ObjectValue;
+  Goccia.Values.ObjectValue,
+  Goccia.Values.Primitives;
 
 { Creates a JavaScript error object with the given name and message.
   ASkipTop controls how many frames to skip from the top of the call stack. }
 function CreateErrorObject(const AName, AMessage: string; const ASkipTop: Integer = 0): TGocciaObjectValue;
+
+{ True when AValue carries [[ErrorData]] — the slot every error constructor
+  installs, including through a `class MyError extends Error` subclass. Merely
+  inheriting from Error.prototype does not make an object an error, and
+  DOMException clears the slot on purpose. }
+function IsErrorObject(const AValue: TGocciaValue): Boolean;
 
 { Creates a DOMException object with the standard legacy code for AName. }
 function CreateDOMExceptionObject(const AName, AMessage: string;
@@ -57,8 +64,7 @@ uses
   Goccia.Constants.ErrorNames,
   Goccia.Constants.PropertyNames,
   Goccia.Values.Error,
-  Goccia.Values.ObjectPropertyDescriptor,
-  Goccia.Values.Primitives;
+  Goccia.Values.ObjectPropertyDescriptor;
 
 function DOMExceptionLegacyCode(const AName: string): Integer;
 begin
@@ -98,6 +104,12 @@ begin
     Result := GetErrorProto
   else
     Result := GetErrorProto;
+end;
+
+function IsErrorObject(const AValue: TGocciaValue): Boolean;
+begin
+  Result := (AValue is TGocciaObjectValue) and
+    TGocciaObjectValue(AValue).HasErrorData;
 end;
 
 function CreateDOMExceptionObject(const AName, AMessage: string;

--- a/tests/built-ins/Goccia/expect/toEqual.js
+++ b/tests/built-ins/Goccia/expect/toEqual.js
@@ -10,6 +10,15 @@ class Other {
   }
 }
 
+class CustomError extends Error {}
+
+class NamedError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "NamedError";
+  }
+}
+
 describe("toEqual", () => {
   test("compares primitives with Object.is semantics", () => {
     expect(1).toEqual(1);
@@ -152,6 +161,188 @@ describe("toEqual", () => {
     right.self = right;
 
     expect(left).toEqual(right);
+  });
+
+  test("compares errors on name and message", () => {
+    expect(new Error("a")).toEqual(new Error("a"));
+    expect(new Error("a")).not.toEqual(new Error("b"));
+    expect(new TypeError("m")).toEqual(new TypeError("m"));
+    expect(new TypeError("m")).not.toEqual(new Error("m"));
+  });
+
+  test("compares an error's own enumerable properties", () => {
+    const withCode = new Error("m");
+    withCode.code = 1;
+    const sameCode = new Error("m");
+    sameCode.code = 1;
+    const otherCode = new Error("m");
+    otherCode.code = 2;
+
+    expect(withCode).toEqual(sameCode);
+    expect(withCode).not.toEqual(otherCode);
+    expect(withCode).not.toEqual(new Error("m"));
+
+    // The undefined-key rule still applies inside errors.
+    const undefinedCode = new Error("m");
+    undefinedCode.code = undefined;
+    expect(undefinedCode).toEqual(new Error("m"));
+  });
+
+  test("never equates an error with a plain object", () => {
+    expect(new Error("a")).not.toEqual({});
+    expect(new Error("a")).not.toEqual({ message: "a" });
+    expect(new Error("a")).not.toEqual({ name: "Error", message: "a" });
+    expect({}).not.toEqual(new Error("a"));
+  });
+
+  test("keys error subclasses on name rather than the class", () => {
+    // A subclass that leaves name alone inherits "Error" and matches one.
+    expect(new CustomError("m")).toEqual(new Error("m"));
+    expect(new CustomError("m")).toEqual(new CustomError("m"));
+    expect(new NamedError("m")).not.toEqual(new Error("m"));
+
+    const renamed = new Error("m");
+    renamed.name = "Weird";
+    const sameName = new Error("m");
+    sameName.name = "Weird";
+    expect(renamed).toEqual(sameName);
+    expect(renamed).not.toEqual(new Error("m"));
+  });
+
+  test("compares the cause", () => {
+    expect(new Error("m", { cause: "c" })).toEqual(
+      new Error("m", { cause: "c" }),
+    );
+    expect(new Error("m", { cause: "c" })).not.toEqual(
+      new Error("m", { cause: "d" }),
+    );
+    expect(new Error("m", { cause: "c" })).not.toEqual(new Error("m"));
+    expect(new Error("m")).not.toEqual(new Error("m", { cause: "c" }));
+    expect(new Error("m", { cause: { a: 1 } })).toEqual(
+      new Error("m", { cause: { a: 1 } }),
+    );
+    expect(new Error("m", { cause: { a: 1 } })).not.toEqual(
+      new Error("m", { cause: { a: 2 } }),
+    );
+  });
+
+  test("terminates on a cyclic cause chain", () => {
+    const left = new Error("m");
+    left.cause = left;
+    const right = new Error("m");
+    right.cause = right;
+    expect(left).toEqual(right);
+
+    const outerLeft = new Error("outer");
+    const innerLeft = new Error("inner");
+    outerLeft.cause = innerLeft;
+    innerLeft.cause = outerLeft;
+    const outerRight = new Error("outer");
+    const innerRight = new Error("inner");
+    outerRight.cause = innerRight;
+    innerRight.cause = outerRight;
+    expect(outerLeft).toEqual(outerRight);
+  });
+
+  test("ignores AggregateError contents, matching bun", () => {
+    // bun compares neither `errors` nor `stack`; only name, message, cause
+    // and own enumerable properties participate.
+    expect(new AggregateError([new Error("x")], "agg")).toEqual(
+      new AggregateError([new Error("y")], "agg"),
+    );
+    expect(new AggregateError([new Error("x")], "agg")).not.toEqual(
+      new AggregateError([new Error("x")], "other"),
+    );
+  });
+
+  test("keys error-ness on the error slot, not the prototype chain", () => {
+    // Inheriting from Error.prototype does not make an object an error; only
+    // the slot an error constructor installs does.
+    expect(Object.create(Error.prototype)).toEqual({});
+    expect(Object.setPrototypeOf({}, Error.prototype)).toEqual({});
+    expect(Object.create(Error.prototype)).not.toEqual(new Error(""));
+    expect(new CustomError("m")).not.toEqual({});
+  });
+
+  test("forgives a cause that is present but undefined", () => {
+    expect(new Error("m", { cause: undefined })).toEqual(new Error("m"));
+    expect(new Error("m")).toEqual(new Error("m", { cause: undefined }));
+  });
+
+  test("compares name by value rather than by its string form", () => {
+    const undefinedName = new Error("m");
+    Object.setPrototypeOf(
+      undefinedName,
+      Object.create(Error.prototype, { name: { value: undefined } }),
+    );
+    const emptyName = new Error("m");
+    Object.setPrototypeOf(
+      emptyName,
+      Object.create(Error.prototype, { name: { value: "" } }),
+    );
+
+    expect(undefinedName).not.toEqual(emptyName);
+  });
+
+  test("never stringifies name, so a throwing toString stays put", () => {
+    let calls = 0;
+    const shared = Object.create(Error.prototype, {
+      name: {
+        value: {
+          toString: () => {
+            calls = calls + 1;
+            throw new RangeError("boom");
+          },
+        },
+      },
+    });
+    const left = new Error("m");
+    Object.setPrototypeOf(left, shared);
+    const right = new Error("m");
+    Object.setPrototypeOf(right, shared);
+
+    expect(left).toEqual(right);
+    expect(calls).toBe(0);
+  });
+
+  test("compares an AggregateError nested inside a cause", () => {
+    expect(
+      new Error("m", { cause: new AggregateError([new Error("x")], "agg") }),
+    ).toEqual(
+      new Error("m", { cause: new AggregateError([new Error("y")], "agg") }),
+    );
+    expect(
+      new Error("m", { cause: new AggregateError([], "agg") }),
+    ).not.toEqual(new Error("m", { cause: new AggregateError([], "other") }));
+  });
+
+  test("distinguishes DOMExceptions by their enumerable fields", () => {
+    // Known divergence: a DOMException carries name/message/code as ordinary
+    // enumerable properties here, so the plain object walk separates them.
+    // bun equates DOMExceptions with differing messages. Pre-existing.
+    expect(new DOMException("a", "AbortError")).toEqual(
+      new DOMException("a", "AbortError"),
+    );
+    expect(new DOMException("a", "AbortError")).not.toEqual(
+      new DOMException("b", "AbortError"),
+    );
+  });
+
+  test("compares errors nested in containers", () => {
+    expect([new Error("x")]).toEqual([new Error("x")]);
+    expect([new Error("x")]).not.toEqual([new Error("y")]);
+    expect(new Set([new Error("x")])).toEqual(new Set([new Error("x")]));
+    expect(new Set([new Error("x")])).not.toEqual(new Set([new Error("y")]));
+    expect(new Map([["k", new Error("x")]])).toEqual(
+      new Map([["k", new Error("x")]]),
+    );
+    expect(new Map([["k", new Error("x")]])).not.toEqual(
+      new Map([["k", new Error("y")]]),
+    );
+    expect({ e: new Error("x") }).toEqual({ e: new Error("x") });
+    expect({ e: new Error("x") }).not.toEqual({ e: new Error("y") });
+    expect([new Error("x")]).toContainEqual(new Error("x"));
+    expect([new Error("x")]).not.toContainEqual(new Error("y"));
   });
 
   test("supports negation", () => {

--- a/tests/built-ins/Goccia/expect/toHaveBeenCalledWith.js
+++ b/tests/built-ins/Goccia/expect/toHaveBeenCalledWith.js
@@ -38,6 +38,16 @@ describe("toHaveBeenCalledWith", () => {
     expect(fn).toHaveBeenCalledWith({ x: 1 });
   });
 
+  test("compares error arguments by identity", () => {
+    const fn = mock();
+    fn(new Error("boom"));
+
+    expect(fn).toHaveBeenCalledWith(new Error("boom"));
+    expect(fn).not.toHaveBeenCalledWith(new Error("other"));
+    expect(fn).not.toHaveBeenCalledWith(new TypeError("boom"));
+    expect(fn).not.toHaveBeenCalledWith({});
+  });
+
   test("matches any recorded call", () => {
     const fn = mock();
     fn("first");

--- a/tests/built-ins/Goccia/expect/toStrictEqual.js
+++ b/tests/built-ins/Goccia/expect/toStrictEqual.js
@@ -10,6 +10,8 @@ class Other {
   }
 }
 
+class CustomError extends Error {}
+
 describe("toStrictEqual", () => {
   test("compares plain values like toEqual", () => {
     expect({ a: 1, b: [2, 3] }).toStrictEqual({ a: 1, b: [2, 3] });
@@ -87,6 +89,36 @@ describe("toStrictEqual", () => {
     right.push(right);
 
     expect(left).toStrictEqual(right);
+  });
+
+  test("applies error identity without adding a class check", () => {
+    expect(new Error("a")).toStrictEqual(new Error("a"));
+    expect(new Error("a")).not.toStrictEqual(new Error("b"));
+    expect(new TypeError("m")).not.toStrictEqual(new Error("m"));
+    expect(new Error("a")).not.toStrictEqual({});
+
+    // Unlike plain objects, a subclass instance is not distinguished from a
+    // base Error: the name is what identifies an error.
+    expect(new CustomError("m")).toStrictEqual(new Error("m"));
+    expect(new CustomError("m")).toStrictEqual(new CustomError("m"));
+  });
+
+  test("compares the cause strictly too", () => {
+    expect(new Error("m", { cause: "c" })).toStrictEqual(
+      new Error("m", { cause: "c" }),
+    );
+    expect(new Error("m", { cause: "c" })).not.toStrictEqual(
+      new Error("m", { cause: "d" }),
+    );
+  });
+
+  test("keeps a present-but-undefined cause distinct", () => {
+    expect(new Error("m", { cause: undefined })).not.toStrictEqual(
+      new Error("m"),
+    );
+    expect(new Error("m")).not.toStrictEqual(
+      new Error("m", { cause: undefined }),
+    );
   });
 
   test("supports negation", () => {


### PR DESCRIPTION
## Summary

- Deep equality treated every Error as equal to every other Error and to plain objects (`expect(new Error('a')).toEqual({})` passed). Errors now compare by name, message, own enumerable properties, and `cause` — with bun 1.3.14 as the empirical oracle throughout — inherited by the whole matcher family (toEqual, toStrictEqual, toContainEqual, toMatchObject, toHaveBeenCalledWith, asymmetric matchers, Set/Map membership) via the shared comparison helper.
- Semantics, each probe-verified against bun: error-ness keyed on `[[ErrorData]]` alone (prototype chaining is neither necessary for subclasses nor sufficient, and would misclassify DOMException); errors never equal plain objects in either direction; subclasses key on `name`, so `toStrictEqual` adds no class check for errors; `cause: undefined` reads as absent to `toEqual`, distinct under `toStrictEqual`; name/message compared by raw value so user `toString`/getters never execute inside the matcher; cyclic cause chains terminate via the standard pair guard; `AggregateError.errors` deliberately not compared (bun's behavior — diverges from the Vitest docs, recorded).
- Known pre-existing divergences recorded, not fixed: DOMException equality (goccia's carries own enumerable name/message/code), and prototype-based strict class identity for non-instances.
- `toThrow(new Error(m))` remains intentionally message-only — pinned by the existing 19-test contract.

Layer 9 of the 0.11.0 adversarial-findings stack — extends the differential battery (battery D: 20 → 32 tests) and the harness still exits 0, which is the parity proof.

## Testing

- [x] Verified in end-to-end tests — full suite 12008/12008 in both modes; extended `toEqual.js`/`toStrictEqual.js` + battery D's new error block pass under goccia-interpreted, goccia-bytecode, and bun (78/78, 217 assertions under bun); differential harness exit 0, 0 divergences; `toThrow.js` 19/19 both modes
- [x] Updated documentation — `docs/testing-api.md` deep-equality section (Errors row, AggregateError and DOMException notes)
- [ ] Optional: native Pascal tests — n/a (shared-helper change exercised through the JS matcher suites per project convention)
- [ ] Optional: benchmarks — error gate is two boolean field reads per object pair

Review: fresh-context review with paired goccia/bun probes ran fix-first (detection arm, cause-undefined, stringification) — all findings resolved and probe cases pinned as regression tests in the second commit's amendments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
