### PR TITLE
feat(testing): abort file collection when a describe callback throws

### DIFF
--- a/scripts/test-cli-apps.ts
+++ b/scripts/test-cli-apps.ts
@@ -3645,31 +3645,52 @@ for (const modeArgs of [[], ["--mode=bytecode"]]) {
       expected: { passed: 2, failed: 0, skipped: 1, suiteErrors: 1 },
     },
     {
-      // A describe callback that throws is a registration failure, not a
-      // test failure: the remaining describes still register and run, so
-      // the passing suite below still reports its pass. Like Vitest, the
-      // error stays out of `failed` and fails the FILE via suiteErrors.
+      // A describe callback that throws aborts collection for the WHOLE
+      // file, exactly as Vitest does: no test runs, not even in the
+      // passing suite below. Collection-time; hook and test failures are
+      // execution-time and leave collected results intact.
       name: "a describe block throws during registration",
       source: [
         'describe("boom", () => { throw new Error("registration exploded"); });',
         'describe("ok", () => { test("passes", () => { expect(1).toBe(1); }); });',
         "",
       ].join("\n"),
-      expected: { passed: 1, failed: 0, skipped: 0, suiteErrors: 1 },
+      expected: { passed: 0, failed: 0, skipped: 0, suiteErrors: 1 },
+      extraMarkers: ["Error in describe block"],
+    },
+    {
+      // The decisive collection-abort property: a suite collected BEFORE
+      // the throwing describe is discarded too, so its test never runs.
+      // Verified against Vitest, which reports zero tests for this shape.
+      name: "a describe block throws after an earlier suite was collected",
+      source: [
+        'describe("collected first", () => {',
+        '  test("earlier", () => { expect(1).toBe(1); });',
+        "});",
+        'describe("boom", () => { throw new Error("registration exploded"); });',
+        'describe("collected last", () => {',
+        '  test("later", () => { expect(2).toBe(2); });',
+        "});",
+        "",
+      ].join("\n"),
+      expected: { passed: 0, failed: 0, skipped: 0, suiteErrors: 1 },
       extraMarkers: ["Error in describe block"],
     },
   ];
 
