### PR TITLE
fix(testing): Vitest comparison parity across equality, Set/Map, and errors

### DIFF
--- a/source/units/Goccia.Builtins.TestingLibrary.pas
+++ b/source/units/Goccia.Builtins.TestingLibrary.pas
@@ -385,6 +385,7 @@ uses
   Goccia.Values.ErrorHelper,
   Goccia.Values.Formatting,
   Goccia.Values.HoleValue,
+  Goccia.Values.MapValue,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.PromiseValue,
   Goccia.Values.SetValue,
@@ -762,6 +763,45 @@ begin
     Result := ERROR_NAME;
 end;
 
+{ The subject the string and RegExp forms match against. Vitest reads the
+  thrown value's message, falling back to the thrown value itself only when it
+  is already a string; a thrown number, boolean or message-less object offers
+  no subject and matches nothing. A thrown null or undefined is the one shape
+  Vitest lets match anything. }
+type
+  TGocciaThrowSubject = (tsAnything, tsText, tsNothing);
+
+function ThrownMessageSubject(const AValue: TGocciaValue;
+  out AText: string): TGocciaThrowSubject;
+var
+  MessageValue: TGocciaValue;
+begin
+  AText := '';
+
+  if (AValue = nil) or (AValue is TGocciaUndefinedLiteralValue) or
+     (AValue is TGocciaNullLiteralValue) then
+    Exit(tsAnything);
+
+  if AValue is TGocciaObjectValue then
+  begin
+    MessageValue := TGocciaObjectValue(AValue).GetProperty(PROP_MESSAGE);
+    if MessageValue is TGocciaStringLiteralValue then
+    begin
+      AText := TGocciaStringLiteralValue(MessageValue).Value;
+      Exit(tsText);
+    end;
+    Exit(tsNothing);
+  end;
+
+  if AValue is TGocciaStringLiteralValue then
+  begin
+    AText := TGocciaStringLiteralValue(AValue).Value;
+    Exit(tsText);
+  end;
+
+  Result := tsNothing;
+end;
+
 { toThrow accepts a substring, a RegExp, an error constructor, an Error
   instance, or an asymmetric matcher. Anything else is a usage error. }
 function IsSupportedThrowExpectation(const AValue: TGocciaValue): Boolean;
@@ -792,6 +832,7 @@ function ThrownValueMatchesExpectation(const AThrownValue,
   AExpected: TGocciaValue): Boolean;
 var
   ExpectedSubstring: string;
+  Subject: string;
   MatchValue: TGocciaValue;
   MatchIndex: Integer;
   MatchEnd: Integer;
@@ -800,17 +841,25 @@ begin
   if AExpected is TGocciaAsymmetricMatcherValue then
     Exit(IsDeepEqual(AThrownValue, AExpected));
 
-  if AExpected is TGocciaStringLiteralValue then
+  if (AExpected is TGocciaStringLiteralValue) or
+     IsRegExpInstance(AExpected) then
   begin
-    ExpectedSubstring := TGocciaStringLiteralValue(AExpected).Value;
-    // Pos returns 0 for an empty needle, but every message contains one.
-    Exit((ExpectedSubstring = '') or
-      (Pos(ExpectedSubstring, ThrownValueMessage(AThrownValue)) > 0));
-  end;
+    case ThrownMessageSubject(AThrownValue, Subject) of
+      tsAnything: Exit(True);
+      tsNothing: Exit(False);
+    end;
 
-  if IsRegExpInstance(AExpected) then
-    Exit(MatchRegExpObject(AExpected, ThrownValueMessage(AThrownValue), 0,
-      False, False, MatchValue, MatchIndex, MatchEnd, NextIndex));
+    if IsRegExpInstance(AExpected) then
+      Exit(MatchRegExpObject(AExpected, Subject, 0, False, False, MatchValue,
+        MatchIndex, MatchEnd, NextIndex));
+
+    ExpectedSubstring := TGocciaStringLiteralValue(AExpected).Value;
+    { An empty expected string asserts an empty message rather than matching
+      everything, the way Vitest compiles it to /^$/. }
+    if ExpectedSubstring = '' then
+      Exit(Subject = '');
+    Exit(Pos(ExpectedSubstring, Subject) > 0);
+  end;
 
   // ES2026 §13.10.2 InstanceofOperator(value, target) — the same prototype
   // walk the instanceof operator uses, so `class Derived extends Error {}`
@@ -818,7 +867,10 @@ begin
   if AExpected.IsCallable then
     Exit(InstanceofOperatorResult(AThrownValue, AExpected));
 
-  Result := ThrownValueMessage(AThrownValue) = ThrownValueMessage(AExpected);
+  { An expected error instance is compared as a value: name, message, own
+    enumerable properties and an expected-side cause all participate, so a
+    TypeError never satisfies an expected plain Error. }
+  Result := IsDeepEqual(AThrownValue, AExpected);
 end;
 
 function FormatThrowValueDetail(const AValue: TGocciaValue): string;
@@ -1278,29 +1330,49 @@ function TGocciaExpectationValue.ToContainEqual(const AArgs: TGocciaArgumentsCol
 var
   Expected: TGocciaValue;
   I: Integer;
+  SetCursor: Integer;
+  SetItem: TGocciaValue;
   Contains: Boolean;
 begin
   TGocciaArgumentValidator.RequireExactly(AArgs, 1, 'toContainEqual', FTestAssertions.ThrowError);
 
-  if not (FActualValue is TGocciaArrayValue) then
+  if not ((FActualValue is TGocciaArrayValue) or
+     (FActualValue is TGocciaSetValue)) then
   begin
     if FIsNegated then
       TGocciaTestAssertions(FTestAssertions).AssertionPassed('toContainEqual')
     else
       TGocciaTestAssertions(FTestAssertions).AssertionFailed('toContainEqual',
-        'Expected an array but received ' + FormatForDisplay(FActualValue));
+        'Expected an array or a Set but received ' +
+        FormatForDisplay(FActualValue));
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
     Exit;
   end;
 
   Expected := AArgs.GetElement(0);
   Contains := False;
-  for I := 0 to TGocciaArrayValue(FActualValue).Elements.Count - 1 do
-    if IsDeepEqual(TGocciaArrayValue(FActualValue).Elements[I], Expected) then
-    begin
-      Contains := True;
-      Break;
+  if FActualValue is TGocciaSetValue then
+  begin
+    SetCursor := 0;
+    TGocciaSetValue(FActualValue).RetainIterator;
+    try
+      while TGocciaSetValue(FActualValue).NextItem(SetCursor, SetItem) do
+        if IsDeepEqual(SetItem, Expected) then
+        begin
+          Contains := True;
+          Break;
+        end;
+    finally
+      TGocciaSetValue(FActualValue).ReleaseIterator;
     end;
