### PR TITLE
fix(parser): bound the arrow return-type probe; hard-gate web-tooling outcomes

### DIFF
--- a/docs/adr/0090-web-tooling-goccia-benchmark-lane.md
+++ b/docs/adr/0090-web-tooling-goccia-benchmark-lane.md
@@ -42,10 +42,16 @@ uses a 25 MB managed-heap ceiling so bytecode memory-pressure collections run
 before a constrained CI host can terminate the process.
 
 The report is normalized JSON with one target entry per workload. A build
-failure, timeout, crash, OOM, or missing `runs/s` line is recorded as a
-first-class target outcome instead of failing the whole report. The job fails
-only when the driver cannot produce a structurally complete report for every
-manifest workload. CI runs one workload per matrix job, then validates and
+failure, timeout, crash, OOM, syntax error, or missing `runs/s` line is recorded
+as a first-class target outcome so the report stays structurally complete and
+diagnosable. Those outcomes also **gate the job**: `web-tooling-ci-report.js`
+exits nonzero when a workload's build outcome is not `ok` or when any sample
+outcome is not `ok`. Correctness regressions — a workload that stops parsing or
+running — therefore fail CI instead of being visible only in the PR comment.
+Performance stays non-gating: no `runs/s` threshold is enforced, and a workload
+that runs to completion passes however slow it is. The job also fails when the
+driver cannot produce a structurally complete report for every manifest
+workload. CI runs one workload per matrix job, then validates and
 merges those shards into one report. PR CI uploads the `web-tooling-report`
 artifact and posts a Goccia-only comment. Main CI uploads the same artifact and, when
 `BLOB_READ_WRITE_TOKEN` is configured, publishes the compressed report plus a

--- a/perf/web-tooling/manifest.json
+++ b/perf/web-tooling/manifest.json
@@ -54,6 +54,9 @@
       "terser",
       "typescript",
       "uglify-js"
-    ]
+    ],
+    "timeoutMsByWorkload": {
+      "babel": 600000
+    }
   }
 }

--- a/scripts/test-cli-parser.ts
+++ b/scripts/test-cli-parser.ts
@@ -1081,4 +1081,51 @@ console.log("Type alias skipping under ASI...");
   }
 }
 
+// -- Parenthesized ternary consequent in minified bundles -----------------------
+
+console.log("Parenthesized ternary consequent...");
+{
+  // Regression from the v8 web-tooling prettier bundle: `cond?(a):b` enters the
+  // speculative arrow-function probe as "parenthesized group followed by ':'".
+  // The probe scanned for a '=>' with no bound and latched onto an unrelated
+  // arrow later in the file, so the ternary was parsed as an arrow function and
+  // the conditional reported a missing ':'. These shapes need the web-tooling
+  // compatibility flags, so they cannot live in the JS suite.
+  const COMPAT = ["--compat-asi", "--compat-var", "--compat-function"];
+
+  const cases = [
+    {
+      desc: "ternary and a later arrow in the same statement list",
+      source: "var c=1,a=2,b=3;var x=c?(a):b;var f=v=>v;console.log(x,f(9));\n",
+      output: "2 9\n",
+    },
+    {
+      desc: "ternary inside a function body with a later arrow",
+      source:
+        "var c=1,a=2,b=3;function g(){var x=c?(a):b;return x}var f=v=>v;console.log(g(),f(9));\n",
+      output: "2 9\n",
+    },
+    {
+      desc: "both branches parenthesized with a later arrow",
+      source: "var c=0,a=2,b=3;var x=c?(a):(b);var f=v=>v;console.log(x,f(1));\n",
+      output: "3 1\n",
+    },
+    {
+      desc: "arrow return type annotations still parse",
+      source: "var f=(v: number): number => v*2;console.log(f(4));\n",
+      output: "8\n",
+    },
+  ] as const;
+
+  for (const { desc, source, output } of cases)
+    for (const modeArgs of [[] as string[], ["--mode=bytecode"]]) {
+      const label = modeArgs.length ? `${desc} (bytecode)` : desc;
+      const res = runLoaderJson(source, [...COMPAT, ...modeArgs]);
+      if (res.exitCode !== 0)
+        throw new Error(`${label}: should parse, got exit ${res.exitCode} ${JSON.stringify(res.json.error)}`);
+      if (normalizeLineEndings(res.json.output) !== output)
+        throw new Error(`${label}: expected ${JSON.stringify(output)}, got ${JSON.stringify(res.json.output)}`);
+    }
+}
+
 console.log("\nAll test-cli-parser.ts tests passed.");

