### PR TITLE
feat(testing): Vitest-exact suite-error attribution and hook control flow

### DIFF
--- a/scripts/test-cli-apps.ts
+++ b/scripts/test-cli-apps.ts
@@ -3540,7 +3540,10 @@ for (const modeArgs of [[], ["--mode=bytecode"]]) {
   const scenarios: Array<{
     name: string;
     source: string;
-    expected: { passed: number; failed: number; skipped: number };
+    // suiteErrors: describe/hook failures. Vitest keeps these OUT of
+    // `failed` (affected tests report as skipped) and fails the file
+    // instead, so they are asserted separately. Defaults to 0.
+    expected: { passed: number; failed: number; skipped: number; suiteErrors?: number };
     // Reporter markers this shape can leak beyond the shared set below.
     extraMarkers?: string[];
   }> = [
@@ -3576,11 +3579,9 @@ for (const modeArgs of [[], ["--mode=bytecode"]]) {
       expected: { passed: 1, failed: 1, skipped: 2 },
     },
     {
-      // A throwing beforeAll is a suite-setup failure, counted once for the
-      // suite rather than once per test. This engine still runs the suite's
-      // tests after the hook fails, so both tests below report their pass --
-      // bun instead skips them and reports only the hook failure. The
-      // ok/exit contract matches bun either way.
+      // A throwing beforeAll aborts its suite: every test in it (and in
+      // any descendant suite) reports as SKIPPED, and the hook failure is
+      // a suite error rather than a failed test. Matches Vitest exactly.
       name: "a beforeAll hook throws",
       source: [
         'describe("suite", () => {',
@@ -3590,12 +3591,12 @@ for (const modeArgs of [[], ["--mode=bytecode"]]) {
         "});",
         "",
       ].join("\n"),
-      expected: { passed: 2, failed: 1, skipped: 0 },
+      expected: { passed: 0, failed: 0, skipped: 2, suiteErrors: 1 },
     },
     {
       // A throwing afterAll is a teardown failure: the suite's tests have
-      // already run and keep their passes, and the hook adds one failure.
-      // This matches bun's counts exactly.
+      // already run and keep their passes, so nothing is skipped and the
+      // hook is recorded as a suite error. Matches Vitest exactly.
       name: "an afterAll hook throws",
       source: [
         'describe("suite", () => {',
@@ -3605,21 +3606,56 @@ for (const modeArgs of [[], ["--mode=bytecode"]]) {
         "});",
         "",
       ].join("\n"),
-      expected: { passed: 2, failed: 1, skipped: 0 },
+      expected: { passed: 2, failed: 0, skipped: 0, suiteErrors: 1 },
     },
     {
-      // A describe callback that throws is a registration failure, not a test
-      // failure: the remaining describes still register and run, so the
-      // passing suite below still reports its pass. The error is counted as a
-      // failure so ok/exit reflect it -- bun exits non-zero here too, though
-      // it books the error in a separate `error` counter rather than `fail`.
+      // Scope check: a failed beforeAll skips the suite's own tests AND
+      // every test in its descendant suites -- the child's test never
+      // runs even though the child itself has no failing hook.
+      name: "a beforeAll hook throws in a suite with nested child suites",
+      source: [
+        'describe("parent", () => {',
+        '  beforeAll(() => { throw new Error("parent beforeAll exploded"); });',
+        '  test("direct", () => { expect(1).toBe(1); });',
+        '  describe("child", () => {',
+        '    test("nested", () => { expect(2).toBe(2); });',
+        "  });",
+        "});",
+        "",
+      ].join("\n"),
+      expected: { passed: 0, failed: 0, skipped: 2, suiteErrors: 1 },
+    },
+    {
+      // Scope check, other direction: an inner suite's failed beforeAll
+      // must NOT affect the outer suite's own tests or a sibling suite.
+      name: "a nested suite's beforeAll throws without affecting siblings",
+      source: [
+        'describe("outer", () => {',
+        '  test("outer-test", () => { expect(1).toBe(1); });',
+        '  describe("inner", () => {',
+        '    beforeAll(() => { throw new Error("inner beforeAll exploded"); });',
+        '    test("inner-test", () => { expect(2).toBe(2); });',
+        "  });",
+        '  describe("sibling", () => {',
+        '    test("sibling-test", () => { expect(3).toBe(3); });',
+        "  });",
+        "});",
+        "",
+      ].join("\n"),
+      expected: { passed: 2, failed: 0, skipped: 1, suiteErrors: 1 },
+    },
+    {
+      // A describe callback that throws is a registration failure, not a
+      // test failure: the remaining describes still register and run, so
+      // the passing suite below still reports its pass. Like Vitest, the
+      // error stays out of `failed` and fails the FILE via suiteErrors.
       name: "a describe block throws during registration",
       source: [
         'describe("boom", () => { throw new Error("registration exploded"); });',
         'describe("ok", () => { test("passes", () => { expect(1).toBe(1); }); });',
         "",
       ].join("\n"),
-      expected: { passed: 1, failed: 1, skipped: 0 },
+      expected: { passed: 1, failed: 0, skipped: 0, suiteErrors: 1 },
       extraMarkers: ["Error in describe block"],
     },
   ];
@@ -3659,9 +3695,15 @@ for (const modeArgs of [[], ["--mode=bytecode"]]) {
         throw new Error(`${label} failed should be ${scenario.expected.failed}, got ${json.failed}`);
       if (json.skipped !== scenario.expected.skipped)
         throw new Error(`${label} skipped should be ${scenario.expected.skipped}, got ${json.skipped}`);
+      const expectedSuiteErrors = scenario.expected.suiteErrors ?? 0;
+      if (json.suiteErrors !== expectedSuiteErrors)
+        throw new Error(`${label} suiteErrors should be ${expectedSuiteErrors}, got ${json.suiteErrors}`);
       const failedTests = json.files?.[0]?.failedTests;
-      if (!Array.isArray(failedTests) || failedTests.length !== scenario.expected.failed)
-        throw new Error(`${label} should report ${scenario.expected.failed} failedTests entries, got: ${JSON.stringify(failedTests)}`);
+      // failedTests stays the human-visible detail channel for BOTH
+      // failed tests and suite errors, so it carries one entry each.
+      const expectedDetails = scenario.expected.failed + expectedSuiteErrors;
+      if (!Array.isArray(failedTests) || failedTests.length !== expectedDetails)
+        throw new Error(`${label} should report ${expectedDetails} failedTests entries, got: ${JSON.stringify(failedTests)}`);
     } finally {
       clean(tmp);
     }
@@ -3701,19 +3743,56 @@ for (const modeArgs of [[], ["--mode=bytecode"]]) {
       }
 
       if (json.ok !== false) throw new Error(`${label} ok should be false, got ${json.ok}`);
-      if (json.failed !== 1) throw new Error(`${label} merged failed should be 1, got ${json.failed}`);
+      if (json.failed !== 0) throw new Error(`${label} merged failed should be 0, got ${json.failed}`);
+      if (json.suiteErrors !== 1) throw new Error(`${label} merged suiteErrors should be 1, got ${json.suiteErrors}`);
       if (json.passed !== 2) throw new Error(`${label} merged passed should be 2, got ${json.passed}`);
 
       const badResult = json.files?.find((f: any) => String(f.fileName).endsWith("test-describe-throws.js"));
       const goodResult = json.files?.find((f: any) => String(f.fileName).endsWith("test-describe-clean.js"));
       if (badResult?.ok !== false)
         throw new Error(`${label} the throwing file should report ok=false, got ${badResult?.ok}`);
-      if (badResult?.failed !== 1)
-        throw new Error(`${label} the throwing file should report failed=1, got ${badResult?.failed}`);
+      if (badResult?.suiteErrors !== 1)
+        throw new Error(`${label} the throwing file should report suiteErrors=1, got ${badResult?.suiteErrors}`);
       if (!badResult?.failedTests?.some((t: string) => t.includes('Describe "boom"')))
         throw new Error(`${label} should keep the describe error visible in failedTests, got: ${JSON.stringify(badResult?.failedTests)}`);
       if (goodResult?.ok !== true)
         throw new Error(`${label} the clean sibling file should stay ok, got ${goodResult?.ok}`);
+    } finally {
+      clean(tmp);
+    }
+  }
+
+  // Body-execution guard. A failed beforeEach produces IDENTICAL counts
+  // whether or not the body runs (the test fails either way), so counts
+  // cannot detect a regression here -- only the body's side effects can.
+  // Vitest and bun both skip the body; running it executes user code
+  // against a fixture the hook failed to build.
+  {
+    const label = `TestRunner (${modeLabel}) beforeEach failure skips the test body`;
+    console.log(`TestRunner: a failed beforeEach does not run the test body (${modeLabel})...`);
+    const tmp = makeTmp();
+    try {
+      const file = join(tmp, "test-beforeeach-body.js");
+      writeFileSync(file, [
+        'describe("suite", () => {',
+        '  beforeEach(() => { console.log("RAN:beforeEach"); throw new Error("beforeEach exploded"); });',
+        '  test("t1", () => { console.log("RAN:body1"); expect(1).toBe(1); });',
+        '  test("t2", () => { console.log("RAN:body2"); expect(2).toBe(2); });',
+        "});",
+        "",
+      ].join("\n"));
+
+      const proc = Bun.spawnSync(
+        [resolve(TESTRUNNER), file, "--no-progress", ...modeArgs],
+        { stdout: "pipe", stderr: "pipe" },
+      );
+      const all = proc.stdout.toString() + proc.stderr.toString();
+      if (!all.includes("RAN:beforeEach"))
+        throw new Error(`${label} should still run the beforeEach hook, got: ${all.slice(0, 300)}`);
+      if (all.includes("RAN:body1") || all.includes("RAN:body2"))
+        throw new Error(`${label} must NOT execute the test body after the hook failed, got: ${all.slice(0, 300)}`);
+      if (proc.exitCode === 0)
+        throw new Error(`${label} should exit non-zero, got 0`);
     } finally {
       clean(tmp);
     }
@@ -3755,14 +3834,18 @@ for (const modeArgs of [[], ["--mode=bytecode"]]) {
       }
 
       if (json.ok !== false) throw new Error(`${label} ok should be false, got ${json.ok}`);
-      if (json.failed !== 1) throw new Error(`${label} merged failed should be 1, got ${json.failed}`);
+      if (json.failed !== 0) throw new Error(`${label} merged failed should be 0, got ${json.failed}`);
+      if (json.suiteErrors !== 1) throw new Error(`${label} merged suiteErrors should be 1, got ${json.suiteErrors}`);
+      if (json.skipped !== 1) throw new Error(`${label} merged skipped should be 1, got ${json.skipped}`);
 
       const badResult = json.files?.find((f: any) => String(f.fileName).endsWith("test-hook-throws.js"));
       const goodResult = json.files?.find((f: any) => String(f.fileName).endsWith("test-hook-clean.js"));
       if (badResult?.ok !== false)
         throw new Error(`${label} the hook-failing file should report ok=false, got ${badResult?.ok}`);
-      if (badResult?.failed !== 1)
-        throw new Error(`${label} the hook-failing file should report failed=1, got ${badResult?.failed}`);
+      if (badResult?.suiteErrors !== 1)
+        throw new Error(`${label} the hook-failing file should report suiteErrors=1, got ${badResult?.suiteErrors}`);
+      if (badResult?.skipped !== 1)
+        throw new Error(`${label} the hook-failing file's test should report as skipped, got ${badResult?.skipped}`);
       if (!badResult?.failedTests?.some((t: string) => t.includes('Hook "beforeAll"')))
         throw new Error(`${label} should keep the hook error visible in failedTests, got: ${JSON.stringify(badResult?.failedTests)}`);
       if (goodResult?.ok !== true)

--- a/source/app/GocciaTestRunner.dpr
+++ b/source/app/GocciaTestRunner.dpr
@@ -74,6 +74,7 @@ type
     Passed: Double;
     Failed: Double;
     Skipped: Double;
+    SuiteErrors: Double;
     TotalRunTests: Double;
     Assertions: Double;
     Duration: Double;
@@ -105,6 +106,7 @@ type
     Passed: Double;
     Failed: Double;
     Skipped: Double;
+    SuiteErrors: Double;
     TotalTests: Double;
     LexTimeNanoseconds: Int64;
     ParseTimeNanoseconds: Int64;
@@ -239,6 +241,7 @@ begin
   Result.AssignProperty('passed', TGocciaNumberLiteralValue.ZeroValue);
   Result.AssignProperty('failed', TGocciaNumberLiteralValue.ZeroValue);
   Result.AssignProperty('skipped', TGocciaNumberLiteralValue.ZeroValue);
+  Result.AssignProperty('suiteErrors', TGocciaNumberLiteralValue.ZeroValue);
   Result.AssignProperty('assertions', TGocciaNumberLiteralValue.ZeroValue);
   Result.AssignProperty('duration', TGocciaNumberLiteralValue.ZeroValue);
   Result.AssignProperty('failedTests', TGocciaArrayValue.Create);
@@ -255,6 +258,8 @@ begin
     ATarget.AssignProperty('failed', AFileResult.GetProperty('failed'));
   if AFileResult.GetProperty('skipped').ToStringLiteral.Value <> 'undefined' then
     ATarget.AssignProperty('skipped', AFileResult.GetProperty('skipped'));
+  if AFileResult.GetProperty('suiteErrors').ToStringLiteral.Value <> 'undefined' then
+    ATarget.AssignProperty('suiteErrors', AFileResult.GetProperty('suiteErrors'));
   if AFileResult.GetProperty('assertions').ToStringLiteral.Value <> 'undefined' then
     ATarget.AssignProperty('assertions', AFileResult.GetProperty('assertions'));
   if AFileResult.GetProperty('duration').ToStringLiteral.Value <> 'undefined' then
@@ -1054,6 +1059,8 @@ begin
         FileResult.TestResult.GetProperty('failed').ToNumberLiteral.Value;
       Result.FileResults[0].Skipped :=
         FileResult.TestResult.GetProperty('skipped').ToNumberLiteral.Value;
+      Result.FileResults[0].SuiteErrors :=
+        FileResult.TestResult.GetProperty('suiteErrors').ToNumberLiteral.Value;
       Result.FileResults[0].TotalTests :=
         FileResult.TestResult.GetProperty('totalRunTests').ToNumberLiteral.Value;
       FileFailedTests := FileResult.TestResult.GetProperty('failedTests');
@@ -1103,6 +1110,7 @@ var
   FileResult: TAggregatedTestResult;
   FileFailedTests: TGocciaValue;
   PassedCount, FailedCount, SkippedCount, TotalRunCount, TotalAssertions, TotalDuration: Double;
+  SuiteErrorCount: Double;
 begin
   GC := TGarbageCollector.Instance;
 
@@ -1120,6 +1128,7 @@ begin
   AllTestResults.AssignProperty('passed', TGocciaNumberLiteralValue.ZeroValue);
   AllTestResults.AssignProperty('failed', TGocciaNumberLiteralValue.ZeroValue);
   AllTestResults.AssignProperty('skipped', TGocciaNumberLiteralValue.ZeroValue);
+  AllTestResults.AssignProperty('suiteErrors', TGocciaNumberLiteralValue.ZeroValue);
   AllTestResults.AssignProperty('assertions', TGocciaNumberLiteralValue.ZeroValue);
   AllTestResults.AssignProperty('duration', TGocciaNumberLiteralValue.ZeroValue);
   AllTestResults.AssignProperty('failedTests', AllFailedTests);
@@ -1127,6 +1136,7 @@ begin
   PassedCount := 0;
   FailedCount := 0;
   SkippedCount := 0;
+  SuiteErrorCount := 0;
   TotalRunCount := 0;
   TotalAssertions := 0;
   TotalDuration := 0;
@@ -1158,6 +1168,7 @@ begin
     PassedCount := PassedCount + FileResult.TestResult.GetProperty('passed').ToNumberLiteral.Value;
     FailedCount := FailedCount + FileResult.TestResult.GetProperty('failed').ToNumberLiteral.Value;
     SkippedCount := SkippedCount + FileResult.TestResult.GetProperty('skipped').ToNumberLiteral.Value;
+    SuiteErrorCount := SuiteErrorCount + FileResult.TestResult.GetProperty('suiteErrors').ToNumberLiteral.Value;
     TotalRunCount := TotalRunCount + FileResult.TestResult.GetProperty('totalRunTests').ToNumberLiteral.Value;
     TotalDuration := TotalDuration + FileResult.TestResult.GetProperty('duration').ToNumberLiteral.Value;
     TotalAssertions := TotalAssertions + FileResult.TestResult.GetProperty('assertions').ToNumberLiteral.Value;
@@ -1184,6 +1195,8 @@ begin
       FileResult.TestResult.GetProperty('failed').ToNumberLiteral.Value;
     Result.FileResults[ProcessedCount].Skipped :=
       FileResult.TestResult.GetProperty('skipped').ToNumberLiteral.Value;
+    Result.FileResults[ProcessedCount].SuiteErrors :=
+      FileResult.TestResult.GetProperty('suiteErrors').ToNumberLiteral.Value;
     Result.FileResults[ProcessedCount].TotalTests :=
       FileResult.TestResult.GetProperty('totalRunTests').ToNumberLiteral.Value;
     if Length(FileResult.FileResults) > 0 then
@@ -1217,6 +1230,7 @@ begin
   AllTestResults.AssignProperty('passed', TGocciaNumberLiteralValue.Create(PassedCount));
   AllTestResults.AssignProperty('failed', TGocciaNumberLiteralValue.Create(FailedCount));
   AllTestResults.AssignProperty('skipped', TGocciaNumberLiteralValue.Create(SkippedCount));
+  AllTestResults.AssignProperty('suiteErrors', TGocciaNumberLiteralValue.Create(SuiteErrorCount));
   AllTestResults.AssignProperty('totalRunTests', TGocciaNumberLiteralValue.Create(TotalRunCount));
   AllTestResults.AssignProperty('duration', TGocciaNumberLiteralValue.Create(TotalDuration));
   AllTestResults.AssignProperty('assertions', TGocciaNumberLiteralValue.Create(TotalAssertions));
@@ -1252,6 +1266,7 @@ begin
       WorkerResults^[AIndex].Passed := TestResult.GetProperty('passed').ToNumberLiteral.Value;
       WorkerResults^[AIndex].Failed := TestResult.GetProperty('failed').ToNumberLiteral.Value;
       WorkerResults^[AIndex].Skipped := TestResult.GetProperty('skipped').ToNumberLiteral.Value;
+      WorkerResults^[AIndex].SuiteErrors := TestResult.GetProperty('suiteErrors').ToNumberLiteral.Value;
       WorkerResults^[AIndex].TotalRunTests := TestResult.GetProperty('totalRunTests').ToNumberLiteral.Value;
       WorkerResults^[AIndex].Assertions := TestResult.GetProperty('assertions').ToNumberLiteral.Value;
       WorkerResults^[AIndex].Duration := TestResult.GetProperty('duration').ToNumberLiteral.Value;
@@ -1323,6 +1338,7 @@ var
   AllTestResults: TGocciaObjectValue;
   AllFailedTests: TGocciaArrayValue;
   PassedCount, FailedCount, SkippedCount, TotalRunCount, TotalAssertions: Double;
+  SuiteErrorCount: Double;
   WallClockStart, WallClockDuration: Int64;
   EffectiveTimeoutMs: Integer;
   WatchdogMs: Integer;
@@ -1481,6 +1497,7 @@ begin
   PassedCount := 0;
   FailedCount := 0;
   SkippedCount := 0;
+  SuiteErrorCount := 0;
   TotalRunCount := 0;
   TotalAssertions := 0;
   Result.TotalLexNanoseconds := 0;
@@ -1509,6 +1526,7 @@ begin
     PassedCount := PassedCount + Source^.Passed;
     FailedCount := FailedCount + Source^.Failed;
     SkippedCount := SkippedCount + Source^.Skipped;
+    SuiteErrorCount := SuiteErrorCount + Source^.SuiteErrors;
     TotalRunCount := TotalRunCount + Source^.TotalRunTests;
     TotalAssertions := TotalAssertions + Source^.Assertions;
 
@@ -1532,6 +1550,7 @@ begin
     Result.FileResults[I].Passed := Source^.Passed;
     Result.FileResults[I].Failed := Source^.Failed;
     Result.FileResults[I].Skipped := Source^.Skipped;
+    Result.FileResults[I].SuiteErrors := Source^.SuiteErrors;
     Result.FileResults[I].TotalTests := Source^.TotalRunTests;
     Result.FileResults[I].ErrorMessage := Source^.ErrorMessage;
     SetLength(Result.FileResults[I].FailedTests,
@@ -1545,6 +1564,7 @@ begin
   AllTestResults.AssignProperty('passed', TGocciaNumberLiteralValue.Create(PassedCount));
   AllTestResults.AssignProperty('failed', TGocciaNumberLiteralValue.Create(FailedCount));
   AllTestResults.AssignProperty('skipped', TGocciaNumberLiteralValue.Create(SkippedCount));
+  AllTestResults.AssignProperty('suiteErrors', TGocciaNumberLiteralValue.Create(SuiteErrorCount));
   AllTestResults.AssignProperty('duration', TGocciaNumberLiteralValue.Create(WallClockDuration));
   AllTestResults.AssignProperty('assertions', TGocciaNumberLiteralValue.Create(TotalAssertions));
   AllTestResults.AssignProperty('failedTests', AllFailedTests);
@@ -1571,6 +1591,11 @@ var
 begin
   IsBytecodeMode := EngineOptions.Mode.Matches(emBytecode);
   FailedCount := Round(AResult.TestResult.GetProperty('failed').ToNumberLiteral.Value);
+  { Suite-level errors never enter `failed` (Vitest keeps them out of the
+    test counts), so `ok` and the exit code must consult them separately
+    -- otherwise a file whose describe or beforeAll threw reports ok. }
+  FailedCount := FailedCount +
+    Round(AResult.TestResult.GetProperty('suiteErrors').ToNumberLiteral.Value);
   if IsBytecodeMode then
     TotalNanoseconds := AResult.TotalLexNanoseconds + AResult.TotalParseNanoseconds + AResult.TotalCompileNanoseconds + AResult.TotalExecNanoseconds
   else
@@ -1608,6 +1633,7 @@ begin
     Lines.Add(Format('  "passed": %d,', [Round(AResult.TestResult.GetProperty('passed').ToNumberLiteral.Value)]));
     Lines.Add(Format('  "failed": %d,', [Round(AResult.TestResult.GetProperty('failed').ToNumberLiteral.Value)]));
     Lines.Add(Format('  "skipped": %d,', [Round(AResult.TestResult.GetProperty('skipped').ToNumberLiteral.Value)]));
+    Lines.Add(Format('  "suiteErrors": %d,', [Round(AResult.TestResult.GetProperty('suiteErrors').ToNumberLiteral.Value)]));
     Lines.Add(Format('  "assertions": %d,', [Round(AResult.TestResult.GetProperty('assertions').ToNumberLiteral.Value)]));
     Lines.Add(Format('  "durationNanoseconds": %d,', [Round(AResult.TestResult.GetProperty('duration').ToNumberLiteral.Value)]));
     Lines.Add(Format('  "lexTimeNanoseconds": %d,', [AResult.TotalLexNanoseconds]));
@@ -1702,9 +1728,12 @@ begin
       end;
 
       Entry.Append('    {');
+      { A file is ok only when nothing failed AND no suite-level error
+        (throwing describe / beforeAll / afterAll) was recorded. Vitest
+        fails the FILE for those while leaving the test counts alone. }
       Entry.Append(BuildCLIFileBaseJSON(Fr.FileName,
-        (Fr.Failed = 0) and (Fr.ErrorMessage = ''), '', '', '', ErrorJSON,
-        Timing, '"memory":null', ACompact));
+        (Fr.Failed = 0) and (Fr.ErrorMessage = '') and (Fr.SuiteErrors = 0),
+        '', '', '', ErrorJSON, Timing, '"memory":null', ACompact));
       Entry.Append(', ');
       Entry.Append('"passed": ');
       Entry.Append(Round(Fr.Passed));
@@ -1712,6 +1741,8 @@ begin
       Entry.Append(Round(Fr.Failed));
       Entry.Append(', "skipped": ');
       Entry.Append(Round(Fr.Skipped));
+      Entry.Append(', "suiteErrors": ');
+      Entry.Append(Round(Fr.SuiteErrors));
       Entry.Append(', "totalTests": ');
       Entry.Append(Round(Fr.TotalTests));
       Entry.Append(', "errorMessage": "');
@@ -1829,7 +1860,11 @@ begin
       WriteResultsJSON(AResult, CurrentOutputFile, False);
   end;
 
-  if StrToFloat(TotalFailed) > 0 then
+  { Suite-level errors (throwing describe / beforeAll / afterAll) are
+    deliberately absent from `failed`, so the exit code consults them
+    alongside it -- same rule as the envelope `ok`. }
+  if (StrToFloat(TotalFailed) > 0) or
+    (TestResult.GetProperty('suiteErrors').ToNumberLiteral.Value > 0) then
     ExitCode := 1;
 end;
 

--- a/source/units/Goccia.Builtins.TestingLibrary.pas
+++ b/source/units/Goccia.Builtins.TestingLibrary.pas
@@ -168,9 +168,19 @@ type
       PassedTests: Integer;
       FailedTests: Integer;
       SkippedTests: Integer;
+      { Suite-level errors: a describe callback that threw during
+        registration, or a failed beforeAll/afterAll hook. Vitest keeps
+        these out of the test counts (the affected tests report as
+        skipped) and fails the FILE instead, so they are tracked apart
+        from FailedTests and surface as the `suiteErrors` field. }
+      SuiteErrors: Integer;
       CurrentSuiteName: string;
       CurrentTestName: string;
       CurrentTestHasFailures: Boolean;
+      { Message of the first failure recorded for the current test or
+        hook. Hook/describe detail strings surface it so the reported
+        payload keeps the error text both oracles print. }
+      CurrentFailureMessage: string;
       CurrentTestIsSkipped: Boolean;
       CurrentTestAssertionCount: Integer;  // Assertions in current test
       TotalAssertionCount: Integer;        // Total assertions across all tests
@@ -222,9 +232,13 @@ type
       const AHasFocusedEntries: Boolean): Boolean;
     function SuiteHasRunnableEntries(const ASuite: TGocciaTestSuite;
       const AHasFocusedEntries: Boolean): Boolean;