+  end
+  else
+    for I := 0 to TGocciaArrayValue(FActualValue).Elements.Count - 1 do
+      if IsDeepEqual(TGocciaArrayValue(FActualValue).Elements[I], Expected) then
+      begin
+        Contains := True;
+        Break;
+      end;
 
   if FIsNegated then
     Contains := not Contains;
@@ -1910,6 +1982,15 @@ begin
   if FActualValue is TGocciaArrayValue then
   begin
     HasLength := TGocciaArrayValue(FActualValue).Elements.Count = Expected.ToNumberLiteral.Value;
+  end
+  // A Set and a Map report their entry count as size rather than length.
+  else if FActualValue is TGocciaSetValue then
+  begin
+    HasLength := TGocciaSetValue(FActualValue).Count = Expected.ToNumberLiteral.Value;
+  end
+  else if FActualValue is TGocciaMapValue then
+  begin
+    HasLength := TGocciaMapValue(FActualValue).Count = Expected.ToNumberLiteral.Value;
   end
   else if FActualValue is TGocciaObjectValue then
   begin

--- a/source/units/Goccia.Evaluator.Comparison.pas
+++ b/source/units/Goccia.Evaluator.Comparison.pas
@@ -85,21 +85,35 @@ end;
   Class instances only match instances of the same class, and never a plain
   object; every non-class object — including a null-prototype object or one
   built with Object.create(proto) — counts as plain. }
-function HasSameObjectType(const AActual, AExpected: TGocciaValue): Boolean;
-var
-  ActualClass, ExpectedClass: TGocciaClassValue;
+{ Strict equality additionally requires the two objects to resolve to the same
+  constructor. Comparing the constructor the prototype chain yields — rather
+  than any class the engine attached, or the prototype object itself — is what
+  keeps Object.create(null) and Object.create(Array.prototype) apart from a
+  plain literal while still equating Object.create(somePlainObject) with one,
+  and what keeps two same-named anonymous classes distinct. }
+function HasSameObjectType(const AActual, AExpected: TGocciaObjectValue): Boolean;
 begin
-  if AActual is TGocciaInstanceValue then
-    ActualClass := TGocciaInstanceValue(AActual).ClassValue
-  else
-    ActualClass := nil;
+  Result := AActual.GetProperty(PROP_CONSTRUCTOR) =
+    AExpected.GetProperty(PROP_CONSTRUCTOR);
+end;
 
-  if AExpected is TGocciaInstanceValue then
-    ExpectedClass := TGocciaInstanceValue(AExpected).ClassValue
-  else
-    ExpectedClass := nil;
+{ An error's stack is incidental: two errors raised at different places are
+  still the same error to a matcher, so an own `stack` never participates. }
+function IsIgnoredErrorKey(const AKey: string;
+  const ABothErrors: Boolean): Boolean;
+begin
+  Result := ABothErrors and (AKey = PROP_STACK);
+end;
 