--- a/scripts/test-web-tooling-driver.js
+++ b/scripts/test-web-tooling-driver.js
@@ -178,7 +178,7 @@ console.log('web-tooling-ci-report: validation...');
   assertEqual(workloadTimeoutMs(manifest.ciReport, 'acorn'), 300000, 'ci uses the five-minute workload timeout');
   assertEqual(workloadTimeoutMs(manifest.ciReport, 'coffeescript'), 900000, 'ci applies the CoffeeScript timeout override');
   assertEqual(workloadTimeoutMs(manifest.ciReport, 'postcss'), 3600000, 'ci applies the PostCSS timeout override');
-  validateReport({
+  const okReport = () => ({
     metadata: { driver: { version: 4 }, options: { repetitions: 1 } },
     summary: { workloadCount: 2 },
     targets: [
@@ -192,11 +192,72 @@ console.log('web-tooling-ci-report: validation...');
         kind: 'web-tooling',
         name: 'coffeescript',
         build: { outcome: 'ok' },
-        summary: { ok: 0, syntaxError: 1 },
+        summary: { ok: 1 },
       },
     ],
-  }, manifest);
-  assert(true, 'ci report validation accepts complete workload reports with recorded failures');
+  });
+
+  validateReport(okReport(), manifest);
+  assert(true, 'ci report validation accepts workload reports whose samples are all ok');
+
+  function assertRejects(mutate, expectedFragment, message) {
+    const report = okReport();
+    mutate(report);
+    let error = null;
+    try {
+      validateReport(report, manifest);
+    } catch (e) {
+      error = e;
+    }
+    assert(error !== null, `${message} (expected a throw)`);
+    assert(
+      String(error.message).includes(expectedFragment),
+      `${message} (expected message containing ${JSON.stringify(expectedFragment)}, got ${JSON.stringify(String(error?.message))})`,
+    );
+  }
+
+  // Outcome gating: any non-ok sample outcome must fail the job rather than
+  // being recorded and reported as a passing run.
+  assertRejects(
+    (report) => { report.targets[1].summary = { ok: 0, syntaxError: 1 }; },
+    'non-ok sample outcomes (syntaxError=1)',
+    'ci report validation rejects syntax-error samples',
+  );
+  assertRejects(
+    (report) => { report.targets[1].summary = { ok: 0, timeout: 1 }; },
+    'non-ok sample outcomes (timeout=1)',
+    'ci report validation rejects timeout samples',
+  );
+  assertRejects(
+    (report) => { report.targets[1].summary = { ok: 0, runtimeError: 1 }; },
+    'non-ok sample outcomes (runtimeError=1)',
+    'ci report validation rejects runtime-error samples',
+  );
+  assertRejects(
+    (report) => { report.targets[1].summary = { ok: 0, crash: 1 }; },
+    'non-ok sample outcomes (crash=1)',
+    'ci report validation rejects crash samples',
+  );
+  assertRejects(
+    (report) => { report.targets[1].summary = { ok: 0, oom: 1 }; },
+    'non-ok sample outcomes (oom=1)',
+    'ci report validation rejects oom samples',
+  );
+  assertRejects(
+    (report) => { report.targets[1].summary = { ok: 0, missingResult: 1 }; },
+    'non-ok sample outcomes (missingResult=1)',
+    'ci report validation rejects missing-result samples',
+  );
+  assertRejects(
+    (report) => { report.targets[1].build = { outcome: 'build-failed' }; },
+    'build outcome build-failed',
+    'ci report validation rejects failed builds',
+  );
+  assertRejects(
+    (report) => { report.targets[1].summary = { ok: 0 }; },
+    'expected 1 ok samples, report recorded 0',
+    'ci report validation rejects a workload with no ok samples',
+  );
 
   const shardMetadata = {
     driver: { version: 4 },

--- a/scripts/web-tooling-ci-report.js
+++ b/scripts/web-tooling-ci-report.js
@@ -72,6 +72,17 @@ function parsePositiveInteger(value, optionName) {
   return parsed;
 }
 
+// Sample outcome counters that must all be zero for a workload to pass. These
+// mirror the counters produced by summarizeSamples in web-tooling-driver.js.
+const NON_OK_SAMPLE_COUNTS = [
+  'timeout',
+  'crash',
+  'syntaxError',
+  'runtimeError',
+  'oom',
+  'missingResult',
+];
+
 function reportConfig(manifest) {
   return manifest.ciReport || {};
 }
@@ -114,9 +125,26 @@ function validateReport(report, manifest, expectedWorkloads = null) {
     if (target.kind !== 'web-tooling') failures.push(`${workload}: wrong kind ${target.kind}`);
     if (!target.build || typeof target.build.outcome !== 'string') {
       failures.push(`${workload}: missing build outcome`);
+    } else if (target.build.outcome !== 'ok') {
+      // Outcome gating: a workload that cannot be built or run is a hard
+      // failure, not a report footnote. Performance figures stay non-gating —
+      // nothing here looks at runs/s.
+      failures.push(`${workload}: build outcome ${target.build.outcome}`);
     }
     if (!target.summary || typeof target.summary.ok !== 'number') {
       failures.push(`${workload}: missing sample summary`);
+    } else {
+      const nonOk = NON_OK_SAMPLE_COUNTS
+        .filter((key) => Number(target.summary[key]) > 0)
+        .map((key) => `${key}=${target.summary[key]}`);
+      if (nonOk.length > 0) {
+        failures.push(`${workload}: non-ok sample outcomes (${nonOk.join(', ')})`);
+      }
+      if (target.summary.ok !== expectedRepetitions) {
+        failures.push(
+          `${workload}: expected ${expectedRepetitions} ok samples, report recorded ${target.summary.ok}`,
+        );
+      }
     }
   }
 

--- a/source/units/Goccia.Parser.pas
+++ b/source/units/Goccia.Parser.pas
@@ -406,6 +406,24 @@ uses
   Goccia.Scope.BindingMap,
   Goccia.Values.BigIntValue;
 
+// Terminators for the return-type annotation in the speculative arrow-function
+// probe (`(params) : Type => body`).
+//
+// The probe reaches this point for a plain parenthesized expression followed by
+// a colon too — which is exactly a ternary with a parenthesized consequent,
+// `cond ? (x) : y`. With only '=>' as a terminator the collector scanned past
+// the end of the statement looking for an arrow, found an unrelated one later
+// in the file, and concluded the ternary was an arrow function; the conditional
+// then reported a missing ':'. None of the tokens below can appear at depth 0
+// inside a real return type, so they bound the probe to its own expression:
+// ';' and ',' end the annotation, and ')' ']' '}' are unbalanced closers that
+// prove the scan has left the construct it started in. '?' and ':' are
+// deliberately absent so conditional return types still collect whole.
+const
+  ARROW_RETURN_TYPE_TERMINATORS: array[0..5] of TGocciaTokenType = (
+    gttArrow, gttSemicolon, gttComma,
+    gttRightParen, gttRightBracket, gttRightBrace);
+
 { TGocciaPrivateClassContext }
 
 constructor TGocciaPrivateClassContext.Create;
@@ -8156,7 +8174,7 @@ begin
         if CheckWithLexicalGoal(gttColon, glgInputElementDiv) then
         begin
           Advance;
-          CollectTypeAnnotation([gttArrow]);
+          CollectTypeAnnotation(ARROW_RETURN_TYPE_TERMINATORS);
         end;
         Result := CheckWithLexicalGoal(gttArrow, glgInputElementDiv);
         Exit;
@@ -8236,7 +8254,7 @@ begin
       if CheckWithLexicalGoal(gttColon, glgInputElementDiv) then
       begin
         Advance;
-        CollectTypeAnnotation([gttArrow]);
+        CollectTypeAnnotation(ARROW_RETURN_TYPE_TERMINATORS);
       end;
 
       Result := CheckWithLexicalGoal(gttArrow, glgInputElementDiv);

--- a/tests/language/expressions/conditional/parenthesized-consequent.js
+++ b/tests/language/expressions/conditional/parenthesized-consequent.js
@@ -1,0 +1,82 @@
+/*---
+description: A ternary whose consequent is parenthesized is not mistaken for an arrow function parameter list, even when an arrow appears later in the file
+features: [conditional, ternary]
+---*/
+
+// Regression: `cond ? (x) : y` reaches the speculative arrow-function probe as
+// "parenthesized group followed by ':'", the same shape as an arrow with a
+// return type. The probe used to scan for a '=>' with no bound, find an
+// unrelated arrow later in the file, and parse the ternary as an arrow — the
+// conditional then failed with "Expected ':' in conditional expression". Every
+// case here therefore needs at least one arrow somewhere after it, which the
+// surrounding test callbacks already provide.
+
+describe("parenthesized ternary consequent", () => {
+  test("parenthesized consequent with an identifier alternate", () => {
+    const c = true;
+    const a = 2;
+    const b = 3;
+
+    expect(c ? (a) : b).toBe(2);
+    expect(!c ? (a) : b).toBe(3);
+  });
+
+  test("parenthesized consequent inside a declaration", () => {
+    const flag = false;
+    const x = flag ? (1) : 2;
+
+    expect(x).toBe(2);
+  });
+
+  test("parenthesized consequent followed by a statement boundary", () => {
+    const flag = true;
+    const values = [];
+    values.push(flag ? (10) : 20);
+
+    expect(values[0]).toBe(10);
+  });
+
+  test("both branches parenthesized", () => {
+    const flag = false;
+
+    expect(flag ? (1) : (2)).toBe(2);
+  });
+
+  test("parenthesized consequent with a call alternate", () => {
+    const flag = false;
+    const fallback = () => 42;
+
+    expect(flag ? (1) : fallback()).toBe(42);
+  });
+
+  test("empty-paren-like shapes still parse", () => {
+    const flag = true;
+    const obj = { v: 5 };
+
+    expect(flag ? (obj).v : 0).toBe(5);
+    expect(flag ? (obj.v) : 0).toBe(5);
+  });
+
+  test("nested parenthesized consequents", () => {
+    const outer = true;
+    const inner = false;
+
+    expect(outer ? (inner ? (1) : 2) : 3).toBe(2);
+  });
+
+  test("arrow functions with return type annotations still parse", () => {
+    const typed = (v: number): number => v * 2;
+    const noParams = (): string => "ok";
+
+    expect(typed(4)).toBe(8);
+    expect(noParams()).toBe("ok");
+  });
+
+  test("arrow with a structured return type still parses", () => {
+    const make = (): { a: number } => ({ a: 1 });
+    const union = (flag: boolean): string | null => (flag ? "y" : null);
+
+    expect(make().a).toBe(1);
+    expect(union(true)).toBe("y");
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes the web-tooling prettier workload's syntax error (surfaced in the PR report comment; reproduced locally): a ternary with a parenthesized consequent — `cond ? (x) : y` — mis-parsed as an arrow function whenever a `=>` appeared anywhere later in the file. The `IsArrowFunction` probe took the ternary's `:` as a return-type annotation whose only terminator was `=>`, so it scanned across statements and latched onto an unrelated arrow. The unsoundness is pre-existing; the type-syntax layer's (correct) depth clamp removed the unbalanced-closer accident that had masked it — which is exactly why minified bundles started failing. Probe return-type collection now also terminates on `; , ) ] }` at depth 0 (none can appear inside a real return type; conditional return types still collect whole).
- Per user decision, web-tooling **outcome** failures now hard-fail CI: `validateReport` rejects failed builds, timeouts, crashes, syntax/runtime errors, OOM, and missing results — performance stays non-gating. The driver test pinning the old non-gating behavior is replaced with 8 rejection cases; ADR 0090's non-gating paragraph updated. No workflow YAML change needed (the report step's exit code already fails the job — verified, not assumed).
- babel gets an explicit `timeoutMsByWorkload: 600000`: at ~0.003 runs/s it needs ~330s/rep against a 300s default that was calibrated when timeouts were non-fatal. Documented calibration, not masking — still catches order-of-magnitude slowdowns. Measured on a saturated machine; real CI timing may allow tightening.

Stack #1083 layer. Bundle-verified: prettier (0.016 runs/s), typescript, acorn, and uglify-js all run `ok`; 13 of 18 workloads not individually re-measured locally.

## Testing

- [x] Verified in end-to-end tests — new `tests/language/expressions/conditional/parenthesized-consequent.js` (13 assertions, both modes) + a CLI-parser block for the minified compat-flag shapes; full suite 12,023/12,023 both modes; differential harness exit 0; driver tests 62 assertions
- [x] Updated documentation — ADR 0090 gating paragraph
- [ ] Optional: native Pascal tests — n/a (parser change exercised via JS/CLI per convention)
- [x] Optional: benchmark coverage — the hard gate itself now guards workload outcomes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