+  // Both JSON shapes: compact-json shares the envelope's count fields but
+  // omits build/memory/stdout/stderr, so it needs its own coverage.
+  for (const outputFlag of ["--output=json", "--output=compact-json"]) {
   for (const scenario of scenarios) {
-    const label = `TestRunner --output=json (${modeLabel}) when ${scenario.name}`;
-    console.log(`TestRunner: --output=json keeps stdout clean when ${scenario.name} (${modeLabel})...`);
+    const label = `TestRunner ${outputFlag} (${modeLabel}) when ${scenario.name}`;
+    console.log(`TestRunner: ${outputFlag} keeps stdout clean when ${scenario.name} (${modeLabel})...`);
     const tmp = makeTmp();
     try {
       const file = join(tmp, "test-reporter-markers.js");
       writeFileSync(file, scenario.source);
 
       const proc = Bun.spawnSync(
-        [resolve(TESTRUNNER), file, "--no-progress", "--output=json", ...modeArgs],
+        [resolve(TESTRUNNER), file, "--no-progress", outputFlag, ...modeArgs],
         { stdout: "pipe", stderr: "pipe" },
       );
       if (proc.exitCode === 0)
@@ -3708,6 +3729,7 @@ for (const modeArgs of [[], ["--mode=bytecode"]]) {
       clean(tmp);
     }
   }
+  }
 
   // The worker-merge path aggregates counts differently from the single-file
   // path, so pin the describe-error accounting there too: the throwing file
@@ -3745,7 +3767,9 @@ for (const modeArgs of [[], ["--mode=bytecode"]]) {
       if (json.ok !== false) throw new Error(`${label} ok should be false, got ${json.ok}`);
       if (json.failed !== 0) throw new Error(`${label} merged failed should be 0, got ${json.failed}`);
       if (json.suiteErrors !== 1) throw new Error(`${label} merged suiteErrors should be 1, got ${json.suiteErrors}`);
-      if (json.passed !== 2) throw new Error(`${label} merged passed should be 2, got ${json.passed}`);
+      // Only the clean sibling contributes a pass: collection aborted for
+      // the throwing file, so its own passing suite never ran either.
+      if (json.passed !== 1) throw new Error(`${label} merged passed should be 1, got ${json.passed}`);
 
       const badResult = json.files?.find((f: any) => String(f.fileName).endsWith("test-describe-throws.js"));
       const goodResult = json.files?.find((f: any) => String(f.fileName).endsWith("test-describe-clean.js"));
@@ -3753,6 +3777,10 @@ for (const modeArgs of [[], ["--mode=bytecode"]]) {
         throw new Error(`${label} the throwing file should report ok=false, got ${badResult?.ok}`);
       if (badResult?.suiteErrors !== 1)
         throw new Error(`${label} the throwing file should report suiteErrors=1, got ${badResult?.suiteErrors}`);
+      if (badResult?.passed !== 0)
+        throw new Error(`${label} the throwing file should run no tests at all, got passed=${badResult?.passed}`);
+      if (goodResult?.passed !== 1)
+        throw new Error(`${label} the clean sibling file should keep its pass, got ${goodResult?.passed}`);
       if (!badResult?.failedTests?.some((t: string) => t.includes('Describe "boom"')))
         throw new Error(`${label} should keep the describe error visible in failedTests, got: ${JSON.stringify(badResult?.failedTests)}`);
       if (goodResult?.ok !== true)

--- a/source/units/Goccia.Builtins.TestingLibrary.pas
+++ b/source/units/Goccia.Builtins.TestingLibrary.pas
@@ -188,6 +188,12 @@ type
 
     FRootSuite: TGocciaTestSuite;
     FCurrentRegistrationSuite: TGocciaTestSuite;
+    { A describe callback threw while the file was being collected.
+      Vitest discards the WHOLE file in that case -- including suites
+      collected before the throwing one -- so registration stops and no
+      test runs. Distinct from a hook or test failure, which are
+      execution-time and leave already-collected results intact. }
+    FCollectionAborted: Boolean;
     FSkipNextDescribe: Boolean;
     FFocusNextDescribe: Boolean;
     FSkipNextTest: Boolean;
@@ -3574,6 +3580,10 @@ var
 begin
   for I := 0 to ASuite.Entries.Count - 1 do
   begin
+    { Collection died in an earlier describe: stop walking the tree. }
+    if FCollectionAborted then
+      Exit;
+
     Entry := ASuite.Entries[I];
     if not (Entry is TGocciaTestSuite) then
       Continue;
@@ -3611,14 +3621,16 @@ begin
             else
               AFailedTestDetails.Add('Describe "' + ChildSuite.GetFullName +
                 '": ' + E.Message);
-            { Record the registration failure, do not re-raise. Re-raising
-              would discard every result already collected for this file;
-              the remaining describes still register and run. Vitest keeps
-              a suite-level error out of the test counts and fails the
-              FILE instead, so this counts as a suite error rather than a
-              failed test -- `suiteErrors` makes the file not-ok, which is
-              what drives the envelope `ok` and the exit code. }
+            { A throw in a describe CALLBACK is a collection failure, and
+              Vitest discards the entire file for it: zero tests run, even
+              ones in suites collected before the throwing describe.
+              Registration stops here and RunTests skips execution
+              entirely. `suiteErrors` makes the file not-ok, which drives
+              the envelope `ok` and the exit code. Execution-time failures
+              (hooks, tests) keep their own accounting and do NOT abort
+              collection. }
             Inc(FTestStats.SuiteErrors);
+            FCollectionAborted := True;
           end;
         end;
       finally
@@ -4103,6 +4115,7 @@ begin
   FTestStats.FailedTests := 0;
   FTestStats.SkippedTests := 0;
   FTestStats.SuiteErrors := 0;
+  FCollectionAborted := False;
   FTestStats.CurrentSuiteName := '';
   FTestStats.CurrentTestName := '';
   FTestStats.CurrentTestHasFailures := False;
@@ -4731,8 +4744,11 @@ begin
 
     HasFocusedEntries := SuiteHasSelectedEntries(FRootSuite, True);
     ShouldStop := False;
-    ExecuteSuite(FRootSuite, HasFocusedEntries, ExitOnFirstFailure,
-      FailedTestDetails, ShouldStop);
+    { Collection aborted: the file is discarded whole, so nothing runs.
+      Counts stay at zero and `suiteErrors` carries the failure. }
+    if not FCollectionAborted then
+      ExecuteSuite(FRootSuite, HasFocusedEntries, ExitOnFirstFailure,
+        FailedTestDetails, ShouldStop);
 
     if Assigned(FSnapshotState) then
     begin


### PR DESCRIPTION
## Summary

- Completes the Vitest-exact lifecycle series: a describe callback that throws during collection now discards the **entire file** — including suites collected *before* the throwing one (probe-verified against Vitest 4.1.10: registrations run, zero tests do) — with the failure carried by `suiteErrors` + `totalTests=0` (unambiguous vs hook failures; zero new envelope fields), `ok=false`, exit 1, and only the throwing file affected in multi-file runs.
- The line drawn in code: describe-callback throws are collection-time and file-fatal; hook and test failures stay execution-time with collected results intact. The old "don't re-raise, it would discard results" comment is replaced — discarding is now precisely the contract, for this shape only.
- Also extends the CLI scenario loop with an output-mode dimension — every failure-shape scenario now runs under `--output=json` *and* `--output=compact-json` in both execution modes (36 runs), closing CodeRabbit's coverage gap on #1086.
- Noted divergence, deliberately untouched: a top-level throw outside any describe keeps the pre-existing load-error attribution (both engines fail the file; Vitest reports 0 tests where goccia reports the load failure as 1).

Stack #1083 layer; the piece scoped out of the attribution layer with evidence, now delivered.

## Testing

- [x] Verified in end-to-end tests — decisive before-the-throw probe pinned as a scenario; 12-combination aggregation sweep × both modes incl. `--jobs=2` isolation (throwing file dies, clean sibling passes); full suite 12,023/12,023 both modes; differential harness exit 0
- [x] Updated documentation — envelope semantics documented in-layer (testing-api.md rewrite lands with the harness/docs layer)
- [ ] Optional: native Pascal tests — n/a (34-line collection-flow change, JS/CLI surface primary)
- [ ] Optional: benchmarks — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)