+    { ASetupFailed: an ancestor suite's beforeAll hook threw. Its tests
+      and every descendant's report as skipped, and neither beforeAll nor
+      afterAll runs for those descendants. }
     procedure ExecuteSuite(const ASuite: TGocciaTestSuite;
       const AHasFocusedEntries, AExitOnFirstFailure: Boolean;
-      const AFailedTestDetails: TStringList; var AShouldStop: Boolean);
+      const AFailedTestDetails: TStringList; var AShouldStop: Boolean;
+      const ASetupFailed: Boolean = False);
     function CountRegisteredTests(const ASuite: TGocciaTestSuite): Integer;
     procedure CollectSuiteNames(const ASuite: TGocciaTestSuite;
       const ANames: TStringList);
@@ -3504,6 +3518,52 @@ begin
       TGocciaTestSuite(ASuite.Entries[I]).ClearRegisteredContent;
 end;
 
+{ ': <message>' when there is one, otherwise ''. Keeps the detail
+  string readable when a hook failed without a usable payload. }
+function FormatHookFailureSuffix(const AMessage: string): string;
+begin
+  if AMessage = '' then
+    Result := ''
+  else
+    Result := ': ' + AMessage;
+end;
+
+{ Error objects render as an empty object literal through
+  FormatForDisplay because their data lives on non-enumerable own
+  properties, which loses exactly the text both oracles print. Prefer
+  'Name: message' when the value looks like an Error, and fall back to
+  the generic formatter otherwise. }
+function DescribeThrownValue(const AValue: TGocciaValue): string;
+var
+  NameValue, MessageValue: TGocciaValue;
+  NameText, MessageText: string;
+begin
+  Result := '';
+  if not Assigned(AValue) then
+    Exit;
+
+  if AValue is TGocciaObjectValue then
+  begin
+    NameValue := AValue.GetProperty('name');
+    MessageValue := AValue.GetProperty('message');
+    if Assigned(MessageValue) and not (MessageValue is TGocciaUndefinedLiteralValue) then
+    begin
+      MessageText := MessageValue.ToStringLiteral.Value;
+      NameText := '';
+      if Assigned(NameValue) and not (NameValue is TGocciaUndefinedLiteralValue) then
+        NameText := NameValue.ToStringLiteral.Value;
+      if (NameText <> '') and (MessageText <> '') then
+        Exit(NameText + ': ' + MessageText);
+      if MessageText <> '' then
+        Exit(MessageText);
+      if NameText <> '' then
+        Exit(NameText);
+    end;
+  end;
+
+  Result := FormatForDisplay(AValue);
+end;
+
 procedure TGocciaTestAssertions.BuildNestedRegistrations(
   const ASuite: TGocciaTestSuite; const AFailedTestDetails: TStringList);
 var
