### PR TITLE
test(cli): split coverage keys on both path separators

### DIFF
--- a/scripts/test-cli-apps.ts
+++ b/scripts/test-cli-apps.ts
@@ -2536,11 +2536,13 @@ console.log("Loader: coverage --output=json not corrupted...");
       ].join("\n"),
     );
     // Normalize to basenames: the entry is keyed by the path as typed while
-    // imported modules are keyed by their resolved absolute path.
+    // imported modules are keyed by their resolved absolute path. Split on
+    // both separators — on Windows the engine resolves imports through FPC's
+    // ExpandFileName, so coverage keys arrive with backslashes.
     const readCoverageByBasename = (path: string) => {
       const raw = JSON.parse(readFileSync(path, "utf-8"));
       return Object.fromEntries(
-        Object.entries(raw).map(([file, entry]) => [file.split("/").pop(), entry]),
+        Object.entries(raw).map(([file, entry]) => [file.split(/[\\/]/).pop(), entry]),
       ) as Record<string, any>;
     };
     const implyReports: Record<string, Record<string, any>> = {};


### PR DESCRIPTION
## Summary

- The one real defect among nine full-CI job failures on the stack top: the coverage-by-basename test helper split paths on `/` only, while on Windows the engine resolves imports through FPC's `ExpandFileName` (backslashes) — so both Windows `cli` legs failed at the coverage-implication check. The engine's behavior is correct; the harness was POSIX-only. Now splits on both separators (one helper, all three call sites).
- Diagnosis provenance: attempt-1-vs-attempt-2 log comparison across the manually-dispatched full-CI run — seven of nine failures were a GitHub Actions action-resolution outage ("Failed to resolve action download info"), one a cascade of a never-started shard, and the timeout-calibration hypothesis was disproven with real numbers (no workload within 45% of its cap). GC-rooting on aarch64-linux exonerated; layer 13's Windows TTY probe confirmed working.
- Known follow-on: this failure masked eight later Windows CLI steps (including the differential harness on Windows) — the full-CI re-dispatch after this layer is the real verdict. The LCOV backslash-emission question is recorded on #1094 with the canonical-path decision it belongs to.

Stack #1083 layer 24; from the user-requested full-CI Windows verification.

## Testing

- [x] Verified in end-to-end tests — POSIX path re-verified green (all binaries + full test-cli-apps); the Windows path is verified by the full-CI re-dispatch on this head (in flight)
- [x] Updated documentation — n/a (test-harness change; #1094 comment carries the product question)
- [ ] Optional: native Pascal tests — n/a
- [ ] Optional: benchmarks — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)
