### PR TITLE
feat(testing): goccia:test module and default-on vitest compatibility shim

### DIFF
--- a/docs/differential-testing.md
+++ b/docs/differential-testing.md
@@ -52,15 +52,16 @@ oracle instead of inheriting a default.
 | `b-modules.test.js` | language | skip | gate |
 | `c-builtins.test.js` | language | skip | gate |
 | `d-matchers.test.js` | matcher | gate | advisory |
-| `e-mocks.goccia.test.js` | mocks | skip | skip |
+| `e-mocks.test.js` | mocks | gate | skip |
 | `f-lifecycle.test.js` | lifecycle | gate | advisory |
 | `g-filehook.test.js` | lifecycle | gate | advisory |
 
-`e-mocks.goccia.test.js` is compared between the two goccia modes only: it
-reaches for the `mock` and `spyOn` globals, which neither external runtime
-injects. Its upgrade to a three-way battery waits on the planned `goccia:test`
-module and shipped vitest-compat shim, which will let it import `vi` from a bare
-`vitest` specifier under every runtime.
+`e-mocks.test.js` imports `vi` from a bare `vitest` specifier, which Vitest
+resolves to itself and goccia resolves to its bundled compatibility shim, so the
+battery gates against Vitest across both goccia modes. Bun stays skipped: it
+injects its own `vi` under `bun:test`, but importing the real `vitest` package
+from a file run by `bun test` drops bun's injected globals and the file fails on
+`describe is not defined`, so there is no bun-runnable spelling of it.
 
 ## The three invariants
 
@@ -149,7 +150,8 @@ A battery that is handed to an external runtime uses only the
 `describe`/`test`/`expect` and hook globals that every runtime injects; a
 battery named `*.goccia.test.js` is the exception, because it deliberately
 reaches for goccia-only globals, and it is classified `skip` for both external
-runtimes. A `.test.ts` battery works under bun because bun transpiles TypeScript
+runtimes. A battery that needs the mocking API instead imports `vi` from
+`vitest`, which every runtime that can run it resolves for itself. A `.test.ts` battery works under bun because bun transpiles TypeScript
 natively while goccia parses annotations as types-as-comments.
 
 The pinned oracle lives in the same directory: `scripts/differential/package.json`