@@ -3543,20 +3603,22 @@ begin
             if not FSuppressOutput then
               WriteLn('Error in describe block "', ChildSuite.GetFullName,
                 '": ', E.Message);
-            AFailedTestDetails.Add('Describe "' + ChildSuite.GetFullName +
-              '": ' + E.Message);
-            { Count the registration failure, do not re-raise. Re-raising
+            { E.Message is empty for a thrown JS value; the payload lives
+              on TGocciaThrowValue.Value. }
+            if (E is TGocciaThrowValue) and Assigned(TGocciaThrowValue(E).Value) then
+              AFailedTestDetails.Add('Describe "' + ChildSuite.GetFullName +
+                '": ' + DescribeThrownValue(TGocciaThrowValue(E).Value))
+            else
+              AFailedTestDetails.Add('Describe "' + ChildSuite.GetFullName +
+                '": ' + E.Message);
+            { Record the registration failure, do not re-raise. Re-raising
               would discard every result already collected for this file;
-              the remaining describes still register and run. But the
-              detail string alone is invisible to the runner: `failed` is
-              published from this counter, and both the envelope `ok` and
-              the process exit code derive from `failed` alone. Without
-              the bump a file whose describe threw reports ok/exit 0 and
-              CI misses it. Bumping TotalTests too keeps
-              passed+failed+skipped consistent with totalRunTests, the
-              same pairing snapshot-finalization errors use below. }
-            Inc(FTestStats.TotalTests);
-            Inc(FTestStats.FailedTests);
+              the remaining describes still register and run. Vitest keeps
+              a suite-level error out of the test counts and fails the
+              FILE instead, so this counts as a suite error rather than a
+              failed test -- `suiteErrors` makes the file not-ok, which is
+              what drives the envelope `ok` and the exit code. }
+            Inc(FTestStats.SuiteErrors);
           end;
         end;
       finally
