### PR TITLE
fix(testing): count beforeAll/afterAll hook failures as failures

### DIFF
--- a/scripts/test-cli-apps.ts
+++ b/scripts/test-cli-apps.ts
@@ -3573,6 +3573,38 @@ for (const modeArgs of [[], ["--mode=bytecode"]]) {
       ].join("\n"),
       expected: { passed: 1, failed: 1, skipped: 2 },
     },
+    {
+      // A throwing beforeAll is a suite-setup failure, counted once for the
+      // suite rather than once per test. This engine still runs the suite's
+      // tests after the hook fails, so both tests below report their pass --
+      // bun instead skips them and reports only the hook failure. The
+      // ok/exit contract matches bun either way.
+      name: "a beforeAll hook throws",
+      source: [
+        'describe("suite", () => {',
+        '  beforeAll(() => { throw new Error("beforeAll exploded"); });',
+        '  test("t1", () => { expect(1).toBe(1); });',
+        '  test("t2", () => { expect(2).toBe(2); });',
+        "});",
+        "",
+      ].join("\n"),
+      expected: { passed: 2, failed: 1, skipped: 0 },
+    },
+    {
+      // A throwing afterAll is a teardown failure: the suite's tests have
+      // already run and keep their passes, and the hook adds one failure.
+      // This matches bun's counts exactly.
+      name: "an afterAll hook throws",
+      source: [
+        'describe("suite", () => {',
+        '  afterAll(() => { throw new Error("afterAll exploded"); });',
+        '  test("t1", () => { expect(1).toBe(1); });',
+        '  test("t2", () => { expect(2).toBe(2); });',
+        "});",
+        "",
+      ].join("\n"),
+      expected: { passed: 2, failed: 1, skipped: 0 },
+    },
   ];
 
   for (const scenario of scenarios) {
@@ -3657,6 +3689,59 @@ for (const modeArgs of [[], ["--mode=bytecode"]]) {
       const failedTests = json.files?.[0]?.failedTests;
       if (!Array.isArray(failedTests) || !failedTests.some((t: string) => t.includes('Describe "boom"')))
         throw new Error(`${label} should keep the describe error visible in failedTests, got: ${JSON.stringify(failedTests)}`);
+    } finally {
+      clean(tmp);
+    }
+  }
+
+  // The worker-merge path aggregates counts separately from the single-file
+  // path, so pin the hook-failure accounting there too: the file with the
+  // throwing beforeAll must flip its own ok and the top-level ok, while the
+  // clean sibling file stays ok and the merged `failed` carries the hook.
+  {
+    const label = `TestRunner --output=json --jobs (${modeLabel}) when a beforeAll hook throws`;
+    console.log(`TestRunner: --output=json counts a throwing beforeAll under --jobs (${modeLabel})...`);
+    const tmp = makeTmp();
+    try {
+      const bad = join(tmp, "test-hook-throws.js");
+      const good = join(tmp, "test-hook-clean.js");
+      writeFileSync(bad, [
+        'describe("suite", () => {',
+        '  beforeAll(() => { throw new Error("beforeAll exploded"); });',
+        '  test("t1", () => { expect(1).toBe(1); });',
+        "});",
+        "",
+      ].join("\n"));
+      writeFileSync(good, 'describe("clean", () => { test("passes", () => { expect(2).toBe(2); }); });\n');
+
+      const proc = Bun.spawnSync(
+        [resolve(TESTRUNNER), bad, good, "--jobs=2", "--no-progress", "--output=json", ...modeArgs],
+        { stdout: "pipe", stderr: "pipe" },
+      );
+      if (proc.exitCode === 0)
+        throw new Error(`${label} should exit non-zero because a beforeAll hook threw, got 0`);
+
+      const stdout = proc.stdout.toString();
+      let json: any;
+      try {
+        json = JSON.parse(stdout);
+      } catch {
+        throw new Error(`${label} should produce parseable JSON on stdout, got: ${stdout.slice(0, 200)}`);
+      }
+
+      if (json.ok !== false) throw new Error(`${label} ok should be false, got ${json.ok}`);
+      if (json.failed !== 1) throw new Error(`${label} merged failed should be 1, got ${json.failed}`);
+
+      const badResult = json.files?.find((f: any) => String(f.fileName).endsWith("test-hook-throws.js"));
+      const goodResult = json.files?.find((f: any) => String(f.fileName).endsWith("test-hook-clean.js"));
+      if (badResult?.ok !== false)
+        throw new Error(`${label} the hook-failing file should report ok=false, got ${badResult?.ok}`);
+      if (badResult?.failed !== 1)
+        throw new Error(`${label} the hook-failing file should report failed=1, got ${badResult?.failed}`);
+      if (!badResult?.failedTests?.some((t: string) => t.includes('Hook "beforeAll"')))
+        throw new Error(`${label} should keep the hook error visible in failedTests, got: ${JSON.stringify(badResult?.failedTests)}`);
+      if (goodResult?.ok !== true)
+        throw new Error(`${label} the clean sibling file should stay ok, got ${goodResult?.ok}`);
     } finally {
       clean(tmp);
     }

--- a/source/units/Goccia.Builtins.TestingLibrary.pas
+++ b/source/units/Goccia.Builtins.TestingLibrary.pas
@@ -3718,6 +3718,16 @@ begin
     begin
       AFailedTestDetails.Add('Hook "beforeAll" in suite "' + EffectiveSuiteName +
         '" failed');
+      { Count the hook failure. The detail string alone is invisible to
+        the runner: `failed` is published from this counter, and both the
+        envelope `ok` and the process exit code derive from `failed`
+        alone, so without the bump a failing beforeAll reported ok/exit 0
+        and CI missed it. bun books a failed suite hook as one synthetic
+        unnamed test failure, so a single pair here matches its counts.
+        Bumping TotalTests too keeps passed+failed+skipped consistent
+        with totalRunTests, as snapshot finalization errors do. }
+      Inc(FTestStats.TotalTests);
+      Inc(FTestStats.FailedTests);
       if AExitOnFirstFailure then
       begin
         AShouldStop := True;
@@ -3958,6 +3968,13 @@ begin
     begin
       AFailedTestDetails.Add('Hook "afterAll" in suite "' + EffectiveSuiteName +
         '" failed');
+      { Same accounting gap as the beforeAll hook above: without the
+        counter bump a failing afterAll left ok/exit 0. The suite's tests
+        have already run and keep their results -- only the teardown
+        failure is added, matching bun, which reports the suite's passes
+        plus one synthetic failure for the throwing hook. }
+      Inc(FTestStats.TotalTests);
+      Inc(FTestStats.FailedTests);
       if AExitOnFirstFailure then
         AShouldStop := True;
     end;


### PR DESCRIPTION
## Summary

- Failing `beforeAll`/`afterAll` hooks added a detail string to the failed-test list but never bumped the failure counters — the identical accounting gap as throwing describe callbacks (the layer below), at the two hook sites: the run reported `ok: true` and exited 0 to every CI consumer.
- Each detail-add now pairs with the counter bumps. Bun models a failed suite hook as one synthetic test failure, so the counts match bun exactly for `afterAll`; `ok` and exit semantics match bun in every case across 20 mode/aggregation combinations (single-file, nested, multi-file, `--jobs=2` worker merges, all output modes × both execution modes). `beforeEach`/`afterEach` were verified already correct against bun and are untouched.
- Documented divergence, deliberately not changed here: on a `beforeAll` failure bun skips the suite's tests while goccia still runs them — accounting only, control flow untouched. A follow-up layer implementing oracle-backed skip parity (Vitest + bun matrices) is already in flight and will update this layer's scenarios.

Stack #1083 layer; found during the describe-error accounting work.

## Testing

- [x] Verified in end-to-end tests — two hook scenarios folded into the CLI scenario loop + a `--jobs=2` worker-merge variant, both modes (6 cases); bun 1.3.14 contract matrix drove all semantics; full suite 12,014/12,014 both modes; differential harness exit 0; no JS test uses throwing hooks (grep-verified)
- [x] Updated documentation — n/a (matches the documented ok/exit contract)
- [ ] Optional: native Pascal tests — n/a (two paired counter insertions)
- [ ] Optional: benchmarks — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)