--- a/docs/testing-api.md
+++ b/docs/testing-api.md
@@ -40,6 +40,16 @@ describe("Feature Name", () => {
 
 Nested `describe` blocks compose their suite names with ` > ` separators. In the example above, the nested test's suite name would be `"Feature Name > sub-feature"`.
 
+### Importing the API
+
+`GocciaTestRunner` injects the whole testing API as globals, matching Vitest's `globals: true`, so a suite needs no imports. The same API is also importable from `goccia:test`, which is the canonical spelling in documentation and the only way to reach it outside the runner — an embedder that installs the testing extension gets the module, not the globals:
+
+```javascript
+import { describe, expect, mock, spyOn, test } from "goccia:test";
+```
+
+The module exports everything the globals do — `describe`, `test`, `it`, `expect`, `beforeAll`, `beforeEach`, `afterEach`, `afterAll`, `onTestFinished`, `mock`, and `spyOn` — and the imported `test` and `describe` carry their modifiers (`.each`, `.skip`, `.only`, `.todo`). Both spellings drive the same registry, so a mock created through the import is assertable through the global `expect` and the other way round.
+
 ### Available Assertions
 
 ```javascript
@@ -465,6 +475,20 @@ npx vitest                        # Watch mode
 ```
 
 Running `tests/` under Vitest needs a local Vitest install and a config that points at those files; the repository pins its own Vitest only for the differential battery lane, under `scripts/differential/`.
+
+### The `vitest` compatibility shim
+
+A suite written against Vitest imports from a bare `vitest` specifier, which would otherwise resolve to nothing. `GocciaTestRunner` ships a small shim inside the binary and resolves that specifier to it by default, so such a suite runs unchanged. Pass `--no-vitest-compat` to leave the specifier unresolvable.
+
+The shim re-exports `goccia:test` and adds the `vi` namespace. `vi` exists only in the shim — the engine itself never grows one:
+
+| Member | Behavior |
+|---|---|
+| `vi.fn` | The engine's `mock` |
+| `vi.spyOn` | The engine's `spyOn` |
+| everything else | Throws, naming the member and why it cannot be honored |
+
+Nothing is a silent no-op. `vi.mock` and the rest of the module-mocking family throw because the engine resolves every import once, at load time, and keeps no module registry to intercept. The fake-timer family throws because there is no fake clock — timers run on the real event loop. `vi.stubGlobal` and `vi.stubEnv` throw because globals are not snapshotted, so a stub could not be unwound safely. `vi.clearAllMocks`, `vi.resetAllMocks`, and `vi.restoreAllMocks` throw because no registry of created mocks exists; call `mockClear`, `mockReset`, or `mockRestore` on the mock itself.
 
 ### Writing Cross-Compatible Tests
 

--- a/scripts/differential/e-mocks.test.js
+++ b/scripts/differential/e-mocks.test.js
@@ -1,31 +1,33 @@
+import { vi } from "vitest";
+
 describe("mock semantics (vitest-documented behavior)", () => {
   test("mockResolvedValueOnce ordering with mockResolvedValue", async () => {
-    const m = mock();
+    const m = vi.fn();
     m.mockResolvedValue("base").mockResolvedValueOnce("first").mockResolvedValueOnce("second");
     expect(await m()).toBe("first");
     expect(await m()).toBe("second");
     expect(await m()).toBe("base");
   });
   test("mockRejectedValue produces rejection", async () => {
-    const m = mock();
+    const m = vi.fn();
     m.mockRejectedValue(new Error("nope"));
     await expect(m()).rejects.toThrow(/nope/);
   });
   test("mixing sync Once with resolved base", async () => {
-    const m = mock();
+    const m = vi.fn();
     m.mockResolvedValue("async").mockReturnValueOnce("sync");
     expect(m()).toBe("sync");
     expect(await m()).toBe("async");
   });
   test("spy restore chain", () => {
     const o = { f: () => "orig" };
-    const s = spyOn(o, "f").mockImplementation(() => "fake");
+    const s = vi.spyOn(o, "f").mockImplementation(() => "fake");
     expect(o.f()).toBe("fake");
     s.mockRestore();
     expect(o.f()).toBe("orig");
   });
   test("asymmetric matcher inside toHaveBeenCalledWith", () => {
-    const m = mock();
+    const m = vi.fn();
     m({ id: "abc", n: 7 });
     expect(m).toHaveBeenCalledWith(expect.objectContaining({ id: expect.any(String) }));
   });

--- a/scripts/test-cli-apps.ts
+++ b/scripts/test-cli-apps.ts
@@ -6739,4 +6739,47 @@ for (const app of [
     throw new Error(`${app.name} should not advertise the stdin rule:\n${help}`);
 }
 
+console.log("TestRunner: vitest compatibility shim and its off-switch...");
+{
+  const tmp = makeTmp();
+  try {
+    const suitePath = join(tmp, "vitest-import.test.js");
+    writeFileSync(
+      suitePath,
+      [
+        'import { vi } from "vitest";',
+        'test("vi.fn is available", () => {',
+        "  const fn = vi.fn();",
+        "  fn(1);",
+        "  expect(fn).toHaveBeenCalledWith(1);",
+        "});",
+        "",
+      ].join("\n"),
+    );
+
+    const enabled = Bun.spawnSync([TESTRUNNER, suitePath, "--no-progress"]);
+    const enabledOutput = new TextDecoder().decode(enabled.stdout);
+    if (!enabledOutput.includes("Passed: 1"))
+      throw new Error(
+        `TestRunner should resolve the bare vitest specifier by default:\n${enabledOutput}`,
+      );
+
+    const disabled = Bun.spawnSync([
+      TESTRUNNER,
+      suitePath,
+      "--no-progress",
+      "--no-vitest-compat",
+    ]);
+    const disabledOutput =
+      new TextDecoder().decode(disabled.stdout) +
+      new TextDecoder().decode(disabled.stderr);
+    if (!disabledOutput.includes('Cannot resolve bare module specifier "vitest"'))
+      throw new Error(
+        `--no-vitest-compat should leave the vitest specifier unresolvable:\n${disabledOutput}`,
+      );
+  } finally {
+    clean(tmp);
+  }
+}
+
 console.log("\nAll test-cli-apps.ts tests passed.");

--- a/scripts/test-cli-differential.ts
+++ b/scripts/test-cli-differential.ts
@@ -83,11 +83,13 @@ const CLASSIFICATION: Record<string, Classification> = {
   "b-modules.test.js": { kind: "language", bun: "gate", vitest: "skip" },
   "c-builtins.test.js": { kind: "language", bun: "gate", vitest: "skip" },
   "d-matchers.test.js": { kind: "matcher", bun: "advisory", vitest: "gate" },
-  // Goccia-only for now: the battery reaches for the `mock`/`spyOn` globals,
-  // which neither external runtime injects. Its three-way upgrade waits on the
-  // planned `goccia:test` module and shipped vitest-compat shim, which let it
-  // import `vi` from a bare `vitest` specifier under every runtime.
-  "e-mocks.goccia.test.js": { kind: "mocks", bun: "skip", vitest: "skip" },
+  // Now three-way: the battery imports `vi` from a bare `vitest` specifier,
+  // which vitest resolves to itself and goccia resolves to its bundled
+  // compatibility shim. Bun stays skipped — it injects its own `vi` under
+  // `bun:test`, but importing the real `vitest` package from a `bun test` file
+  // drops bun's injected globals and the file dies on `describe is not
+  // defined`, so there is no bun-runnable spelling of this battery.
+  "e-mocks.test.js": { kind: "mocks", bun: "skip", vitest: "gate" },
   "f-lifecycle.test.js": { kind: "lifecycle", bun: "advisory", vitest: "gate" },
   "g-filehook.test.js": { kind: "lifecycle", bun: "advisory", vitest: "gate" },
 };

--- a/source/app/GocciaTestRunner.dpr
+++ b/source/app/GocciaTestRunner.dpr
@@ -140,6 +140,7 @@ type
     FDescribeTimeout: TIntegerOption;
     FUpdateSnapshots: TFlagOption;
     FUpdateSnapshotsAlias: TFlagOption;
+    FNoVitestCompat: TFlagOption;
     function SnapshotUpdateMode: TGocciaSnapshotUpdateMode;
     procedure InitializeRuntime(const AEngine: TGocciaEngine;
       const AEnableHostFileLoading: Boolean = True);
@@ -337,6 +338,8 @@ begin
   FUpdateSnapshots.ShortName := 'u';
   FUpdateSnapshotsAlias := AddFlag('update',
     'Alias for --update-snapshots');
+  FNoVitestCompat := AddFlag('no-vitest-compat',
+    'Do not resolve the bare "vitest" specifier to the bundled compatibility shim');
 end;
 
 function TTestRunnerApp.SnapshotUpdateMode: TGocciaSnapshotUpdateMode;
@@ -656,7 +659,7 @@ begin
   Runtime := AttachRuntime(AEngine, AEnableHostFileLoading);
   ApplyTestRunnerRuntimeProfile(Runtime,
     TGocciaTestRunnerSnapshotHost.Create(AEngine.SourcePath),
-    SnapshotUpdateMode);
+    SnapshotUpdateMode, nil, not FNoVitestCompat.Present);
 end;
 
 procedure TTestRunnerApp.WarmUpRuntime(const AEngine: TGocciaEngine);

--- a/source/units/Goccia.RuntimeExtensions.TestingLibrary.pas
+++ b/source/units/Goccia.RuntimeExtensions.TestingLibrary.pas
@@ -8,7 +8,9 @@ uses
   Goccia.Builtins.Testing.SnapshotFormatting,
   Goccia.Builtins.Testing.Snapshots,
   Goccia.Builtins.TestingLibrary,
-  Goccia.Runtime;
+  Goccia.Runtime,
+  Goccia.RuntimeExtensions.NamespaceModule,
+  Goccia.Values.Primitives;
 
 type
   TGocciaTestingLibraryRuntimeExtension = class(TGocciaRuntimeExtension)
@@ -17,6 +19,8 @@ type
     FSnapshotHost: IGocciaSnapshotHost;
     FSnapshotUpdateMode: TGocciaSnapshotUpdateMode;
     FSnapshotFormatter: IGocciaSnapshotFormatter;
+    FTestModule: TGocciaRuntimeNamespaceModuleRegistration;
+    function MaterializeTestModule: TGocciaValue;
   public
     constructor Create(const ASnapshotHost: IGocciaSnapshotHost = nil;
       const ASnapshotUpdateMode: TGocciaSnapshotUpdateMode = sumNew;
@@ -51,10 +55,23 @@ begin
     Runtime.Engine.Interpreter.GlobalScope, Runtime.Engine.ThrowError,
     FSnapshotHost, FSnapshotUpdateMode, FSnapshotFormatter);
   Runtime.RegisterRuntimeGlobalName('TestAssertions');
+
+  { The same helpers the runner exposes as globals are also importable, so a
+    suite can name what it uses and so embedders that do not install globals
+    still reach the testing API. }
+  FTestModule := TGocciaRuntimeNamespaceModuleRegistration.Create(Runtime,
+    'goccia:test', MaterializeTestModule);
+end;
+
+function TGocciaTestingLibraryRuntimeExtension.MaterializeTestModule: TGocciaValue;
+begin
+  Result := FBuiltinTestAssertions.BuiltinObject;
 end;
 
 procedure TGocciaTestingLibraryRuntimeExtension.Detach;
 begin
+  FTestModule.Free;
+  FTestModule := nil;
   FBuiltinTestAssertions.Free;
   FBuiltinTestAssertions := nil;
   inherited;

--- a/source/units/Goccia.RuntimeExtensions.VitestCompat.pas
+++ b/source/units/Goccia.RuntimeExtensions.VitestCompat.pas
@@ -1,0 +1,145 @@
+unit Goccia.RuntimeExtensions.VitestCompat;
+
+{$I Goccia.inc}
+
+{ Vitest compatibility shim.
+
+  Resolves the bare `vitest` specifier to a small module that re-exports
+  `goccia:test` and assembles the `vi` namespace on top of it. The shim ships
+  inside the binary as source text rather than as a file on disk, so a suite
+  written against Vitest imports the same way under GocciaScript.
+
+  `vi` lives only here. The engine never grows a `vi` namespace, and every
+  member the engine cannot honestly provide is a function that throws a named,
+  actionable error instead of silently doing nothing. }
+
+interface
+
+uses
+  Goccia.Runtime;
+
+const
+  VITEST_COMPAT_SPECIFIER = 'vitest';
+
+type
+  TGocciaVitestCompatRuntimeExtension = class(TGocciaRuntimeExtension)
+  public
+    procedure Attach(const ARuntime: TGocciaRuntimeCore); override;
+  end;
+
+function VitestCompatShimSource: string;
+
+implementation
+
+uses
+  SysUtils;
+
+function VitestCompatShimSource: string;
+const
+  LB = sLineBreak;
+begin
+  Result :=
+    '// GocciaScript vitest compatibility shim. Shipped inside the runner.' + LB +
+    'import {' + LB +
+    '  describe,' + LB +
+    '  test,' + LB +
+    '  it,' + LB +
+    '  expect,' + LB +
+    '  beforeAll,' + LB +
+    '  beforeEach,' + LB +
+    '  afterEach,' + LB +
+    '  afterAll,' + LB +
+    '  onTestFinished,' + LB +
+    '  mock,' + LB +
+    '  spyOn,' + LB +
+    '} from "goccia:test";' + LB +
+    LB +
+    'export {' + LB +
+    '  describe,' + LB +
+    '  test,' + LB +
+    '  it,' + LB +
+    '  expect,' + LB +
+    '  beforeAll,' + LB +
+    '  beforeEach,' + LB +
+    '  afterEach,' + LB +
+    '  afterAll,' + LB +
+    '  onTestFinished,' + LB +
+    '  mock,' + LB +
+    '  spyOn,' + LB +
+    '};' + LB +
+    LB +
+    'const DOCS =' + LB +
+    '  "See docs/testing-api.md (Vitest compatibility) for the supported surface.";' + LB +
+    LB +
+    'const unsupported = (member, reason) => () => {' + LB +
+    '  throw new Error(' + LB +
+    '    "vi." + member + " is not supported by the GocciaScript vitest " +' + LB +
+    '      "compatibility shim. " + reason + " " + DOCS,' + LB +
+    '  );' + LB +
+    '};' + LB +
+    LB +
+    'const MODULE_REGISTRY =' + LB +
+    '  "GocciaScript resolves every import once, at load time, and keeps no " +' + LB +
+    '  "module registry to intercept, so module mocking cannot be emulated.";' + LB +
+    'const FAKE_TIMERS =' + LB +
+    '  "GocciaScript has no fake-timer clock; timers run on the real event loop.";' + LB +
+    'const GLOBAL_STUBS =' + LB +
+    '  "GocciaScript does not snapshot globals or environment variables, so a " +' + LB +
+    '  "stub could not be unwound safely.";' + LB +
+    'const MOCK_REGISTRY =' + LB +
+    '  "GocciaScript keeps no registry of created mocks; call mockClear, " +' + LB +
+    '  "mockReset or mockRestore on the mock itself.";' + LB +
+    LB +
+    'export const vi = {' + LB +
+    '  fn: mock,' + LB +
+    '  spyOn: spyOn,' + LB +
+    LB +
+    '  mock: unsupported("mock", MODULE_REGISTRY),' + LB +
+    '  unmock: unsupported("unmock", MODULE_REGISTRY),' + LB +
+    '  doMock: unsupported("doMock", MODULE_REGISTRY),' + LB +
+    '  doUnmock: unsupported("doUnmock", MODULE_REGISTRY),' + LB +
+    '  mocked: unsupported("mocked", MODULE_REGISTRY),' + LB +
+    '  importActual: unsupported("importActual", MODULE_REGISTRY),' + LB +
+    '  importMock: unsupported("importMock", MODULE_REGISTRY),' + LB +
+    '  hoisted: unsupported("hoisted", MODULE_REGISTRY),' + LB +
+    LB +
+    '  useFakeTimers: unsupported("useFakeTimers", FAKE_TIMERS),' + LB +
+    '  useRealTimers: unsupported("useRealTimers", FAKE_TIMERS),' + LB +
+    '  isFakeTimers: unsupported("isFakeTimers", FAKE_TIMERS),' + LB +
+    '  setSystemTime: unsupported("setSystemTime", FAKE_TIMERS),' + LB +
+    '  getMockedSystemTime: unsupported("getMockedSystemTime", FAKE_TIMERS),' + LB +
+    '  getRealSystemTime: unsupported("getRealSystemTime", FAKE_TIMERS),' + LB +
+    '  advanceTimersByTime: unsupported("advanceTimersByTime", FAKE_TIMERS),' + LB +
+    '  advanceTimersByTimeAsync:' + LB +
+    '    unsupported("advanceTimersByTimeAsync", FAKE_TIMERS),' + LB +
+    '  advanceTimersToNextTimer:' + LB +
+    '    unsupported("advanceTimersToNextTimer", FAKE_TIMERS),' + LB +
+    '  runAllTimers: unsupported("runAllTimers", FAKE_TIMERS),' + LB +
+    '  runOnlyPendingTimers: unsupported("runOnlyPendingTimers", FAKE_TIMERS),' + LB +
+    LB +
+    '  stubEnv: unsupported("stubEnv", GLOBAL_STUBS),' + LB +
+    '  stubGlobal: unsupported("stubGlobal", GLOBAL_STUBS),' + LB +
+    '  unstubAllEnvs: unsupported("unstubAllEnvs", GLOBAL_STUBS),' + LB +
+    '  unstubAllGlobals: unsupported("unstubAllGlobals", GLOBAL_STUBS),' + LB +
+    LB +
+    '  clearAllMocks: unsupported("clearAllMocks", MOCK_REGISTRY),' + LB +
+    '  resetAllMocks: unsupported("resetAllMocks", MOCK_REGISTRY),' + LB +
+    '  restoreAllMocks: unsupported("restoreAllMocks", MOCK_REGISTRY),' + LB +
+    '  resetModules: unsupported("resetModules", MODULE_REGISTRY),' + LB +
+    LB +
+    '  waitFor: unsupported("waitFor", FAKE_TIMERS),' + LB +
+    '  waitUntil: unsupported("waitUntil", FAKE_TIMERS),' + LB +
+    '  setConfig: unsupported("setConfig", GLOBAL_STUBS),' + LB +
+    '  resetConfig: unsupported("resetConfig", GLOBAL_STUBS),' + LB +
+    '};' + LB;
+end;
+
+procedure TGocciaVitestCompatRuntimeExtension.Attach(
+  const ARuntime: TGocciaRuntimeCore);
+begin
+  inherited Attach(ARuntime);
+  Runtime.Engine.ModuleLoader.InjectModule(VITEST_COMPAT_SPECIFIER,
+    VitestCompatShimSource);
+end;
+
+end.

--- a/source/units/Goccia.RuntimeProfiles.TestRunner.pas
+++ b/source/units/Goccia.RuntimeProfiles.TestRunner.pas
@@ -14,28 +14,36 @@ procedure ApplyTestRunnerRuntimeProfile(const ARuntime: TGocciaRuntimeCore);
 procedure ApplyTestRunnerRuntimeProfile(const ARuntime: TGocciaRuntimeCore;
   const ASnapshotHost: IGocciaSnapshotHost;
   const ASnapshotUpdateMode: TGocciaSnapshotUpdateMode;
-  const ASnapshotFormatter: IGocciaSnapshotFormatter = nil); overload;
+  const ASnapshotFormatter: IGocciaSnapshotFormatter = nil;
+  const AVitestCompat: Boolean = True); overload;
 
 implementation
 
 uses
   Goccia.RuntimeExtensions.TestingLibrary,
+  Goccia.RuntimeExtensions.VitestCompat,
   Goccia.RuntimeProfiles.Loader;
 
 procedure ApplyTestRunnerRuntimeProfile(const ARuntime: TGocciaRuntimeCore);
   overload;
 begin
-  ApplyTestRunnerRuntimeProfile(ARuntime, nil, sumNew, nil);
+  ApplyTestRunnerRuntimeProfile(ARuntime, nil, sumNew, nil, True);
 end;
 
 procedure ApplyTestRunnerRuntimeProfile(const ARuntime: TGocciaRuntimeCore;
   const ASnapshotHost: IGocciaSnapshotHost;
   const ASnapshotUpdateMode: TGocciaSnapshotUpdateMode;
-  const ASnapshotFormatter: IGocciaSnapshotFormatter); overload;
+  const ASnapshotFormatter: IGocciaSnapshotFormatter;
+  const AVitestCompat: Boolean); overload;
 begin
   ApplyLoaderRuntimeProfile(ARuntime);
   ARuntime.Install(TGocciaTestingLibraryRuntimeExtension.Create(
     ASnapshotHost, ASnapshotUpdateMode, ASnapshotFormatter));
+  { A suite written against Vitest imports from a bare `vitest` specifier,
+    which resolves to nothing otherwise. Installed by default so such a suite
+    runs unchanged; --no-vitest-compat leaves the specifier unresolvable. }
+  if AVitestCompat then
+    ARuntime.Install(TGocciaVitestCompatRuntimeExtension.Create);
 end;
 
 end.

--- a/tests/language/modules/goccia-test-module.js
+++ b/tests/language/modules/goccia-test-module.js
@@ -1,0 +1,66 @@
+/*---
+description: >
+  The complete testing API is importable from goccia:test, so a suite can name
+  what it uses instead of relying on the runner installing globals.
+features: [modules, runtime-modules]
+---*/
+
+import * as testing from "goccia:test";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  onTestFinished,
+  spyOn,
+  test,
+} from "goccia:test";
+
+describe("goccia:test", () => {
+  test("exports the registration helpers", () => {
+    expect(typeof describe).toBe("function");
+    expect(typeof test).toBe("function");
+    expect(typeof it).toBe("function");
+    expect(typeof expect).toBe("function");
+  });
+
+  test("exports every lifecycle hook", () => {
+    expect(typeof beforeAll).toBe("function");
+    expect(typeof beforeEach).toBe("function");
+    expect(typeof afterEach).toBe("function");
+    expect(typeof afterAll).toBe("function");
+    expect(typeof onTestFinished).toBe("function");
+  });
+
+  test("exports the mocking helpers", () => {
+    expect(typeof mock).toBe("function");
+    expect(typeof spyOn).toBe("function");
+  });
+
+  test("carries the modifiers on test and describe", () => {
+    expect(typeof test.each).toBe("function");
+    expect(typeof test.skip).toBe("function");
+    expect(typeof test.todo).toBe("function");
+    expect(typeof test.only).toBe("function");
+    expect(typeof describe.each).toBe("function");
+    expect(typeof describe.skip).toBe("function");
+    expect(typeof describe.only).toBe("function");
+  });
+
+  test("namespace import sees the same surface", () => {
+    expect(typeof testing.describe).toBe("function");
+    expect(typeof testing.expect).toBe("function");
+    expect(testing.test).toBe(test);
+  });
+
+  test("imported helpers drive the same registry as the globals", () => {
+    const viaImport = mock();
+    viaImport("value");
+
+    expect(viaImport).toHaveBeenCalledWith("value");
+  });
+});

--- a/tests/language/modules/vitest-compat-shim.js
+++ b/tests/language/modules/vitest-compat-shim.js
@@ -1,0 +1,85 @@
+/*---
+description: >
+  The bundled vitest compatibility shim resolves the bare "vitest" specifier,
+  re-exports goccia:test and assembles a vi namespace whose unsupported members
+  throw instead of silently doing nothing.
+features: [modules, runtime-modules]
+---*/
+
+import { describe, expect, mock, test, vi } from "vitest";
+
+describe("vitest compatibility shim", () => {
+  test("re-exports the testing API", () => {
+    expect(typeof describe).toBe("function");
+    expect(typeof test).toBe("function");
+    expect(typeof expect).toBe("function");
+    expect(typeof mock).toBe("function");
+  });
+
+  test("vi.fn is the engine's mock", () => {
+    expect(vi.fn).toBe(mock);
+
+    const fn = vi.fn();
+    fn(1, 2);
+    expect(fn).toHaveBeenCalledWith(1, 2);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  test("vi.spyOn wraps a method", () => {
+    const target = { run: () => "ok" };
+    const spy = vi.spyOn(target, "run");
+
+    expect(target.run()).toBe("ok");
+    expect(spy).toHaveBeenCalled();
+  });
+
+  test("a globally created mock is assertable through the imported expect", () => {
+    // Same registry either way: the shim re-exports the very same helpers.
+    const viaGlobal = mock();
+    viaGlobal("shared");
+
+    expect(viaGlobal).toHaveBeenCalledWith("shared");
+  });
+
+  test("module mocking throws and names the reason", () => {
+    expect(() => vi.mock("./x.js")).toThrow(
+      "vi.mock is not supported by the GocciaScript vitest compatibility shim",
+    );
+    expect(() => vi.mock("./x.js")).toThrow("keeps no module registry");
+    expect(() => vi.unmock("./x.js")).toThrow("vi.unmock is not supported");
+    expect(() => vi.importActual("./x.js")).toThrow("vi.importActual");
+    expect(() => vi.hoisted(() => {})).toThrow("vi.hoisted");
+  });
+
+  test("fake timers throw and name the reason", () => {
+    expect(() => vi.useFakeTimers()).toThrow("vi.useFakeTimers is not supported");
+    expect(() => vi.useFakeTimers()).toThrow("no fake-timer clock");
+    expect(() => vi.setSystemTime(0)).toThrow("vi.setSystemTime");
+    expect(() => vi.advanceTimersByTime(1)).toThrow("vi.advanceTimersByTime");
+    expect(() => vi.runAllTimers()).toThrow("vi.runAllTimers");
+  });
+
+  test("global stubbing throws and names the reason", () => {
+    expect(() => vi.stubGlobal("x", 1)).toThrow("vi.stubGlobal is not supported");
+    expect(() => vi.stubEnv("X", "1")).toThrow("does not snapshot globals");
+    expect(() => vi.unstubAllGlobals()).toThrow("vi.unstubAllGlobals");
+  });
+
+  test("bulk mock management points at the per-mock methods", () => {
+    expect(() => vi.restoreAllMocks()).toThrow("vi.restoreAllMocks is not supported");
+    expect(() => vi.restoreAllMocks()).toThrow("mockRestore");
+    expect(() => vi.clearAllMocks()).toThrow("vi.clearAllMocks");
+    expect(() => vi.resetAllMocks()).toThrow("vi.resetAllMocks");
+  });
+
+  test("every unsupported member is a defined function, never a no-op", () => {
+    expect(typeof vi.mock).toBe("function");
+    expect(typeof vi.useFakeTimers).toBe("function");
+    expect(typeof vi.stubGlobal).toBe("function");
+    expect(typeof vi.restoreAllMocks).toBe("function");
+  });
+
+  test("every unsupported member points at the docs", () => {
+    expect(() => vi.mock("./x.js")).toThrow("docs/testing-api.md");
+  });
+});


### PR DESCRIPTION
## Summary

- The testing API becomes importable as **`goccia:test`** (runtime-extension module, `goccia:toml` idiom) — same objects as the runner's globals (which stay default-on, Vitest `globals: true` semantics; no suite migration), with modifier carriers intact on the imported functions. Canonical import in docs; the only path outside the runner's globals.
- A **vitest-compat shim** compiles into the runner and resolves the bare `'vitest'` specifier by default (`--no-vitest-compat` opts out; verified the specifier resolved to nothing before, so nothing breaks). It re-exports `goccia:test` and assembles `vi`: `fn`→`mock`, `spyOn`→`spyOn`, honest mapping of what exists (bulk mock-management helpers are throwers pointing at the per-mock methods), and **30 unsupported members across four families are loud-throwing stubs** naming the design reason and docs — never silent no-ops. `vi` exists only in the shim; the engine grows no `vi` namespace.
- The `e-mocks` battery imports `vi` from `'vitest'` and becomes **three-way** (goccia-interp / goccia-bytecode / vitest, all 5p/0f); bun is skipped with the recorded reason — importing the real vitest package under `bun test` drops bun's injected globals, so no bun-runnable spelling exists.
- Two flagged decisions: `goccia:test` is available wherever the testing extension loads — the loader profile deliberately does not install it (that would hand every loader script the testing globals; a separate product decision, recorded in docs). The shim ships as a compiled-in constant rather than the generated-resource pipeline (same shipped-in-binary end state; the pipeline is sized for data tables).

Stack #1083's final implementation layer, per the four-point grilled contract.

## Testing

- [x] Verified in end-to-end tests — 16 new module/shim tests (exports, hooks, modifiers, registry coexistence, every thrower family's message shape) in both modes; CLI coverage for the off-switch; full suite 12,086/12,086 both modes; differential harness exit 0 with the three-way e-mocks; all doc validators green
- [x] Updated documentation — testing-api.md ("Importing the API" + shim support table, extending the harness layer's section), differential-testing.md e-mocks row
- [ ] Optional: native Pascal tests — n/a (module registration follows the tested runtime-extension pattern)
- [ ] Optional: benchmarks — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)