@@ -3690,7 +3752,8 @@ end;
 
 procedure TGocciaTestAssertions.ExecuteSuite(const ASuite: TGocciaTestSuite;
   const AHasFocusedEntries, AExitOnFirstFailure: Boolean;
-  const AFailedTestDetails: TStringList; var AShouldStop: Boolean);
+  const AFailedTestDetails: TStringList; var AShouldStop: Boolean;
+  const ASetupFailed: Boolean);
 var
   I: Integer;
   Entry: TGocciaRegisteredEntry;
@@ -3703,13 +3766,21 @@ var
   FailureRecorded: Boolean;
   EffectiveSuiteName: string;
   HookFailed: Boolean;
+  HookMessage: string;
   RunSuiteHooks: Boolean;
+  SetupFailed: Boolean;
 begin
+  { Inherited from an ancestor whose beforeAll threw; set below when this
+    suite's own beforeAll fails. }
+  SetupFailed := ASetupFailed;
   if AShouldStop then
     Exit;
 
   EffectiveSuiteName := ASuite.GetFullName;
-  RunSuiteHooks := not IsSuiteSkipped(ASuite) and
+  { ASetupFailed (not SetupFailed) gates both hooks: a suite whose own
+    beforeAll throws still runs its afterAll, but a descendant of a
+    failed suite runs neither. Both match Vitest. }
+  RunSuiteHooks := not ASetupFailed and not IsSuiteSkipped(ASuite) and
     SuiteHasRunnableEntries(ASuite, AHasFocusedEntries);
 
   { The per-describe deadline is no longer pushed here.  It now lives in
@@ -3725,21 +3796,18 @@ begin
     ResetCurrentTestState;
     RunCallbacks(ASuite.BeforeAllCallbacks);
     HookFailed := FTestStats.CurrentTestHasFailures;
+    HookMessage := FTestStats.CurrentFailureMessage;
     ResetCurrentTestState;
     if HookFailed then
     begin
       AFailedTestDetails.Add('Hook "beforeAll" in suite "' + EffectiveSuiteName +
-        '" failed');
-      { Count the hook failure. The detail string alone is invisible to
-        the runner: `failed` is published from this counter, and both the
-        envelope `ok` and the process exit code derive from `failed`
-        alone, so without the bump a failing beforeAll reported ok/exit 0
-        and CI missed it. bun books a failed suite hook as one synthetic
-        unnamed test failure, so a single pair here matches its counts.
-        Bumping TotalTests too keeps passed+failed+skipped consistent
-        with totalRunTests, as snapshot finalization errors do. }
-      Inc(FTestStats.TotalTests);
-      Inc(FTestStats.FailedTests);
+        '" failed' + FormatHookFailureSuffix(HookMessage));
+      { Record the hook failure as a suite error, not a failed test:
+        Vitest reports this suite's tests as SKIPPED with fail=0 and
+        fails the file instead. SetupFailed below carries that decision
+        into the entry loop and into descendant suites. }
+      Inc(FTestStats.SuiteErrors);
+      SetupFailed := True;
       if AExitOnFirstFailure then
       begin
         AShouldStop := True;
@@ -3757,7 +3825,7 @@ begin
     if Entry is TGocciaTestSuite then
     begin
       ExecuteSuite(TGocciaTestSuite(Entry), AHasFocusedEntries,
-        AExitOnFirstFailure, AFailedTestDetails, AShouldStop);
+        AExitOnFirstFailure, AFailedTestDetails, AShouldStop, SetupFailed);
       Continue;
     end;
 