-  Result := ActualClass = ExpectedClass;
+function CountComparableKeys(const AKeys: TArray<string>;
+  const ABothErrors: Boolean): Integer;
+var
+  I: Integer;
+begin
+  Result := 0;
+  for I := 0 to High(AKeys) do
+    if not IsIgnoredErrorKey(AKeys[I], ABothErrors) then
+      Inc(Result);
 end;
 
 { Reads a property the comparison needs but the enumerable-key walk cannot
@@ -112,13 +126,6 @@ begin
   Result := AObject.GetProperty(AName);
   if Result = nil then
     Result := TGocciaUndefinedLiteralValue.UndefinedValue;
-end;
-
-{ An asymmetric matcher accepts a whole family of values, so it has to be
-  paired off after the exact members have claimed their partners. }
-function IsAsymmetricValue(const AValue: TGocciaValue): Boolean;
-begin
-  Result := AValue is TGocciaAsymmetricMatcherValue;
 end;
 
 { Exactly one side being an array, Set or Map makes the two values different
@@ -202,12 +209,9 @@ var
   ActualMembers, ExpectedMembers: TArray<TGocciaValue>;
   ActualMapKeys, ActualMapValues: TArray<TGocciaValue>;
   ExpectedMapKeys, ExpectedMapValues: TArray<TGocciaValue>;
-  Used: TArray<Boolean>;
-  Claimed: TArray<Boolean>;
-  Pass: Integer;
+  Matched: Boolean;
   BothErrors: Boolean;
   ActualIsError, ExpectedIsError: Boolean;
-  ActualHasCause, ExpectedHasCause: Boolean;
   TrialPairs: TComparedValuePairArray;
 begin
   // Vitest/Jest asymmetric matchers participate in every equality-based
@@ -287,11 +291,10 @@ begin
     ActualArr := TGocciaArrayValue(AActual);
     ExpectedArr := TGocciaArrayValue(AExpected);
 
-    { Strict equality preserves length and sparseness. Loose equality ignores
-      undefined items past the shorter length, so [2] equals [2, undefined],
-      while a differing item inside the common prefix still fails. }
-    if AStrict and
-       (ActualArr.Elements.Count <> ExpectedArr.Elements.Count) then
+    { Array equality is length-first for both matchers: [1] never equals
+      [1, undefined]. Only sparseness is forgiven loosely, and only at equal
+      length, where a hole reads as undefined. }
+    if ActualArr.Elements.Count <> ExpectedArr.Elements.Count then
     begin
       Result := False;
       Exit;
@@ -305,11 +308,7 @@ begin
     end;
     AddComparedPair(AComparedPairs, AActual, AExpected);
 
-    CommonCount := ActualArr.Elements.Count;
-    if ExpectedArr.Elements.Count < CommonCount then
-      CommonCount := ExpectedArr.Elements.Count;
-
-    for I := 0 to CommonCount - 1 do
+    for I := 0 to ActualArr.Elements.Count - 1 do
     begin
       LeftValue := ActualArr.Elements[I];
       RightValue := ExpectedArr.Elements[I];
@@ -344,20 +343,6 @@ begin
       end;
     end;
 
-    // Surplus items exist only under loose equality, and must be undefined.
-    for I := CommonCount to ActualArr.Elements.Count - 1 do
-      if not IsUndefinedLike(ActualArr.Elements[I]) then
-      begin
-        Result := False;
-        Exit;
-      end;
-    for I := CommonCount to ExpectedArr.Elements.Count - 1 do
-      if not IsUndefinedLike(ExpectedArr.Elements[I]) then
-      begin
-        Result := False;
-        Exit;
-      end;
-
     Result := True;
     Exit;
   end;
@@ -387,45 +372,32 @@ begin
       Exit;
     end;
 
-    { Two passes so a literal member is never stranded by a matcher that
-      claimed its partner first: pass 0 pairs off the plain members, pass 1
-      lets the asymmetric matchers take what is left. }
-    SetLength(Used, Length(ExpectedMembers));
-    SetLength(Claimed, Length(ActualMembers));
-    for Pass := 0 to 1 do
-      for I := 0 to High(ActualMembers) do
+    { Membership is existential, not a pairing: every actual member has to
+      deep-equal some expected member, and an expected member may match
+      several actual members or none at all. }
+    for I := 0 to High(ActualMembers) do
+    begin
+      Matched := False;
+      for J := 0 to High(ExpectedMembers) do
       begin
-        if Claimed[I] then
-          Continue;
-        if (Pass = 0) and IsAsymmetricValue(ActualMembers[I]) then
-          Continue;
-        for J := 0 to High(ExpectedMembers) do
+        { A rejected candidate must leave no trace: the pairs it recorded on
+          the way down would otherwise read as "already comparing" — and so
+          as equal — when a later member is compared against the same pair. }
+        CopyComparedPairs(AComparedPairs, TrialPairs);
+        if IsDeepEqualInternal(ActualMembers[I], ExpectedMembers[J],
+          TrialPairs, AStrict) then
         begin
-          if Used[J] then
-            Continue;
-          if (Pass = 0) and IsAsymmetricValue(ExpectedMembers[J]) then
-            Continue;
-          { A rejected candidate must leave no trace: the pairs it recorded on
-            the way down would otherwise read as "already comparing" — and so
-            as equal — when a later pass retries the same two members. }
-          CopyComparedPairs(AComparedPairs, TrialPairs);
-          if IsDeepEqualInternal(ActualMembers[I], ExpectedMembers[J],
-            TrialPairs, AStrict) then
-          begin
-            CopyComparedPairs(TrialPairs, AComparedPairs);
-            Used[J] := True;
-            Claimed[I] := True;
-            Break;
-          end;
+          CopyComparedPairs(TrialPairs, AComparedPairs);
+          Matched := True;
+          Break;
         end;
       end;
-
-    for I := 0 to High(ActualMembers) do
-      if not Claimed[I] then
+      if not Matched then
       begin
         Result := False;
         Exit;
       end;
+    end;
 
     Result := True;
     Exit;
@@ -456,46 +428,31 @@ begin
       Exit;
     end;
 
-    { Same two passes as Sets: an entry whose key or value is a matcher only
-      claims a partner once the exact entries have been paired off. }
-    SetLength(Used, Length(ExpectedMapKeys));
-    SetLength(Claimed, Length(ActualMapKeys));
-    for Pass := 0 to 1 do
-      for I := 0 to High(ActualMapKeys) do
+    { Same existential rule as Sets, over whole entries: an actual entry has
+      to find some expected entry matching on both key and value. }
+    for I := 0 to High(ActualMapKeys) do
+    begin
+      Matched := False;
+      for J := 0 to High(ExpectedMapKeys) do
       begin
-        if Claimed[I] then
-          Continue;
-        if (Pass = 0) and (IsAsymmetricValue(ActualMapKeys[I]) or
-           IsAsymmetricValue(ActualMapValues[I])) then
-          Continue;
-        for J := 0 to High(ExpectedMapKeys) do
+        // Same rejected-candidate isolation as the Set branch above.
+        CopyComparedPairs(AComparedPairs, TrialPairs);
+        if IsDeepEqualInternal(ActualMapKeys[I], ExpectedMapKeys[J],
+          TrialPairs, AStrict) and
+           IsDeepEqualInternal(ActualMapValues[I], ExpectedMapValues[J],
+          TrialPairs, AStrict) then
         begin
-          if Used[J] then
-            Continue;
-          if (Pass = 0) and (IsAsymmetricValue(ExpectedMapKeys[J]) or
-             IsAsymmetricValue(ExpectedMapValues[J])) then
-            Continue;
-          // Same rejected-candidate isolation as the Set branch above.
-          CopyComparedPairs(AComparedPairs, TrialPairs);
-          if IsDeepEqualInternal(ActualMapKeys[I], ExpectedMapKeys[J],
-            TrialPairs, AStrict) and
-             IsDeepEqualInternal(ActualMapValues[I], ExpectedMapValues[J],
-            TrialPairs, AStrict) then
-          begin
-            CopyComparedPairs(TrialPairs, AComparedPairs);
-            Used[J] := True;
-            Claimed[I] := True;
-            Break;
-          end;
+          CopyComparedPairs(TrialPairs, AComparedPairs);
+          Matched := True;
+          Break;
         end;
       end;
-
-    for I := 0 to High(ActualMapKeys) do
-      if not Claimed[I] then
+      if not Matched then
       begin
         Result := False;
         Exit;
       end;
+    end;
 
     Result := True;
     Exit;
@@ -521,11 +478,7 @@ begin
       Exit;
     end;
 
-    { The strict matcher's class check does not apply to errors: a
-      `class MyError extends Error` instance that leaves `name` alone is equal
-      to a plain Error with the same message under both matchers. }
-    if AStrict and not BothErrors and
-       not HasSameObjectType(AActual, AExpected) then
+    if AStrict and not HasSameObjectType(ActualObj, ExpectedObj) then
     begin
       Result := False;
       Exit;
@@ -538,7 +491,8 @@ begin
     { Only strict equality requires the key sets to match exactly. Loose
       equality ignores a key whose value is undefined when the other side
       does not have it at all, in either direction. }
-    if AStrict and (Length(ActualKeys) <> Length(ExpectedKeys)) then
+    if AStrict and (CountComparableKeys(ActualKeys, BothErrors) <>
+       CountComparableKeys(ExpectedKeys, BothErrors)) then
     begin
       Result := False;
       Exit;
@@ -550,9 +504,10 @@ begin
     end;
     AddComparedPair(AComparedPairs, AActual, AExpected);
 
-    { An error's identity is its name, message and cause, none of which the
-      enumerable-key walk below can see. Comparing them after the pair is
-      registered lets a chain that loops back on itself terminate. }
+    { An error's identity is its name, message, cause and aggregated errors,
+      none of which the enumerable-key walk below can see. Comparing them
+      after the pair is registered lets a chain that loops back on itself
+      terminate. }
     if BothErrors then
     begin
       if not IsDeepEqualInternal(ErrorFieldValue(ActualObj, PROP_NAME),
@@ -565,38 +520,41 @@ begin
         Exit;
       end;
 
-      ActualHasCause := ActualObj.HasOwnProperty(PROP_CAUSE);
-      ExpectedHasCause := ExpectedObj.HasOwnProperty(PROP_CAUSE);
-      if ActualHasCause <> ExpectedHasCause then
+      { Cause is expected-driven: it participates only when the expected error
+        carries a defined one, so an actual error may hold a cause the
+        expectation does not mention. }
+      if ExpectedObj.HasOwnProperty(PROP_CAUSE) and
+         not IsUndefinedLike(ErrorFieldValue(ExpectedObj, PROP_CAUSE)) then
       begin
-        { A cause that is present but undefined reads the same as no cause at
-          all to the loose matcher, exactly like any other undefined-valued
-          property. The strict matcher keeps them apart. }
-        if AStrict then
+        if not ActualObj.HasOwnProperty(PROP_CAUSE) then
         begin
           Result := False;
           Exit;
         end;
-        if ActualHasCause and
-           not IsUndefinedLike(ErrorFieldValue(ActualObj, PROP_CAUSE)) then
+        if not IsDeepEqualInternal(ErrorFieldValue(ActualObj, PROP_CAUSE),
+          ErrorFieldValue(ExpectedObj, PROP_CAUSE), AComparedPairs,
+          AStrict) then
         begin
           Result := False;
           Exit;
         end;
-        if ExpectedHasCause and
-           not IsUndefinedLike(ErrorFieldValue(ExpectedObj, PROP_CAUSE)) then
-        begin
-          Result := False;
-          Exit;
-        end;
-      end
-      else if ActualHasCause and
-         not IsDeepEqualInternal(ErrorFieldValue(ActualObj, PROP_CAUSE),
-           ErrorFieldValue(ExpectedObj, PROP_CAUSE), AComparedPairs,
-           AStrict) then
+      end;
+
+      // An AggregateError's collected errors participate the same way.
+      if ExpectedObj.HasOwnProperty(PROP_ERRORS) then
       begin
-        Result := False;
-        Exit;
+        if not ActualObj.HasOwnProperty(PROP_ERRORS) then
+        begin
+          Result := False;
+          Exit;
+        end;
+        if not IsDeepEqualInternal(ErrorFieldValue(ActualObj, PROP_ERRORS),
+          ErrorFieldValue(ExpectedObj, PROP_ERRORS), AComparedPairs,
+          AStrict) then
+        begin
+          Result := False;
+          Exit;
+        end;
       end;
     end;
 
@@ -604,6 +562,8 @@ begin
     for I := 0 to High(ActualKeys) do
     begin
       Key := ActualKeys[I];
+      if IsIgnoredErrorKey(Key, BothErrors) then
+        Continue;
 
       // Check if expected object has this key
       if not ExpectedObj.HasOwnProperty(Key) then
@@ -629,6 +589,8 @@ begin
     for I := 0 to High(ExpectedKeys) do
     begin
       Key := ExpectedKeys[I];
+      if IsIgnoredErrorKey(Key, BothErrors) then
+        Continue;
       if not ActualObj.HasOwnProperty(Key) then
         if AStrict or not IsUndefinedLike(ExpectedObj.GetProperty(Key)) then
         begin
@@ -671,10 +633,19 @@ var
   Key: string;
   LeftValue, RightValue: TGocciaValue;
 begin
-  CopyComparedPairs(AComparedPairs, DeepComparedPairs);
-  if IsDeepEqualInternal(AActual, AExpected, DeepComparedPairs, False) then
+  { Shapes the expectation cannot describe a subset of are compared in full:
+    an asymmetric matcher runs its own match, and an expected error, Set or
+    Map must equal the actual one outright rather than merely be contained
+    by it. An expected plain object keeps subset semantics even when the
+    actual value is one of these. }
+  if (AActual is TGocciaAsymmetricMatcherValue) or
+     (AExpected is TGocciaAsymmetricMatcherValue) or
+     IsErrorObject(AExpected) or (AExpected is TGocciaSetValue) or
+     (AExpected is TGocciaMapValue) then
   begin
-    Result := True;
+    CopyComparedPairs(AComparedPairs, DeepComparedPairs);
+    Result := IsDeepEqualInternal(AActual, AExpected, DeepComparedPairs,
+      False);
     Exit;
   end;
 
@@ -749,7 +720,9 @@ begin
     Exit;
   end;
 
-  Result := False;
+  // Primitives and everything else compare outright.
+  CopyComparedPairs(AComparedPairs, DeepComparedPairs);
+  Result := IsDeepEqualInternal(AActual, AExpected, DeepComparedPairs, False);
 end;
 
 function IsPartialDeepEqual(const AActual, AExpected: TGocciaValue): Boolean;

--- a/source/units/Goccia.Values.ErrorHelper.pas
+++ b/source/units/Goccia.Values.ErrorHelper.pas
@@ -15,8 +15,12 @@ function CreateErrorObject(const AName, AMessage: string; const ASkipTop: Intege
 
 { True when AValue carries [[ErrorData]] — the slot every error constructor
   installs, including through a `class MyError extends Error` subclass. Merely
-  inheriting from Error.prototype does not make an object an error, and
-  DOMException clears the slot on purpose. }
+  inheriting from Error.prototype does not make an object an error.
+
+  DOMException clears the slot on purpose, so it compares as an ordinary
+  object through its enumerable name/message/code. That is a deliberate,
+  project-level divergence from Vitest, which treats every DOMException as
+  equal to every other one regardless of name or message. }
 function IsErrorObject(const AValue: TGocciaValue): Boolean;
 
 { Creates a DOMException object with the standard legacy code for AName. }

--- a/tests/built-ins/Goccia/expect/toContain.js
+++ b/tests/built-ins/Goccia/expect/toContain.js
@@ -1,0 +1,22 @@
+describe("toContain", () => {
+  test("finds an array element by identity", () => {
+    expect([1, 2, 3]).toContain(2);
+    expect([1, 2, 3]).not.toContain(4);
+  });
+
+  test("finds a Set member", () => {
+    expect(new Set([1, 2])).toContain(1);
+    expect(new Set([1, 2])).not.toContain(3);
+  });
+
+  test("finds a substring", () => {
+    expect("GocciaScript").toContain("Script");
+    expect("GocciaScript").not.toContain("Vitest");
+  });
+
+  test("distinguishes -0 from 0", () => {
+    // Protected parity: goccia and vitest agree, bun does not.
+    expect([0]).toContain(-0);
+    expect([-0]).toContain(0);
+  });
+});

--- a/tests/built-ins/Goccia/expect/toEqual.js
+++ b/tests/built-ins/Goccia/expect/toEqual.js
@@ -45,11 +45,15 @@ describe("toEqual", () => {
     expect({ a: 1, b: null }).not.toEqual({ a: 1 });
   });
 
-  test("ignores undefined array items past the shorter length", () => {
-    expect([1, undefined]).toEqual([1]);
-    expect([2]).toEqual([2, undefined]);
-    expect([]).toEqual([undefined]);
-    expect([1, 2]).toEqual([1, 2, undefined, undefined]);
+  test("requires arrays to match in length", () => {
+    // Vitest compares arrays length-first: a trailing undefined is a real
+    // element, not padding.
+    expect([1, undefined]).not.toEqual([1]);
+    expect([2]).not.toEqual([2, undefined]);
+    expect([]).not.toEqual([undefined]);
+    expect([1, 2]).not.toEqual([1, 2, undefined, undefined]);
+    expect([[1, undefined]]).not.toEqual([[1]]);
+    expect([1, undefined]).toEqual([1, undefined]);
   });
 
   test("does not shift array items to absorb an undefined", () => {
@@ -125,17 +129,33 @@ describe("toEqual", () => {
     );
   });
 
-  test("requires every member to find its own partner", () => {
-    // bun accepts these because it never marks an expected member as claimed;
-    // requiring a distinct partner per member is the stricter reading.
-    expect(new Set([1, 2])).not.toEqual(new Set([expect.any(Number), 3]));
-    expect(new Set([{ a: 1 }, { a: 1 }])).not.toEqual(
+  test("scans membership existentially rather than pairing off", () => {
+    // Vitest is the oracle: sizes must match and every ACTUAL member must
+    // deep-equal SOME expected member, but an expected member may match
+    // several actual members or none at all.
+    expect(new Set([1, 2])).toEqual(new Set([expect.any(Number), 3]));
+    expect(new Set([1, 2])).toEqual(
+      new Set([expect.any(Number), expect.any(String)]),
+    );
+    expect(new Set([{ a: 1 }, { a: 1 }])).toEqual(
       new Set([{ a: 1 }, { b: 2 }]),
+    );
+
+    // An actual member matching nothing still fails, in either direction.
+    expect(new Set([{ a: 1 }, { b: 2 }])).not.toEqual(
+      new Set([{ a: 1 }, { a: 1 }]),
+    );
+    expect(new Set([1, "x"])).not.toEqual(new Set([expect.any(Number), 1]));
+    expect(new Map([[1, "x"], [2, "y"]])).not.toEqual(
+      new Map([[expect.any(Number), "x"], [3, "x"]]),
     );
   });
 
-  test("ignores a trailing hole", () => {
-    expect([1, ,]).toEqual([1]);
+  test("counts a trailing hole as an element", () => {
+    // [1, ,] has length 2, so it does not equal [1].
+    expect([1, ,]).not.toEqual([1]);
+    expect([1, ,]).toEqual([1, ,]);
+    expect([1, ,]).toEqual([1, undefined]);
   });
 
   test("handles cyclic arrays", () => {
@@ -209,14 +229,13 @@ describe("toEqual", () => {
     expect(renamed).not.toEqual(new Error("m"));
   });
 
-  test("compares the cause", () => {
+  test("compares the cause, driven by the expected side", () => {
     expect(new Error("m", { cause: "c" })).toEqual(
       new Error("m", { cause: "c" }),
     );
     expect(new Error("m", { cause: "c" })).not.toEqual(
       new Error("m", { cause: "d" }),
     );
-    expect(new Error("m", { cause: "c" })).not.toEqual(new Error("m"));
     expect(new Error("m")).not.toEqual(new Error("m", { cause: "c" }));
     expect(new Error("m", { cause: { a: 1 } })).toEqual(
       new Error("m", { cause: { a: 1 } }),
@@ -224,6 +243,9 @@ describe("toEqual", () => {
     expect(new Error("m", { cause: { a: 1 } })).not.toEqual(
       new Error("m", { cause: { a: 2 } }),
     );
+
+    // A cause the expectation does not mention is ignored.
+    expect(new Error("m", { cause: "c" })).toEqual(new Error("m"));
   });
 
   test("terminates on a cyclic cause chain", () => {
@@ -244,15 +266,31 @@ describe("toEqual", () => {
     expect(outerLeft).toEqual(outerRight);
   });
 
-  test("ignores AggregateError contents, matching bun", () => {
-    // bun compares neither `errors` nor `stack`; only name, message, cause
-    // and own enumerable properties participate.
+  test("compares AggregateError contents", () => {
     expect(new AggregateError([new Error("x")], "agg")).toEqual(
+      new AggregateError([new Error("x")], "agg"),
+    );
+    expect(new AggregateError([new Error("x")], "agg")).not.toEqual(
       new AggregateError([new Error("y")], "agg"),
     );
+    expect(
+      new AggregateError([new Error("x"), new Error("y")], "agg"),
+    ).not.toEqual(new AggregateError([new Error("x")], "agg"));
     expect(new AggregateError([new Error("x")], "agg")).not.toEqual(
       new AggregateError([new Error("x")], "other"),
     );
+  });
+
+  test("ignores stack entirely", () => {
+    const left = new Error("m");
+    left.stack = "one";
+    const right = new Error("m");
+    right.stack = "two";
+    expect(left).toEqual(right);
+
+    const restacked = new Error("m");
+    restacked.stack = "different";
+    expect(new Error("m")).toEqual(restacked);
   });
 
   test("keys error-ness on the error slot, not the prototype chain", () => {
@@ -267,6 +305,7 @@ describe("toEqual", () => {
   test("forgives a cause that is present but undefined", () => {
     expect(new Error("m", { cause: undefined })).toEqual(new Error("m"));
     expect(new Error("m")).toEqual(new Error("m", { cause: undefined }));
+    expect(new Error("m", { cause: undefined })).toStrictEqual(new Error("m"));
   });
 
   test("compares name by value rather than by its string form", () => {
@@ -309,17 +348,20 @@ describe("toEqual", () => {
     expect(
       new Error("m", { cause: new AggregateError([new Error("x")], "agg") }),
     ).toEqual(
-      new Error("m", { cause: new AggregateError([new Error("y")], "agg") }),
+      new Error("m", { cause: new AggregateError([new Error("x")], "agg") }),
     );
     expect(
-      new Error("m", { cause: new AggregateError([], "agg") }),
-    ).not.toEqual(new Error("m", { cause: new AggregateError([], "other") }));
+      new Error("m", { cause: new AggregateError([new Error("x")], "agg") }),
+    ).not.toEqual(
+      new Error("m", { cause: new AggregateError([new Error("y")], "agg") }),
+    );
   });
 
   test("distinguishes DOMExceptions by their enumerable fields", () => {
-    // Known divergence: a DOMException carries name/message/code as ordinary
-    // enumerable properties here, so the plain object walk separates them.
-    // bun equates DOMExceptions with differing messages. Pre-existing.
+    // Deliberate divergence from the Vitest oracle, decided by the project:
+    // a DOMException carries name/message/code as ordinary enumerable
+    // properties here, so the object walk separates them. Vitest equates all
+    // DOMExceptions regardless of name or message; goccia keeps them apart.
     expect(new DOMException("a", "AbortError")).toEqual(
       new DOMException("a", "AbortError"),
     );
@@ -343,6 +385,43 @@ describe("toEqual", () => {
     expect({ e: new Error("x") }).not.toEqual({ e: new Error("y") });
     expect([new Error("x")]).toContainEqual(new Error("x"));
     expect([new Error("x")]).not.toContainEqual(new Error("y"));
+  });
+
+  test("matches objectContaining against Map keys", () => {
+    // Protected parity: goccia and vitest agree here, bun does not.
+    expect(
+      new Map([
+        [{ a: 1 }, "v"],
+        [{ a: 1, b: 2 }, "w"],
+      ]),
+    ).toEqual(
+      new Map([
+        [expect.objectContaining({ a: 1 }), "v"],
+        [expect.objectContaining({ a: 1 }), "w"],
+      ]),
+    );
+  });
+
+  test("lets a throwing name getter propagate", () => {
+    // Protected parity with vitest: reading name runs the getter, so its
+    // error escapes the matcher rather than being swallowed. bun differs.
+    const thrower = new Error("m");
+    Object.defineProperty(thrower, "name", {
+      get: () => {
+        throw new Error("boom-getter");
+      },
+      configurable: true,
+    });
+
+    expect(() => expect(thrower).toEqual(new Error("m"))).toThrow(
+      "boom-getter",
+    );
+  });
+
+  test("finds Set members with toContainEqual", () => {
+    expect(new Set([{ a: 1 }])).toContainEqual({ a: 1 });
+    expect(new Set([1, 2])).toContainEqual(1);
+    expect(new Set([{ a: 1 }])).not.toContainEqual({ a: 2 });
   });
 
   test("supports negation", () => {

--- a/tests/built-ins/Goccia/expect/toHaveLength.js
+++ b/tests/built-ins/Goccia/expect/toHaveLength.js
@@ -1,0 +1,24 @@
+describe("toHaveLength", () => {
+  test("reads array length", () => {
+    expect([1, 2, 3]).toHaveLength(3);
+    expect([]).toHaveLength(0);
+    expect([1]).not.toHaveLength(2);
+  });
+
+  test("reads string length", () => {
+    expect("abc").toHaveLength(3);
+    expect("").toHaveLength(0);
+  });
+
+  test("reads size for a Set", () => {
+    expect(new Set([1, 2])).toHaveLength(2);
+    expect(new Set()).toHaveLength(0);
+    expect(new Set([1, 2])).not.toHaveLength(3);
+  });
+
+  test("reads size for a Map", () => {
+    expect(new Map([[1, 2]])).toHaveLength(1);
+    expect(new Map()).toHaveLength(0);
+    expect(new Map([[1, 2]])).not.toHaveLength(2);
+  });
+});

--- a/tests/built-ins/Goccia/expect/toHaveProperty.js
+++ b/tests/built-ins/Goccia/expect/toHaveProperty.js
@@ -46,6 +46,10 @@ describe("toHaveProperty", () => {
   });
 
   test("uses an array path as the escape hatch for dotted keys", () => {
+    // KNOWN DIVERGENCE (outside the audit corpus, pending a decision):
+    // Vitest falls back to the literal key when a dotted path does not
+    // resolve, so it finds {"a.b": 5} via the string path "a.b"; goccia
+    // always splits on dots.
     expect({ "a.b": 5 }).toHaveProperty(["a.b"], 5);
     expect({ "a.b": 5 }).not.toHaveProperty("a.b", 5);
   });
@@ -57,8 +61,8 @@ describe("toHaveProperty", () => {
   });
 
   test("does not walk through a nullish or missing value", () => {
-    // bun throws a TypeError out of the matcher here; reporting a plain
-    // assertion failure keeps .not usable.
+    // Protected parity with vitest, which reports a plain assertion failure
+    // here; bun instead throws a TypeError out of the matcher.
     expect({ a: null }).not.toHaveProperty("a.b");
     expect({ a: undefined }).not.toHaveProperty("a.b");
     expect({}).not.toHaveProperty("zz.b");
@@ -74,11 +78,27 @@ describe("toHaveProperty", () => {
     expect(new WithPrototypeMember()).toHaveProperty("describe");
   });
 
+  test("lets a throwing getter mid-path propagate", () => {
+    // Protected parity: goccia and vitest agree, bun does not.
+    const target = {};
+    Object.defineProperty(target, "a", {
+      get: () => {
+        throw new Error("getter-boom");
+      },
+      configurable: true,
+    });
+
+    expect(() => expect(target).toHaveProperty("a.b")).toThrow("getter-boom");
+  });
+
   test("supports the empty-string key", () => {
     expect({ "": 1 }).toHaveProperty("", 1);
   });
 
   test("treats a trailing separator as a real empty segment", () => {
+    // KNOWN DIVERGENCE (outside the audit corpus, pending a decision):
+    // Vitest ignores a trailing separator entirely — "a." resolves to "a" and
+    // never reaches an empty-string key.
     expect({ a: 1 }).not.toHaveProperty("a.");
     expect({ a: { b: 1 } }).not.toHaveProperty("a.");
     expect({ a: { "": 1 } }).toHaveProperty("a.", 1);
@@ -91,6 +111,8 @@ describe("toHaveProperty", () => {
   });
 
   test("requires a string or array path", () => {
+    // KNOWN DIVERGENCE (outside the audit corpus, pending a decision):
+    // Vitest accepts a numeric path argument rather than raising.
     expect(() => expect([1, 2]).toHaveProperty(0, 1)).toThrow();
     expect(() => expect({ a: 1 }).toHaveProperty(null)).toThrow();
   });

--- a/tests/built-ins/Goccia/expect/toMatchObject.js
+++ b/tests/built-ins/Goccia/expect/toMatchObject.js
@@ -64,6 +64,9 @@ describe("toMatchObject", () => {
   });
 
   test("handles cyclic values", () => {
+    // KNOWN DIVERGENCE for the cyclic ARRAY case (outside the audit corpus,
+    // pending a decision): vitest does not terminate on it. The cyclic Set,
+    // Map and object cases match vitest.
     const leftArray = [];
     leftArray.push(leftArray);
     const rightArray = [];
@@ -87,6 +90,31 @@ describe("toMatchObject", () => {
     const rightObject = {};
     rightObject.self = rightObject;
     expect(leftObject).toMatchObject(rightObject);
+  });
+
+  test("requires an expected undefined key to be present", () => {
+    // Vitest is the oracle: an expected key holding undefined still has to
+    // exist on the actual side.
+    expect({ a: 1 }).not.toMatchObject({ a: 1, b: undefined });
+    expect({ a: 1, b: undefined }).toMatchObject({ a: 1, b: undefined });
+  });
+
+  test("requires full equality for expected Sets and Maps", () => {
+    expect({ s: new Set([1, 2]) }).not.toMatchObject({ s: new Set([1]) });
+    expect({ s: new Set([1, 2]) }).toMatchObject({ s: new Set([2, 1]) });
+    expect({ m: new Map([["a", 1], ["b", 2]]) }).not.toMatchObject({
+      m: new Map([["a", 1]]),
+    });
+    expect({ m: new Map([["a", 1]]) }).toMatchObject({
+      m: new Map([["a", 1]]),
+    });
+  });
+
+  test("compares expected errors by their fields", () => {
+    expect({ e: new Error("x") }).toMatchObject({ e: new Error("x") });
+    expect({ e: new Error("x") }).not.toMatchObject({ e: new Error("y") });
+    // A plain expected object still describes a subset of the error.
+    expect({ e: new Error("x") }).toMatchObject({ e: {} });
   });
 
   test("supports negation", () => {

--- a/tests/built-ins/Goccia/expect/toStrictEqual.js
+++ b/tests/built-ins/Goccia/expect/toStrictEqual.js
@@ -55,11 +55,10 @@ describe("toStrictEqual", () => {
     expect(new Point(1)).not.toStrictEqual(new Point(2));
   });
 
-  test("treats every non-class object as plain", () => {
-    const nullPrototype = Object.create(null);
-    nullPrototype.x = 1;
-    expect(nullPrototype).toStrictEqual({ x: 1 });
-
+  test("keys the type check on the resolved constructor", () => {
+    // Vitest is the oracle here: an object whose prototype is an ordinary
+    // object still resolves to Object, so it stays strictly equal to a
+    // literal, while a null prototype or a built-in one does not.
     const shared = { marker: true };
     const left = Object.create(shared);
     left.x = 1;
@@ -67,7 +66,30 @@ describe("toStrictEqual", () => {
     right.x = 1;
     expect(left).toStrictEqual(right);
     expect(left).toStrictEqual({ x: 1 });
-    expect(new Point(1)).not.toStrictEqual(nullPrototype);
+
+    const nullPrototype = Object.create(null);
+    nullPrototype.x = 1;
+    expect(nullPrototype).not.toStrictEqual({ x: 1 });
+    expect(nullPrototype).toStrictEqual(Object.create(null, {
+      x: { value: 1, enumerable: true },
+    }));
+
+    const arrayPrototype = Object.create(Array.prototype);
+    expect(arrayPrototype).not.toStrictEqual({});
+
+    const pointPrototype = Object.create(Point.prototype);
+    pointPrototype.x = 1;
+    expect(pointPrototype).not.toStrictEqual({ x: 1 });
+    // Both resolve to Point, so they are strictly equal.
+    expect(new Point(1)).toStrictEqual(pointPrototype);
+  });
+
+  test("keeps same-named anonymous classes distinct", () => {
+    // Protected divergence: goccia and vitest agree, bun does not.
+    const First = class Same {};
+    const Second = class Same {};
+    expect(new First()).not.toStrictEqual(new Second());
+    expect(new First()).toEqual(new Second());
   });
 
   test("keeps Set and Map order-insensitive", () => {
@@ -91,15 +113,15 @@ describe("toStrictEqual", () => {
     expect(left).toStrictEqual(right);
   });
 
-  test("applies error identity without adding a class check", () => {
+  test("applies error identity and the constructor check", () => {
     expect(new Error("a")).toStrictEqual(new Error("a"));
     expect(new Error("a")).not.toStrictEqual(new Error("b"));
     expect(new TypeError("m")).not.toStrictEqual(new Error("m"));
     expect(new Error("a")).not.toStrictEqual({});
 
-    // Unlike plain objects, a subclass instance is not distinguished from a
-    // base Error: the name is what identifies an error.
-    expect(new CustomError("m")).toStrictEqual(new Error("m"));
+    // Vitest is the oracle: unlike toEqual, the strict matcher separates a
+    // subclass instance from a base Error even when name and message match.
+    expect(new CustomError("m")).not.toStrictEqual(new Error("m"));
     expect(new CustomError("m")).toStrictEqual(new CustomError("m"));
   });
 
@@ -112,13 +134,12 @@ describe("toStrictEqual", () => {
     );
   });
 
-  test("keeps a present-but-undefined cause distinct", () => {
-    expect(new Error("m", { cause: undefined })).not.toStrictEqual(
-      new Error("m"),
-    );
-    expect(new Error("m")).not.toStrictEqual(
-      new Error("m", { cause: undefined }),
-    );
+  test("reads cause from the expected side only", () => {
+    // An expected error without a cause does not constrain the actual one.
+    expect(new Error("m", { cause: undefined })).toStrictEqual(new Error("m"));
+    expect(new Error("m", { cause: "c" })).toStrictEqual(new Error("m"));
+    expect(new Error("m")).toStrictEqual(new Error("m", { cause: undefined }));
+    expect(new Error("m")).not.toStrictEqual(new Error("m", { cause: "c" }));
   });
 
   test("supports negation", () => {

--- a/tests/built-ins/Goccia/expect/toThrow.js
+++ b/tests/built-ins/Goccia/expect/toThrow.js
@@ -34,9 +34,16 @@ describe("toThrow", () => {
     expect(() => {
       throw new Error("full message here");
     }).not.toThrow("absent");
+  });
+
+  test("treats an empty string as an empty-message assertion", () => {
+    // Vitest compiles toThrow("") to /^$/ rather than a substring test.
+    expect(() => {
+      throw new Error("");
+    }).toThrow("");
     expect(() => {
       throw new Error("anything");
-    }).toThrow("");
+    }).not.toThrow("");
   });
 
   test("matches a regular expression against the message", () => {
@@ -97,7 +104,9 @@ describe("toThrow", () => {
     }).not.toThrow(Error);
   });
 
-  test("matches an error instance by equal messages", () => {
+  test("matches an error instance by error-aware deep equality", () => {
+    // Vitest is the oracle: an expected error instance is compared as a
+    // value, so name, own properties and an expected-side cause all count.
     expect(() => {
       throw new Error("exact text");
     }).toThrow(new Error("exact text"));
@@ -106,10 +115,32 @@ describe("toThrow", () => {
     }).not.toThrow(new Error("exact text"));
     expect(() => {
       throw new TypeError("same");
-    }).toThrow(new Error("same"));
+    }).not.toThrow(new Error("same"));
+
+    expect(() => {
+      const thrown = new Error("m");
+      thrown.code = "X";
+      throw thrown;
+    }).not.toThrow(new Error("m"));
+
+    expect(() => {
+      throw new Error("m", { cause: "c1" });
+    }).not.toThrow(new Error("m", { cause: "c2" }));
+    expect(() => {
+      throw new Error("m");
+    }).not.toThrow(new Error("m", { cause: "c" }));
+    // A cause the expectation does not mention is ignored.
+    expect(() => {
+      throw new Error("m", { cause: "c" });
+    }).toThrow(new Error("m"));
+
+    expect(() => {
+      throw { message: "boom" };
+    }).not.toThrow(new Error("boom"));
   });
 
-  test("matches thrown non-error values by their string form", () => {
+  test("reads the message subject the way Vitest does", () => {
+    // A thrown string is its own subject.
     expect(() => {
       throw "boom string";
     }).toThrow("boom");
@@ -119,15 +150,54 @@ describe("toThrow", () => {
     expect(() => {
       throw "boom string";
     }).not.toThrow(Error);
+
+    // A message-carrying object contributes its message.
+    expect(() => {
+      throw { message: "objmsg" };
+    }).toThrow("objmsg");
+    expect(() => {
+      throw { message: "" };
+    }).toThrow("");
+
+    // Anything else offers no subject, so the string and RegExp forms never
+    // match it — not even the empty string.
     expect(() => {
       throw 42;
-    }).toThrow("42");
+    }).not.toThrow("42");
     expect(() => {
       throw 42;
-    }).toThrow(/42/);
+    }).not.toThrow(/42/);
+    expect(() => {
+      throw 42;
+    }).not.toThrow("");
+    expect(() => {
+      throw true;
+    }).not.toThrow("true");
+    expect(() => {
+      throw { code: 1 };
+    }).not.toThrow("1");
+
+    // The no-argument form still sees the throw.
+    expect(() => {
+      throw 42;
+    }).toThrow();
+  });
+
+  test("lets a thrown nullish value match any message", () => {
+    // Replicates Vitest exactly: with nothing to read a message from, the
+    // string and RegExp forms impose no constraint. The class form still does.
     expect(() => {
       throw null;
-    }).toThrow("null");
+    }).toThrow("anything at all");
+    expect(() => {
+      throw null;
+    }).toThrow(/anything/);
+    expect(() => {
+      throw undefined;
+    }).toThrow("anything at all");
+    expect(() => {
+      throw null;
+    }).not.toThrow(Error);
   });
 
   test("reads the message property of thrown plain objects", () => {


### PR DESCRIPTION
## Summary

- Brings the comparison/matcher core to Vitest 4.1.10 parity, closing the drop-in audit's ledger: a 223-probe three-way corpus goes from **49 divergences to 3** — the remaining 3 being the deliberate, user-decided DOMException distinction (goccia alone distinguishes them; both oracles equate).
- Three chunks, each gated and oracle-verified: **comparison core** — array equality is length-first with no surplus-undefined forgiveness; strict type identity keys on the resolved constructor (empirically neither prototype identity nor class-instance identity: `Object.create({...})` is plain per the oracle). **Set/Map** — exclusive pairing replaced by Vitest's existential rule (sizes equal; every actual member matches some expected member; expected members reusable and unclaimed allowed). **Errors + toThrow + coverage** — `AggregateError.errors` participates (incl. nested in cause); expected-driven asymmetric `cause` with undefined-expected reading absent; own `stack` excluded; the strict constructor check applies to errors; `toMatchObject` applies full equality to expected errors/Sets/Maps while plain objects keep subset semantics; `toThrow(Error-instance)` is error-aware deep equality; `toThrow("")` asserts an empty message; thrown values follow Vitest's subject rule (replicating one probable Vitest bug — thrown `null`/`undefined` matches any string/regex — flagged in tests); `toHaveLength` reads `.size`; `toContainEqual` accepts Sets.
- Where goccia+Vitest agree and bun disagrees (nullish `toHaveProperty` paths, anonymous-class distinction, throwing name getters, and more), tests now name Vitest as oracle so the bun column can't claim regressions. Four small `toHaveProperty`-area divergences found while verifying are annotated in-file as known divergences for a follow-up.
- Battery D's five bun-semantics assertions are deliberately NOT edited here — the harness layer above owns the batteries and rewrites them to the vitest contract, going green exactly when stacked on this layer.

Stack #1083 layer; the divergence ledger, probe corpus, and machine-readable diff came from the three-way drop-in audit.

## Testing

- [x] Verified in end-to-end tests — probe corpus 220/223 matching Vitest (3 deliberate), interp and bytecode agreeing on all 223 at every chunk boundary; matcher test files updated incl. new toContain.js/toHaveLength.js; full suite 12,042/12,042 both modes; CLI harness green
- [x] Updated documentation — in-code oracle citations; the now-false testing-api.md claims are rewritten by the harness/docs layer above
- [ ] Optional: native Pascal tests — n/a (JS matcher surface primary)
- [ ] Optional: benchmarks — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)