@@ -3784,7 +3852,8 @@ begin
           WriteLn('    📝 ', TestCase.Name, ': TODO');
       end;
     end
-    else if TestCase.IsSkipped or IsSuiteSkipped(TestCase.ParentSuite) or
+    else if SetupFailed or TestCase.IsSkipped or
+      IsSuiteSkipped(TestCase.ParentSuite) or
       (AHasFocusedEntries and not IsTestSelected(TestCase, True)) then
     begin
       FTestStats.CurrentTestIsSkipped := True;
@@ -3821,7 +3890,16 @@ begin
           PushTimeoutScope(tsTest, GTestRunnerTestTimeoutMs);
           try
             try
-              if Assigned(TestCase.TestFunction) then
+              { A failed beforeEach leaves the fixture the body depends on
+                broken, so the body must not run -- Vitest and bun both
+                skip it and still fail the test. RunCallbacks routes a
+                throwing/rejecting hook through AssertionFailed, so this
+                flag is exactly "a beforeEach for this test failed". The
+                counts are unchanged; only the side effects of executing
+                a body against a broken fixture go away. }
+              if FTestStats.CurrentTestHasFailures then
+                TestResult := TGocciaUndefinedLiteralValue.UndefinedValue
+              else if Assigned(TestCase.TestFunction) then
                 TestResult := TestCase.TestFunction.Call(TestCase.TestArguments,
                   TGocciaUndefinedLiteralValue.UndefinedValue)
               else
@@ -3975,18 +4053,17 @@ begin
     ResetCurrentTestState;
     RunCallbacks(ASuite.AfterAllCallbacks);
     HookFailed := FTestStats.CurrentTestHasFailures;
+    HookMessage := FTestStats.CurrentFailureMessage;
     ResetCurrentTestState;
     if HookFailed then
     begin
       AFailedTestDetails.Add('Hook "afterAll" in suite "' + EffectiveSuiteName +
-        '" failed');
-      { Same accounting gap as the beforeAll hook above: without the
-        counter bump a failing afterAll left ok/exit 0. The suite's tests
-        have already run and keep their results -- only the teardown
-        failure is added, matching bun, which reports the suite's passes
-        plus one synthetic failure for the throwing hook. }
-      Inc(FTestStats.TotalTests);
-      Inc(FTestStats.FailedTests);
+        '" failed' + FormatHookFailureSuffix(HookMessage));
+      { Teardown failure: the suite's tests have already run and keep
+        their results, so nothing is skipped here. Like the beforeAll
+        hook, Vitest leaves this out of the test counts (fail=0) and
+        fails the file, which `suiteErrors` expresses. }
+      Inc(FTestStats.SuiteErrors);
       if AExitOnFirstFailure then
         AShouldStop := True;
     end;
@@ -4025,9 +4102,11 @@ begin
   FTestStats.PassedTests := 0;
   FTestStats.FailedTests := 0;
   FTestStats.SkippedTests := 0;
+  FTestStats.SuiteErrors := 0;
   FTestStats.CurrentSuiteName := '';
   FTestStats.CurrentTestName := '';
   FTestStats.CurrentTestHasFailures := False;
+  FTestStats.CurrentFailureMessage := '';
   FTestStats.CurrentTestIsSkipped := False;
   FTestStats.CurrentTestAssertionCount := 0;
   FTestStats.TotalAssertionCount := 0;
@@ -4062,7 +4141,7 @@ begin
               Promise := TGocciaPromiseValue(CallbackResult);
               WaitForFetchPromise(Promise);
               if Promise.State = gpsRejected then
-                AssertionFailed('callback execution', 'Async callback rejected: ' + FormatForDisplay(Promise.PromiseResult))
+                AssertionFailed('callback execution', 'Async callback rejected: ' + DescribeThrownValue(Promise.PromiseResult))
               else if Promise.State = gpsPending then
                 AssertionFailed('callback execution', 'Async callback Promise still pending after microtask drain');
             end
@@ -4080,6 +4159,12 @@ begin
             execution keep running past the limit. }
           on E: TGocciaTimeoutError do
             raise;
+          { A thrown JS value carries its payload on TGocciaThrowValue.Value;
+            E.Message is empty for it, which dropped the text both oracles
+            print. }
+          on E: TGocciaThrowValue do
+            AssertionFailed('callback execution',
+              'Callback threw an exception: ' + DescribeThrownValue(E.Value));
           on E: Exception do
             AssertionFailed('callback execution', 'Callback threw an exception: ' + E.Message);
         end;
@@ -4094,6 +4179,7 @@ procedure TGocciaTestAssertions.StartTest(const ATestName: string);
 begin
   FTestStats.CurrentTestName := ATestName;
   FTestStats.CurrentTestHasFailures := False;
+  FTestStats.CurrentFailureMessage := '';
   FTestStats.CurrentTestIsSkipped := False;
   FTestStats.CurrentTestAssertionCount := 0;
 end;
@@ -4116,6 +4202,7 @@ end;
 procedure TGocciaTestAssertions.ResetCurrentTestState;
 begin
   FTestStats.CurrentTestHasFailures := False;
+  FTestStats.CurrentFailureMessage := '';
   FTestStats.CurrentTestAssertionCount := 0;
 end;
 
@@ -4130,6 +4217,11 @@ begin
   Inc(FTestStats.CurrentTestAssertionCount);
   Inc(FTestStats.TotalAssertionCount);
   FTestStats.CurrentTestHasFailures := True;
+  { Keep the first message: later assertions in the same hook must not
+    overwrite the one that actually explains the failure. Recorded
+    before the suppress-output exit so JSON runs keep it too. }
+  if FTestStats.CurrentFailureMessage = '' then
+    FTestStats.CurrentFailureMessage := AMessage;
 
   if FSuppressOutput then
     Exit;
@@ -4702,6 +4794,8 @@ begin
       FTestStats.FailedTests));
     ResultObj.AssignProperty('skipped', TGocciaNumberLiteralValue.Create(
       FTestStats.SkippedTests));
+    ResultObj.AssignProperty('suiteErrors', TGocciaNumberLiteralValue.Create(
+      FTestStats.SuiteErrors));
     ResultObj.AssignProperty('assertions', TGocciaNumberLiteralValue.Create(
       FTestStats.TotalAssertionCount));
     ResultObj.AssignProperty('duration', TGocciaNumberLiteralValue.Create(


### PR DESCRIPTION
## Summary

- Implements Vitest-exact lifecycle semantics (user decision, Vitest 4.1.10 verified empirically alongside bun): a failed `beforeAll` — sync or async, any nesting level, file-level included — skips its suite and all descendants (siblings/outer tests unaffected); a failed `beforeEach` skips the test body (previously bodies ran against broken fixtures and reported green — invisible to counts, caught only by body-execution probes); `afterAll` still runs for the failing suite's own teardown.
- Attribution moves to Vitest's model: suite/hook errors never enter `failed` — they land in a new **additive** `suiteErrors` field (top-level + per-file), and `ok`/exit consult it. This reverts the bun-style synthetic-test attribution from the two layers below, as changes on top (those layers stay frozen). Hook error payloads now carry the thrown message (`Async callback rejected: Error: boom` instead of `{}`).
- 7 of 8 audit scenarios match Vitest exactly on counts *and* body execution, both modes. The eighth — Vitest aborting the entire file's collection when a describe body throws — is a structural collection change deferred to its own layer with evidence.
- Schema note (flagged): `suiteErrors` is additive; no existing field changes meaning. Names/messages stay in `failedTests` details (a `suiteErrors[]` array would duplicate them — deliberately left as a count).

Stack #1083 layer; spec came from the dual-oracle matrices (bun and Vitest agree on all control flow; attribution follows Vitest per the drop-in direction).

## Testing

- [x] Verified in end-to-end tests — 8 CLI scenarios incl. nested-child scope, sibling isolation, `--jobs` variants asserting `failed=0`/`suiteErrors=1`/skipped counts, and a body-execution stdout guard for beforeEach (counts alone can't catch it); aggregation sweep 12 combinations × both modes; full suite 12,023/12,023 both modes (0 skipped — no existing test hits the cascade); differential harness exit 0
- [x] Updated documentation — envelope field documented in the layer (testing-api.md rewrite lands with the audit's docs layer)
- [ ] Optional: native Pascal tests — n/a
- [ ] Optional: benchmarks — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)
