### PR TITLE
fix(review): CodeRabbit round-2 findings across the stack

### DIFF
--- a/docs/contributing/cli-conventions.md
+++ b/docs/contributing/cli-conventions.md
@@ -41,7 +41,9 @@ CI cannot allocate a pseudo-terminal from the CLI harness, so the split is:
 
 - The decision matrix is covered by Pascal unit tests over the pure function.
 - `scripts/test-cli-apps.ts` covers every **non**-terminal path — piped stdin, closed stdin, explicit `-` — plus the `--help` text. These are the paths the rest of the test harness depends on, and they must stay byte-for-byte unchanged.
-- The terminal path is verified by hand under a pty, for example `script -q /dev/null ./build/GocciaTestRunner < /dev/null`.
+- The terminal path is verified by hand under a pty. The `script` invocation differs by platform:
+  - BSD/macOS: `script -q /dev/null ./build/GocciaTestRunner < /dev/null`
+  - Linux (util-linux): `script -q -c "./build/GocciaTestRunner" /dev/null < /dev/null`
 
 ## Stdin conventions
 

--- a/docs/testing-api.md
+++ b/docs/testing-api.md
@@ -55,7 +55,7 @@ The module exports everything the globals do — `describe`, `test`, `it`, `expe
 ```javascript
 // Equality
 expect(value).toBe(expected);           // Strict equality (===)
-expect(value).toEqual(expected);        // Deep equality, ignoring undefined-valued keys and trailing undefined items
+expect(value).toEqual(expected);        // Deep equality, ignoring undefined-valued keys and array sparseness
 expect(value).toStrictEqual(expected);  // Deep equality, type and undefined sensitive
 
 // Type checks

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -331,7 +331,7 @@ Both execution modes must pass. Test subtrees that require opt-in parser or runt
 |------|-------------|
 | `--no-progress` | Suppress per-file progress output |
 | `--no-results` | Suppress test results summary |
-| `--exit-on-first-failure` | Stop on first test failure |
+| `--exit-on-first-failure` | Stop on the first test failure **or suite error** (a throwing `describe`, a failed `beforeAll`/`afterAll`). Under `--jobs` the worker queue is cancelled too; files that never ran are omitted from the report rather than counted as failures |
 | `--silent` | Suppress all console output from test scripts |
 | `--jobs=N` / `-j N` | Number of parallel worker threads (default: CPU count) |
 | `--update-snapshots` / `-u` | Create, update, and prune snapshots |

--- a/scripts/differential/d-matchers.test.js
+++ b/scripts/differential/d-matchers.test.js
@@ -17,6 +17,41 @@ describe("deep equality semantics", () => {
     expect(new Set([1, 2])).toEqual(new Set([2, 1]));
   });
 
+  test("toStrictEqual reads an accessor-backed constructor", () => {
+    // The strict type check compares `actual.constructor` against
+    // `expected.constructor` as ordinary property reads, so a prototype
+    // accessor runs inside the matcher. Pinned here because the alternative
+    // (a type identity resolved without reading the property) is a
+    // plausible-looking change that would silently diverge from vitest.
+    class Fresh {
+      constructor(x) {
+        this.x = x;
+      }
+    }
+    Object.defineProperty(Fresh.prototype, "constructor", {
+      get() {
+        return { fresh: true };
+      },
+      configurable: true,
+    });
+    expect(new Fresh(1)).not.toStrictEqual(new Fresh(1));
+    expect(new Fresh(1)).toEqual({ x: 1 });
+
+    class Stable {
+      constructor(x) {
+        this.x = x;
+      }
+    }
+    Object.defineProperty(Stable.prototype, "constructor", {
+      get() {
+        return Stable;
+      },
+      configurable: true,
+    });
+    expect(new Stable(1)).toStrictEqual(new Stable(1));
+    expect(new Stable(1)).not.toStrictEqual({ x: 1 });
+  });
+
   test("toEqual distinguishes Map from plain object", () => {
     expect(new Map([["a", 1]])).not.toEqual({ a: 1 });
   });

--- a/scripts/test-cli-apps.ts
+++ b/scripts/test-cli-apps.ts
@@ -20,6 +20,7 @@ import {
   mkdirSync,
   realpathSync,
   chmodSync,
+  rmSync,
   symlinkSync,
 } from "fs";
 import { join, resolve } from "path";
@@ -3545,7 +3546,16 @@ for (const modeArgs of [[], ["--mode=bytecode"]]) {
     // suiteErrors: describe/hook failures. Vitest keeps these OUT of
     // `failed` (affected tests report as skipped) and fails the file
     // instead, so they are asserted separately. Defaults to 0.
-    expected: { passed: number; failed: number; skipped: number; suiteErrors?: number };
+    // totalTests: tests the runner actually entered. Defaults to
+    // passed + failed + skipped, which is the only shape that does not hold
+    // when collection aborts and the file is discarded whole.
+    expected: {
+      passed: number;
+      failed: number;
+      skipped: number;
+      suiteErrors?: number;
+      totalTests?: number;
+    };
     // Reporter markers this shape can leak beyond the shared set below.
     extraMarkers?: string[];
   }> = [
@@ -3657,7 +3667,7 @@ for (const modeArgs of [[], ["--mode=bytecode"]]) {
         'describe("ok", () => { test("passes", () => { expect(1).toBe(1); }); });',
         "",
       ].join("\n"),
-      expected: { passed: 0, failed: 0, skipped: 0, suiteErrors: 1 },
+      expected: { passed: 0, failed: 0, skipped: 0, suiteErrors: 1, totalTests: 0 },
       extraMarkers: ["Error in describe block"],
     },
     {
@@ -3675,7 +3685,7 @@ for (const modeArgs of [[], ["--mode=bytecode"]]) {
         "});",
         "",
       ].join("\n"),
-      expected: { passed: 0, failed: 0, skipped: 0, suiteErrors: 1 },
+      expected: { passed: 0, failed: 0, skipped: 0, suiteErrors: 1, totalTests: 0 },
       extraMarkers: ["Error in describe block"],
     },
   ];
@@ -3721,6 +3731,15 @@ for (const modeArgs of [[], ["--mode=bytecode"]]) {
       const expectedSuiteErrors = scenario.expected.suiteErrors ?? 0;
       if (json.suiteErrors !== expectedSuiteErrors)
         throw new Error(`${label} suiteErrors should be ${expectedSuiteErrors}, got ${json.suiteErrors}`);
+      // A collection abort discards the file, so the tests registered before
+      // the throwing describe must not be counted as run either. Without
+      // this the retained registrations of the "collected first" shape pass
+      // undetected.
+      const expectedTotalTests =
+        scenario.expected.totalTests ??
+        scenario.expected.passed + scenario.expected.failed + scenario.expected.skipped;
+      if (json.totalTests !== expectedTotalTests)
+        throw new Error(`${label} totalTests should be ${expectedTotalTests}, got ${json.totalTests}`);
       const failedTests = json.files?.[0]?.failedTests;
       // failedTests stays the human-visible detail channel for BOTH
       // failed tests and suite errors, so it carries one entry each.
@@ -3781,6 +3800,10 @@ for (const modeArgs of [[], ["--mode=bytecode"]]) {
         throw new Error(`${label} the throwing file should report suiteErrors=1, got ${badResult?.suiteErrors}`);
       if (badResult?.passed !== 0)
         throw new Error(`${label} the throwing file should run no tests at all, got passed=${badResult?.passed}`);
+      // Same guard as the single-file scenarios: a retained registration
+      // would surface here as a non-zero total for the discarded file.
+      if (badResult?.totalTests !== 0)
+        throw new Error(`${label} the throwing file should report totalTests=0, got ${badResult?.totalTests}`);
       if (goodResult?.passed !== 1)
         throw new Error(`${label} the clean sibling file should keep its pass, got ${goodResult?.passed}`);
       if (!badResult?.failedTests?.some((t: string) => t.includes('Describe "boom"')))
@@ -3823,6 +3846,23 @@ for (const modeArgs of [[], ["--mode=bytecode"]]) {
         throw new Error(`${label} must NOT execute the test body after the hook failed, got: ${all.slice(0, 300)}`);
       if (proc.exitCode === 0)
         throw new Error(`${label} should exit non-zero, got 0`);
+
+      // The skipped body writes no detail line of its own, so the entry is
+      // built from the fallback. Without the hook's message carried into it,
+      // the JSON payload names the failed test and never says why.
+      const jsonProc = Bun.spawnSync(
+        [resolve(TESTRUNNER), file, "--no-progress", "--output=json", ...modeArgs],
+        { stdout: "pipe", stderr: "pipe" },
+      );
+      const json = JSON.parse(jsonProc.stdout.toString());
+      const details: string[] = json.files?.[0]?.failedTests ?? [];
+      if (details.length !== 2)
+        throw new Error(`${label} should report both tests as failed, got: ${JSON.stringify(details)}`);
+      for (const detail of details)
+        if (!detail.includes("beforeEach exploded"))
+          throw new Error(
+            `${label} failedTests entry must carry the hook failure message, got: ${JSON.stringify(details)}`,
+          );
     } finally {
       clean(tmp);
     }
@@ -3880,6 +3920,92 @@ for (const modeArgs of [[], ["--mode=bytecode"]]) {
         throw new Error(`${label} should keep the hook error visible in failedTests, got: ${JSON.stringify(badResult?.failedTests)}`);
       if (goodResult?.ok !== true)
         throw new Error(`${label} the clean sibling file should stay ok, got ${goodResult?.ok}`);
+    } finally {
+      clean(tmp);
+    }
+  }
+
+  // A suite error never enters `failed`, so a bail keyed on `failed` alone
+  // walks straight past a file that already died. Both the sequential loop
+  // and the worker pool have to stop, and the human summary must not call
+  // the run green.
+  {
+    const label = `TestRunner (${modeLabel}) --exit-on-first-failure on a suite error`;
+    console.log(`TestRunner: --exit-on-first-failure stops on a suite error (${modeLabel})...`);
+    const tmp = makeTmp();
+    try {
+      // "a-" sorts first so the failing file is the one the runner reaches
+      // first on both paths.
+      const failing = join(tmp, "a-suite-error.test.js");
+      writeFileSync(failing, [
+        'describe("suite", () => {',
+        '  beforeAll(() => { throw new Error("beforeAll exploded"); });',
+        '  test("t1", () => { expect(1).toBe(1); });',
+        "});",
+        "",
+      ].join("\n"));
+
+      // Slow enough that a second worker cannot drain the whole queue in the
+      // window before the first file's failure cancels it.
+      const laterFiles: string[] = [];
+      for (const index of [1, 2, 3, 4, 5]) {
+        const later = join(tmp, `b-later-${index}.test.js`);
+        writeFileSync(later, [
+          `test("later ${index}", () => {`,
+          // Array methods, not a traditional for loop: those need
+          // --compat-traditional-for-loop and would fail the file for the
+          // wrong reason.
+          "  const total = Array.from({ length: 200000 }, (_, i) => i)",
+          "    .reduce((sum, value) => sum + value, 0);",
+          `  console.log("RAN:later-${index}");`,
+          "  expect(total > 0).toBe(true);",
+          "});",
+          "",
+        ].join("\n"));
+        laterFiles.push(later);
+      }
+
+      // Sequential: the loop must break before the next file is opened.
+      const sequential = Bun.spawnSync(
+        [resolve(TESTRUNNER), failing, ...laterFiles, "--jobs=1", "--no-progress",
+          "--exit-on-first-failure", ...modeArgs],
+        { stdout: "pipe", stderr: "pipe" },
+      );
+      const sequentialOut = sequential.stdout.toString() + sequential.stderr.toString();
+      if (sequential.exitCode === 0)
+        throw new Error(`${label} sequential should exit non-zero, got 0`);
+      for (const index of [1, 2, 3, 4, 5])
+        if (sequentialOut.includes(`RAN:later-${index}`))
+          throw new Error(
+            `${label} sequential kept running files after the suite error: ${sequentialOut.slice(0, 400)}`,
+          );
+      // The summary must not claim the run passed when only a suite errored.
+      if (sequentialOut.includes("All tests passed"))
+        throw new Error(`${label} printed the all-passed summary for a suite error: ${sequentialOut.slice(0, 400)}`);
+
+      // Parallel: the pool must cancel the queue, so at least one queued file
+      // never runs and never appears as a synthesised failure.
+      const parallel = Bun.spawnSync(
+        [resolve(TESTRUNNER), failing, ...laterFiles, "--jobs=2", "--no-progress",
+          "--exit-on-first-failure", "--output=json", ...modeArgs],
+        { stdout: "pipe", stderr: "pipe" },
+      );
+      if (parallel.exitCode === 0)
+        throw new Error(`${label} parallel should exit non-zero, got 0`);
+      const parallelJson = JSON.parse(parallel.stdout.toString());
+      if (parallelJson.ok !== false)
+        throw new Error(`${label} parallel ok should be false, got ${parallelJson.ok}`);
+      if (!Array.isArray(parallelJson.files) || parallelJson.files.length >= 6)
+        throw new Error(
+          `${label} parallel ran every queued file instead of bailing, got ${parallelJson.files?.length} file results`,
+        );
+      // Cancelled files are omitted, not reported as failures of their own.
+      if (parallelJson.failed !== 0)
+        throw new Error(
+          `${label} parallel should not synthesise failures for cancelled files, got failed=${parallelJson.failed}`,
+        );
+      if (parallelJson.suiteErrors !== 1)
+        throw new Error(`${label} parallel suiteErrors should be 1, got ${parallelJson.suiteErrors}`);
     } finally {
       clean(tmp);
     }
@@ -6614,47 +6740,115 @@ console.log("SandboxRunner: virtual modules share the CLI surface and cannot sha
   // Each binary needs input it can actually accept: the benchmark runner
   // fails a run with zero benchmarks, and the bundler requires an explicit
   // --output when its source came from stdin.
+  //
+  // Exit 0 alone would not prove anything: a regression that drops stdin on
+  // the floor and executes nothing still exits 0. Every entry therefore
+  // carries a postcondition only a real execution of *this* source can
+  // satisfy — a marker the program prints, or, for the bundler (which
+  // prints nothing), the artifact it writes. `reset` runs before each
+  // invocation so a stale artifact cannot stand in for a fresh one.
+  const bundlerOut = join(tmp, "stdin-policy.gbc");
+  const STDIN_MARKER = "stdin-policy-marker";
+  type SpawnResult = {
+    stdout: { toString(): string };
+    stderr: { toString(): string };
+  };
+  const expectMarker = (name: string, run: string, proc: SpawnResult) => {
+    const output = proc.stdout.toString();
+    if (!output.includes(STDIN_MARKER))
+      throw new Error(
+        `${name} ${run}: stdin source did not run (no ${JSON.stringify(STDIN_MARKER)} in stdout): ${output}${proc.stderr.toString()}`,
+      );
+  };
+
   const stdinApps = [
     {
       name: "GocciaScriptLoader",
       bin: LOADER,
       args: [] as string[],
-      source: "const x = 1;\n",
+      source: `console.log("${STDIN_MARKER}");\n`,
       env: undefined as Record<string, string> | undefined,
+      reset: undefined as (() => void) | undefined,
+      verify: expectMarker,
     },
     {
       name: "GocciaScriptLoaderBare",
       bin: BARE,
       args: [],
-      source: "const x = 1;\n",
+      // The bare loader has no console; `print` is its output global.
+      source: `print("${STDIN_MARKER}");\n`,
       env: undefined,
+      reset: undefined,
+      verify: expectMarker,
     },
     {
       name: "GocciaTestRunner",
       bin: TESTRUNNER,
-      args: [],
-      source: "const x = 1;\n",
+      args: ["--no-progress"],
+      // The marker proves the source ran; the passing test proves the suite
+      // was registered and executed rather than merely parsed.
+      source: [
+        'test("stdin suite", () => {',
+        `  console.log("${STDIN_MARKER}");`,
+        "  expect(1 + 1).toBe(2);",
+        "});",
+        "",
+      ].join("\n"),
       env: undefined,
+      reset: undefined,
+      verify: (name: string, run: string, proc: SpawnResult) => {
+        expectMarker(name, run, proc);
+        const output = proc.stdout.toString();
+        if (!output.includes("Test Results Passed: 1"))
+          throw new Error(
+            `${name} ${run}: stdin suite did not run a passing test: ${output}${proc.stderr.toString()}`,
+          );
+      },
     },
     {
       name: "GocciaBenchmarkRunner",
       bin: BENCHRUNNER,
       args: ["--source-type=module", "--no-progress"],
-      source: microbenchModule(['bench("noop", () => 1);']),
+      source: microbenchModule([`bench("${STDIN_MARKER}", () => 1);`]),
       env: stdinBenchEnv,
+      reset: undefined,
+      // The benchmark name only reaches the report if the benchmark was
+      // registered and measured.
+      verify: expectMarker,
     },
     {
       name: "GocciaBundler",
       bin: BUNDLER,
-      args: [`--output=${join(tmp, "stdin-policy.gbc")}`],
-      source: "const x = 1;\n",
+      args: [`--output=${bundlerOut}`],
+      source: `console.log("${STDIN_MARKER}");\n`,
       env: undefined,
+      reset: () => rmSync(bundlerOut, { force: true }),
+      // The bundler compiles rather than runs, so its evidence is the
+      // artifact: it must exist and, when executed, produce the marker that
+      // only the stdin source could have put there.
+      verify: (name: string, run: string, proc: SpawnResult) => {
+        if (!existsSync(bundlerOut))
+          throw new Error(
+            `${name} ${run}: no bundle written from stdin source: ${proc.stdout.toString()}${proc.stderr.toString()}`,
+          );
+        const roundtrip = Bun.spawnSync([LOADER, bundlerOut], {
+          stdout: "pipe",
+          stderr: "pipe",
+          timeout: 120_000,
+        });
+        const roundtripOutput = roundtrip.stdout.toString();
+        if (roundtrip.exitCode !== 0 || !roundtripOutput.includes(STDIN_MARKER))
+          throw new Error(
+            `${name} ${run}: the bundle does not carry the stdin source (exit ${roundtrip.exitCode}): ${roundtripOutput}${roundtrip.stderr.toString()}`,
+          );
+      },
     },
   ];
 
   try {
     console.log("Stdin policy: piped stdin with no arguments still runs...");
     for (const app of stdinApps) {
+      app.reset?.();
       const proc = Bun.spawnSync([app.bin, ...app.args], {
         stdin: new TextEncoder().encode(app.source),
         stdout: "pipe",
@@ -6666,10 +6860,12 @@ console.log("SandboxRunner: virtual modules share the CLI surface and cannot sha
         throw new Error(
           `${app.name} with piped stdin exited ${proc.exitCode}: ${proc.stdout.toString()}${proc.stderr.toString()}`,
         );
+      app.verify(app.name, "with piped stdin", proc);
     }
 
     console.log('Stdin policy: explicit "-" with piped stdin still runs...');
     for (const app of stdinApps) {
+      app.reset?.();
       const proc = Bun.spawnSync([app.bin, ...app.args, "-"], {
         stdin: new TextEncoder().encode(app.source),
         stdout: "pipe",
@@ -6681,6 +6877,7 @@ console.log("SandboxRunner: virtual modules share the CLI surface and cannot sha
         throw new Error(
           `${app.name} with explicit "-" exited ${proc.exitCode}: ${proc.stdout.toString()}${proc.stderr.toString()}`,
         );
+      app.verify(app.name, 'with explicit "-"', proc);
     }
 
     console.log("Stdin policy: closed stdin with no arguments is not a usage error...");
@@ -6722,7 +6919,11 @@ for (const app of [
   if (proc.exitCode !== 0)
     throw new Error(`${app.name} --help exited ${proc.exitCode}: ${proc.stderr.toString()}`);
   const help = normalizeLineEndings(proc.stdout.toString());
-  for (const needle of ["Input:", `${app.name} < app.js`, '"-"', "Ctrl-D", "exits 2"]) {
+  // The EOF key sequence is platform-specific: a Unix console ends input on
+  // Ctrl-D, a Windows console on Ctrl-Z followed by Enter, and the help text
+  // renders whichever one the local console honours (Goccia.CLI.Stdin).
+  const endOfInputKeys = process.platform === "win32" ? "Ctrl-Z then Enter" : "Ctrl-D";
+  for (const needle of ["Input:", `${app.name} < app.js`, '"-"', endOfInputKeys, "exits 2"]) {
     if (!help.includes(needle))
       throw new Error(`${app.name} --help is missing ${JSON.stringify(needle)}:\n${help}`);
   }
@@ -6736,7 +6937,16 @@ for (const app of [
   { name: "GocciaSandboxRunner", bin: SANDBOXRUNNER },
 ]) {
   const proc = Bun.spawnSync([app.bin, "--help"], { stdout: "pipe", stderr: "pipe" });
+  // Without these the test also passes when --help fails outright and prints
+  // nothing: an empty stdout trivially lacks "Input:". Same postconditions as
+  // the stdin-defaulting binaries above.
+  if (proc.exitCode !== 0)
+    throw new Error(`${app.name} --help exited ${proc.exitCode}: ${proc.stderr.toString()}`);
+  if (proc.stderr.toString() !== "")
+    throw new Error(`${app.name} --help wrote to stderr: ${proc.stderr.toString()}`);
   const help = normalizeLineEndings(proc.stdout.toString());
+  if (!help.includes(app.name))
+    throw new Error(`${app.name} --help did not print its own usage:\n${help}`);
   if (help.includes("Input:"))
     throw new Error(`${app.name} should not advertise the stdin rule:\n${help}`);
 }
@@ -6761,6 +6971,12 @@ console.log("TestRunner: vitest compatibility shim and its off-switch...");
 
     const enabled = Bun.spawnSync([TESTRUNNER, suitePath, "--no-progress"]);
     const enabledOutput = new TextDecoder().decode(enabled.stdout);
+    // Output alone does not pin the contract: the process status is what CI
+    // and every caller act on, so assert it on both invocations.
+    if (enabled.exitCode !== 0)
+      throw new Error(
+        `TestRunner with the default shim exited ${enabled.exitCode}:\n${enabledOutput}${new TextDecoder().decode(enabled.stderr)}`,
+      );
     if (!enabledOutput.includes("Passed: 1"))
       throw new Error(
         `TestRunner should resolve the bare vitest specifier by default:\n${enabledOutput}`,
@@ -6775,6 +6991,10 @@ console.log("TestRunner: vitest compatibility shim and its off-switch...");
     const disabledOutput =
       new TextDecoder().decode(disabled.stdout) +
       new TextDecoder().decode(disabled.stderr);
+    if (disabled.exitCode === 0)
+      throw new Error(
+        `--no-vitest-compat should fail the run, but it exited 0:\n${disabledOutput}`,
+      );
     if (!disabledOutput.includes('Cannot resolve bare module specifier "vitest"'))
       throw new Error(
         `--no-vitest-compat should leave the vitest specifier unresolvable:\n${disabledOutput}`,

--- a/scripts/test-cli-differential.ts
+++ b/scripts/test-cli-differential.ts
@@ -285,10 +285,19 @@ const fillVitest = (results: Map<string, Run>, names: string[], error: string): 
   return results;
 };
 
+/**
+ * Renders a skip count. `null` means the runtime does not report skips at
+ * all, which is not the same as reporting zero — printing it as an empty
+ * string (or as the string "null") would claim agreement the output never
+ * established.
+ */
+const fmtSkipped = (skipped: number | null): string =>
+  skipped === null ? "/?s" : skipped > 0 ? `/${skipped}s` : "";
+
 const fmt = (run: Run): string => {
   if (run.error) return run.error;
   const v = run.verdict!;
-  return `${v.passed}p/${v.failed}f${v.skipped ? `/${v.skipped}s` : ""}`;
+  return `${v.passed}p/${v.failed}f${fmtSkipped(v.skipped)}`;
 };
 
 const difference = (a: Set<string>, b: Set<string>): string[] =>
@@ -327,8 +336,20 @@ function compareOracle(
     const o = oracle.verdict!;
     if (v.passed !== o.passed || v.failed !== o.failed)
       disagree.push(`${label} counts differ from ${modeLabel}: ${label}=${fmt(oracle)} ${modeLabel}=${fmt(run)}`);
-    else if (options.compareSkipped && v.skipped !== o.skipped)
-      disagree.push(`${label} skip counts differ from ${modeLabel}: ${label}=${o.skipped}s ${modeLabel}=${v.skipped}s`);
+    // Both sides must actually report skips before a difference means
+    // anything: goccia carries `null` for an envelope without the field, and
+    // comparing that against a number printed a divergence whose message
+    // read `goccia=nulls`. The file-verdict comparison below already guards
+    // both sides the same way.
+    else if (
+      options.compareSkipped &&
+      v.skipped !== null &&
+      o.skipped !== null &&
+      v.skipped !== o.skipped
+    )
+      disagree.push(
+        `${label} skip counts differ from ${modeLabel}: ${label}=${o.skipped}s ${modeLabel}=${v.skipped}s`,
+      );
   }
   if (
     options.compareFileFailed &&

--- a/source/app/Goccia.CLI.Stdin.Test.pas
+++ b/source/app/Goccia.CLI.Stdin.Test.pas
@@ -26,6 +26,7 @@ type
     procedure TestUsageNoteMentionsREPLOnlyWhenRequested;
     procedure TestNoInputMessageIsEmptyForNonStdinCommands;
     procedure TestNoInputMessageNamesTheThreeOuts;
+    procedure TestEndOfInputKeysMatchThePlatformConsole;
   public
     procedure SetupTests; override;
   end;
@@ -57,6 +58,8 @@ begin
     TestNoInputMessageIsEmptyForNonStdinCommands);
   Test('No-input message names the three ways out',
     TestNoInputMessageNamesTheThreeOuts);
+  Test('End-of-input guidance matches the platform console',
+    TestEndOfInputKeysMatchThePlatformConsole);
 end;
 
 { Argument order: AHasInputArgs, AHasExplicitStdinArg, AStdinIsTerminal. }
@@ -125,7 +128,7 @@ begin
   Note := StdinUsageNote('GocciaTestRunner', suStdinDefault);
   Expect<Boolean>(ContainsStr(Note, 'GocciaTestRunner')).ToBe(True);
   Expect<Boolean>(ContainsStr(Note, '"-"')).ToBe(True);
-  Expect<Boolean>(ContainsStr(Note, 'Ctrl-D')).ToBe(True);
+  Expect<Boolean>(ContainsStr(Note, EndOfInputKeys)).ToBe(True);
   Expect<Boolean>(ContainsStr(Note, 'exits 2')).ToBe(True);
 end;
 
@@ -155,6 +158,19 @@ begin
     .ToBe(True);
   Expect<Boolean>(ContainsStr(Message, '"-"')).ToBe(True);
   Expect<Boolean>(ContainsStr(Message, 'GocciaREPL')).ToBe(True);
+  Expect<Boolean>(ContainsStr(Message, EndOfInputKeys)).ToBe(True);
+end;
+
+{ The guidance has to name the key sequence the local console actually
+  honours: a Unix terminal ends input on Ctrl-D, a Windows console on
+  Ctrl-Z followed by Enter. }
+procedure TCLIStdinTests.TestEndOfInputKeysMatchThePlatformConsole;
+begin
+{$IFDEF MSWINDOWS}
+  Expect<string>(EndOfInputKeys).ToBe('Ctrl-Z then Enter');
+{$ELSE}
+  Expect<string>(EndOfInputKeys).ToBe('Ctrl-D');
+{$ENDIF}
 end;
 
 begin

--- a/source/app/Goccia.CLI.Stdin.pas
+++ b/source/app/Goccia.CLI.Stdin.pas
@@ -55,6 +55,13 @@ type
 function DecideStdinInput(const AHasInputArgs, AHasExplicitStdinArg,
   AStdinIsTerminal: Boolean): TGocciaStdinDecision;
 
+{ The key sequence that ends terminal input on this platform, for use in
+  user-facing guidance.  A Unix console signals EOF on Ctrl-D, but the
+  Windows console needs Ctrl-Z followed by Enter — telling a Windows user
+  to press Ctrl-D leaves the command looking hung, which is the exact
+  failure the no-argument rule exists to prevent. }
+function EndOfInputKeys: string;
+
 { True when standard input is attached to an interactive terminal.
   Never mutates console state — unlike IsColorTerminal, which enables
   virtual-terminal processing on the Windows output handle. }
@@ -92,6 +99,15 @@ begin
   if AStdinIsTerminal then
     Exit(sdShowUsage);
   Result := sdReadStdin;
+end;
+
+function EndOfInputKeys: string;
+begin
+{$IFDEF MSWINDOWS}
+  Result := 'Ctrl-Z then Enter';
+{$ELSE}
+  Result := 'Ctrl-D';
+{$ENDIF}
 end;
 
 function IsInputTerminal: Boolean;
@@ -135,7 +151,8 @@ begin
       'so' + sLineBreak +
     '  ' + AProgramName + ' prints this help and exits ' +
       IntToStr(EXIT_CODE_USAGE) + ' instead.  Pass "-" to' + sLineBreak +
-    '  read from the terminal anyway (finish with Ctrl-D).' + sLineBreak;
+    '  read from the terminal anyway (finish with ' + EndOfInputKeys + ').' +
+      sLineBreak;
 
   if AUsage = suStdinDefaultWithREPL then
     Result := Result +
@@ -154,8 +171,8 @@ begin
     '  - pass a file or directory path' + sLineBreak +
     '  - pipe or redirect a script:  ' + AProgramName + ' < app.js' +
       sLineBreak +
-    '  - pass "-" to read from the terminal (finish with Ctrl-D)' +
-      sLineBreak;
+    '  - pass "-" to read from the terminal (finish with ' +
+      EndOfInputKeys + ')' + sLineBreak;
 
   if AUsage = suStdinDefaultWithREPL then
     Result := Result +

--- a/source/app/GocciaTestRunner.dpr
+++ b/source/app/GocciaTestRunner.dpr
@@ -67,6 +67,14 @@ const
     --timeout=0. }
   DEFAULT_TIMEOUT_MS = 30000;  // 30 seconds
 
+  { Sentinel the parallel worker returns as its pool error message when
+    --exit-on-first-failure has to stop the queue. It carries no diagnostic
+    value — the file's own counts and failed-test names are already in
+    TTestWorkerData — it only trips TGocciaThreadPool.CancelOnError, and the
+    aggregation recognises it so the slot is not rewritten as a synthetic
+    failure. }
+  EXIT_ON_FIRST_FAILURE_SIGNAL = '<exit-on-first-failure>';
+
 type
   { Plain-data record for extracting test results from GC-managed objects.
     Used by the parallel path to pass results across thread boundaries
@@ -1225,7 +1233,11 @@ begin
     if Assigned(GC) then
       GC.Collect;
 
-    if FExitOnFirst.Present and (FailedCount > 0) then
+    { Suite-level errors (throwing describe, failed beforeAll/afterAll) never
+      enter `failed` — Vitest keeps them out of the test counts — so bailing
+      on `failed` alone would keep running files after a file already died.
+      Both counters gate the break, matching the parallel path. }
+    if FExitOnFirst.Present and ((FailedCount > 0) or (SuiteErrorCount > 0)) then
       Break;
   end;
   SetLength(Result.FileResults, ProcessedCount);
@@ -1324,6 +1336,19 @@ begin
     end;
   end;
 
+  { Arm --exit-on-first-failure. The pool's only stop signal is a non-empty
+    AErrorMessage (TGocciaFileWorker sets Success := ErrorMsg = '' and
+    cancels the queue when CancelOnError is on), and a file that merely
+    failed tests or errored a suite otherwise returns as a successful
+    worker — so queued files kept running. Suite errors are consulted
+    alongside `failed` because they never enter the test counts. The
+    sentinel is not a real error message: the aggregation recognises it and
+    keeps the slot's own numbers, so nothing is reported twice. }
+  if FExitOnFirst.Present and
+    ((WorkerResults^[AIndex].Failed > 0) or
+     (WorkerResults^[AIndex].SuiteErrors > 0)) then
+    AErrorMessage := EXIT_ON_FIRST_FAILURE_SIGNAL;
+
   // No per-file GC.Collect here. Explicit script-level Goccia.gc() is
   // serialized by the collector lock, but the runner still lets worker
   // shutdown reclaim each thread-local heap in bulk.
@@ -1342,9 +1367,12 @@ var
     aggregation reads is a refcount race we cannot tolerate. }
   OrphanResults: array of TTestWorkerData;
   IsOrphan: array of Boolean;
+  { Files the queue never got to because --exit-on-first-failure cancelled
+    the run. They contribute nothing and are omitted from the report. }
+  NeverRan: array of Boolean;
   Source: ^TTestWorkerData;
   GC: TGarbageCollector;
-  I, J: Integer;
+  I, J, ProcessedCount: Integer;
   AllTestResults: TGocciaObjectValue;
   AllFailedTests: TGocciaArrayValue;
   PassedCount, FailedCount, SkippedCount, TotalRunCount, TotalAssertions: Double;
@@ -1363,6 +1391,9 @@ begin
     WorkerData[I].Passed := 0;
     WorkerData[I].Failed := 0;
     WorkerData[I].Skipped := 0;
+    { Explicit: the cancelled-slot discrimination below reads this field to
+      tell a file that never ran from one that reported a suite error. }
+    WorkerData[I].SuiteErrors := 0;
     WorkerData[I].TotalRunTests := 0;
     WorkerData[I].Assertions := 0;
     WorkerData[I].Duration := 0;
@@ -1445,10 +1476,33 @@ begin
       Success=False slots get rewritten. }
     SetLength(OrphanResults, AFiles.Count);
     SetLength(IsOrphan, AFiles.Count);
+    SetLength(NeverRan, AFiles.Count);
     for I := 0 to AFiles.Count - 1 do
     begin
       if (I > High(Pool.Results)) or Pool.Results[I].Success then
         Continue;
+
+      { The file ran and reported its own numbers; the sentinel exists only
+        to have stopped the queue. Leave WorkerData[I] exactly as the worker
+        wrote it. }
+      if Pool.Results[I].ErrorMessage = EXIT_ON_FIRST_FAILURE_SIGNAL then
+        Continue;
+
+      { Queue cancelled by --exit-on-first-failure: this file never ran, and
+        a bail is not a per-file failure. Drop it from the report instead of
+        synthesising one failed test for it (which is what the watchdog path
+        below legitimately does — there the file was expected to complete). }
+      if FExitOnFirst.Present and
+        (Pool.Results[I].ErrorMessage = GOCCIA_POOL_CANCELLED_MESSAGE) and
+        (WorkerData[I].ErrorMessage = '') and
+        (WorkerData[I].Passed = 0) and
+        (WorkerData[I].Failed = 0) and
+        (WorkerData[I].SuiteErrors = 0) and
+        (WorkerData[I].TotalRunTests = 0) then
+      begin
+        NeverRan[I] := True;
+        Continue;
+      end;
 
       if Pool.Results[I].ErrorMessage <> '' then
       begin
@@ -1516,9 +1570,15 @@ begin
   Result.TotalExecNanoseconds := 0;
   Result.MemoryStats := WorkerMemoryStats;
   SetLength(Result.FileResults, AFiles.Count);
+  ProcessedCount := 0;
 
   for I := 0 to AFiles.Count - 1 do
   begin
+    { Bailed-out files never ran, so they neither print progress nor take a
+      results row — the same shape the sequential path's Break produces. }
+    if (I < Length(NeverRan)) and NeverRan[I] then
+      Continue;
+
     if (not FNoProgress.Present) and (not IsJsonOutput) then
       WriteLn(SysUtils.Format('[%d/%d] %s', [I + 1, AFiles.Count, AFiles[I]]));
 
@@ -1552,22 +1612,25 @@ begin
     { Per-file record for the JSON output. Copying strings by value
       keeps the aggregated result self-contained once WorkerData goes
       out of scope. }
-    Result.FileResults[I].FileName := AFiles[I];
-    Result.FileResults[I].LexTimeNanoseconds := Source^.LexNs;
-    Result.FileResults[I].ParseTimeNanoseconds := Source^.ParseNs;
-    Result.FileResults[I].CompileTimeNanoseconds := Source^.CompileNs;
-    Result.FileResults[I].ExecuteTimeNanoseconds := Source^.ExecNs;
-    Result.FileResults[I].Passed := Source^.Passed;
-    Result.FileResults[I].Failed := Source^.Failed;
-    Result.FileResults[I].Skipped := Source^.Skipped;
-    Result.FileResults[I].SuiteErrors := Source^.SuiteErrors;
-    Result.FileResults[I].TotalTests := Source^.TotalRunTests;
-    Result.FileResults[I].ErrorMessage := Source^.ErrorMessage;
-    SetLength(Result.FileResults[I].FailedTests,
+    Result.FileResults[ProcessedCount].FileName := AFiles[I];
+    Result.FileResults[ProcessedCount].LexTimeNanoseconds := Source^.LexNs;
+    Result.FileResults[ProcessedCount].ParseTimeNanoseconds := Source^.ParseNs;
+    Result.FileResults[ProcessedCount].CompileTimeNanoseconds := Source^.CompileNs;
+    Result.FileResults[ProcessedCount].ExecuteTimeNanoseconds := Source^.ExecNs;
+    Result.FileResults[ProcessedCount].Passed := Source^.Passed;
+    Result.FileResults[ProcessedCount].Failed := Source^.Failed;
+    Result.FileResults[ProcessedCount].Skipped := Source^.Skipped;
+    Result.FileResults[ProcessedCount].SuiteErrors := Source^.SuiteErrors;
+    Result.FileResults[ProcessedCount].TotalTests := Source^.TotalRunTests;
+    Result.FileResults[ProcessedCount].ErrorMessage := Source^.ErrorMessage;
+    SetLength(Result.FileResults[ProcessedCount].FailedTests,
       Length(Source^.FailedTestNames));
     for J := 0 to High(Source^.FailedTestNames) do
-      Result.FileResults[I].FailedTests[J] := Source^.FailedTestNames[J];
+      Result.FileResults[ProcessedCount].FailedTests[J] :=
+        Source^.FailedTestNames[J];
+    Inc(ProcessedCount);
   end;
+  SetLength(Result.FileResults, ProcessedCount);
 
   AllTestResults.AssignProperty('totalTests', TGocciaNumberLiteralValue.Create(AFiles.Count * 1.0));
   AllTestResults.AssignProperty('totalRunTests', TGocciaNumberLiteralValue.Create(TotalRunCount));

--- a/source/units/Goccia.Builtins.TestingLibrary.Test.pas
+++ b/source/units/Goccia.Builtins.TestingLibrary.Test.pas
@@ -193,6 +193,8 @@ type
     function RegisterFocusedSuiteCallback(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function RegisterNonFocusedSuiteCallback(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
     function RegisterDescribeEachSuiteCallback(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function RegisterCollectedFirstSuiteCallback(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+    function ThrowingSuiteCallback(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
 
     { describe.skip }
     procedure TestDescribeSkipRegistersSkippedSuite;
@@ -232,6 +234,9 @@ type
     procedure TestTestEachRegistersExpandedTests;
     procedure TestDescribeEachReturnsCallable;
     procedure TestDescribeEachRegistersExpandedSuites;
+
+    { collection abort }
+    procedure TestAbortedCollectionReportsNoRegisteredTests;
   public
     procedure BeforeAll; override;
     procedure AfterAll; override;
@@ -2119,6 +2124,10 @@ begin
   Test('test.each expands tests for each row', TestTestEachRegistersExpandedTests);
   Test('describe.each returns a callable registration function', TestDescribeEachReturnsCallable);
   Test('describe.each expands suites for each row', TestDescribeEachRegistersExpandedSuites);
+
+  { collection abort }
+  Test('a throwing describe discards the tests collected before it',
+    TestAbortedCollectionReportsNoRegisteredTests);
 end;
 
 { describe.skip }
@@ -2456,6 +2465,77 @@ begin
   ResultObj := RunRegisteredTests;
   Expect<Double>(ResultObj.GetProperty('skipped').ToNumberLiteral.Value).ToBe(1);
   Expect<Double>(ResultObj.GetProperty('totalRunTests').ToNumberLiteral.Value).ToBe(1);
+end;
+
+{ Registers one ordinary test, standing in for a suite collected before a
+  later describe throws. }
+function TTestSkipAndConditionalAPIs.RegisterCollectedFirstSuiteCallback(
+  const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+var
+  TestFunc: TGocciaFunctionBase;
+  TestArgs: TGocciaArgumentsCollection;
+begin
+  TestFunc := ResolveGlobalCallable('test');
+  TestArgs := TGocciaArgumentsCollection.Create([
+    TGocciaStringLiteralValue.Create('earlier'),
+    TGocciaNativeFunctionValue.Create(RecordTestBodyCallback, 'recordTest', 0)
+  ]);
+  try
+    TestFunc.Call(TestArgs, nil);
+  finally
+    TestArgs.Free;
+  end;
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+end;
+
+function TTestSkipAndConditionalAPIs.ThrowingSuiteCallback(
+  const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+  raise Exception.Create('registration exploded');
+end;
+
+{ A throw inside a describe callback is a collection failure, and Vitest
+  discards the whole file for it — including suites collected before the
+  throwing one. The run counts already reflected that; `totalTests` did not,
+  so the result object still advertised a test the runner never intended to
+  run. }
+procedure TTestSkipAndConditionalAPIs.TestAbortedCollectionReportsNoRegisteredTests;
+var
+  DescribeFunc: TGocciaFunctionBase;
+  SuiteArgs: TGocciaArgumentsCollection;
+  ResultObj: TGocciaObjectValue;
+begin
+  DescribeFunc := ResolveGlobalCallable('describe');
+
+  SuiteArgs := TGocciaArgumentsCollection.Create([
+    TGocciaStringLiteralValue.Create('collected first'),
+    TGocciaNativeFunctionValue.Create(RegisterCollectedFirstSuiteCallback,
+      'registerCollectedFirst', 0)
+  ]);
+  try
+    DescribeFunc.Call(SuiteArgs, nil);
+  finally
+    SuiteArgs.Free;
+  end;
+
+  SuiteArgs := TGocciaArgumentsCollection.Create([
+    TGocciaStringLiteralValue.Create('boom'),
+    TGocciaNativeFunctionValue.Create(ThrowingSuiteCallback, 'throwingSuite', 0)
+  ]);
+  try
+    DescribeFunc.Call(SuiteArgs, nil);
+  finally
+    SuiteArgs.Free;
+  end;
+
+  ResultObj := RunRegisteredTests;
+  Expect<Double>(ResultObj.GetProperty('totalTests').ToNumberLiteral.Value).ToBe(0);
+  Expect<Double>(ResultObj.GetProperty('totalRunTests').ToNumberLiteral.Value).ToBe(0);
+  Expect<Double>(ResultObj.GetProperty('passed').ToNumberLiteral.Value).ToBe(0);
+  Expect<Double>(ResultObj.GetProperty('suiteErrors').ToNumberLiteral.Value).ToBe(1);
+  { The earlier suite's test never ran. }
+  Expect<String>(FRecordedEvents.CommaText).ToBe('');
 end;
 
 procedure TTestSkipAndConditionalAPIs.TestBeforeAllRunsOncePerSuite;

--- a/source/units/Goccia.Builtins.TestingLibrary.pas
+++ b/source/units/Goccia.Builtins.TestingLibrary.pas
@@ -4132,13 +4132,20 @@ begin
 
       EndTest;
 
+      { Reached when the failure came from somewhere that did not write its
+        own detail line — most often a beforeEach that threw, which skips
+        the body entirely. The name alone leaves the JSON payload without
+        any explanation, so carry the first recorded failure message (the
+        one AssertionFailed kept) into the entry. }
       if FTestStats.CurrentTestHasFailures and not FailureRecorded then
       begin
         if FTestStats.CurrentSuiteName <> '' then
           AFailedTestDetails.Add('Test "' + TestCase.Name + '" in suite "' +
-            FTestStats.CurrentSuiteName + '"')
+            FTestStats.CurrentSuiteName + '"' +
+            FormatHookFailureSuffix(FTestStats.CurrentFailureMessage))
         else
-          AFailedTestDetails.Add('Test "' + TestCase.Name + '"');
+          AFailedTestDetails.Add('Test "' + TestCase.Name + '"' +
+            FormatHookFailureSuffix(FTestStats.CurrentFailureMessage));
       end;
 
       if FTestStats.CurrentTestHasFailures and AExitOnFirstFailure then
@@ -4896,8 +4903,15 @@ begin
 
      // Create result object
     ResultObj := TGocciaObjectValue.Create;
-    ResultObj.AssignProperty('totalTests', TGocciaNumberLiteralValue.Create(
-      CountRegisteredTests(FRootSuite)));
+    { Collection aborted: Vitest discards the whole file, so the tests
+      registered before the throwing describe are not collected either.
+      Reporting them here contradicted the zero run counts beside it — the
+      envelope claimed a total the runner never intended to run. }
+    if FCollectionAborted then
+      ResultObj.AssignProperty('totalTests', TGocciaNumberLiteralValue.ZeroValue)
+    else
+      ResultObj.AssignProperty('totalTests', TGocciaNumberLiteralValue.Create(
+        CountRegisteredTests(FRootSuite)));
     ResultObj.AssignProperty('totalRunTests', TGocciaNumberLiteralValue.Create(
       FTestStats.TotalTests));
     ResultObj.AssignProperty('passed', TGocciaNumberLiteralValue.Create(
@@ -4930,7 +4944,10 @@ begin
           WriteLn('  • ', FailedTestDetails[I]);
       end;
 
-      if FTestStats.FailedTests = 0 then
+      { A suite-level error (throwing describe, failed beforeAll/afterAll)
+        never enters FailedTests, so checking that alone printed "All tests
+        passed!" for a file the runner is about to mark not-ok. }
+      if (FTestStats.FailedTests = 0) and (FTestStats.SuiteErrors = 0) then
       begin
         if FTestStats.SkippedTests > 0 then
           WriteLn(Format('✅ All tests passed! (%d skipped)',

--- a/source/units/Goccia.Threading.pas
+++ b/source/units/Goccia.Threading.pas
@@ -32,6 +32,13 @@ uses
   Goccia.CLI.JSON.Reporter,
   Goccia.Threading.Flags;
 
+const
+  { Error message recorded for a file that was dequeued after the pool had
+    already been cancelled, i.e. one that never ran. Callers that cancel
+    deliberately (CancelOnError) need to tell these apart from genuine
+    failures, so the spelling is shared rather than duplicated. }
+  GOCCIA_POOL_CANCELLED_MESSAGE = 'Cancelled';
+
 type
   { Callback executed on each worker thread for a single file.
     Implementations must NOT call WriteLn directly — capture output in
@@ -333,7 +340,7 @@ begin
         FResults[Idx].Index := Item.Index;
         FResults[Idx].FileName := Item.FileName;
         FResults[Idx].Success := False;
-        FResults[Idx].ErrorMessage := 'Cancelled';
+        FResults[Idx].ErrorMessage := GOCCIA_POOL_CANCELLED_MESSAGE;
         FResults[Idx].ConsoleOutput := '';
         FResults[Idx].Data := nil;
         Continue;

--- a/tests/built-ins/Goccia/expect/toStrictEqual.js
+++ b/tests/built-ins/Goccia/expect/toStrictEqual.js
@@ -84,6 +84,46 @@ describe("toStrictEqual", () => {
     expect(new Point(1)).toStrictEqual(pointPrototype);
   });
 
+  test("resolves an accessor-backed constructor by reading it", () => {
+    // The type check reads `constructor` as an ordinary property, so a
+    // prototype accessor RUNS during the comparison. Vitest 4.1.10 is the
+    // oracle and does the same (its typeEquality compares
+    // `a.constructor === b.constructor`): a getter returning a fresh object
+    // makes two instances of one class differ, and only a getter with a
+    // stable result behaves like the data slot it replaced. Resolving a
+    // "stable type identity" without reading the property would be a
+    // divergence from the oracle, not a fix.
+    class Fresh {
+      constructor(x) {
+        this.x = x;
+      }
+    }
+    Object.defineProperty(Fresh.prototype, "constructor", {
+      get() {
+        return { fresh: true };
+      },
+      configurable: true,
+    });
+    expect(new Fresh(1)).not.toStrictEqual(new Fresh(1));
+    expect(new Fresh(1)).not.toStrictEqual({ x: 1 });
+    // The type never participates in loose equality.
+    expect(new Fresh(1)).toEqual({ x: 1 });
+
+    class Stable {
+      constructor(x) {
+        this.x = x;
+      }
+    }
+    Object.defineProperty(Stable.prototype, "constructor", {
+      get() {
+        return Stable;
+      },
+      configurable: true,
+    });
+    expect(new Stable(1)).toStrictEqual(new Stable(1));
+    expect(new Stable(1)).not.toStrictEqual({ x: 1 });
+  });
+
   test("keeps same-named anonymous classes distinct", () => {
     // Protected divergence: goccia and vitest agree, bun does not.
     const First = class Same {};

--- a/tests/language/modules/goccia-test-module.js
+++ b/tests/language/modules/goccia-test-module.js
@@ -58,9 +58,20 @@ describe("goccia:test", () => {
   });
 
   test("imported helpers drive the same registry as the globals", () => {
+    // Both directions across the import boundary. Asserting an imported mock
+    // with the imported expect only proves the module is self-consistent —
+    // it would still pass if the module got its own private registry.
     const viaImport = mock();
     viaImport("value");
+    globalThis.expect(viaImport).toHaveBeenCalledWith("value");
 
-    expect(viaImport).toHaveBeenCalledWith("value");
+    const viaGlobal = globalThis.mock();
+    viaGlobal("other");
+    expect(viaGlobal).toHaveBeenCalledWith("other");
+
+    // The two spellings are the same function object, not two wrappers over
+    // separate state.
+    expect(globalThis.mock).toBe(mock);
+    expect(globalThis.expect).toBe(expect);
   });
 });

--- a/website/src/__tests__/positioning.test.ts
+++ b/website/src/__tests__/positioning.test.ts
@@ -12,6 +12,24 @@ import {
   VITEST_COMPATIBILITY_ANSWER,
 } from "@/lib/positioning";
 
+/**
+ * Claims the compatibility copy may never make: the drop-in audit has not
+ * closed, and no repository evidence compares this runner's wall-clock
+ * against Vitest.
+ *
+ * Each alternative carries its own boundaries because `%` is not a word
+ * character — a single trailing `\b` around the whole alternation silently
+ * stopped `100%` from ever matching when followed by a space.
+ */
+const FORBIDDEN_CLAIM_PATTERNS: readonly RegExp[] = [
+  /\b100\s*%/i,
+  /\bexact(?:ly)?\s+compatible\b/i,
+  /\bfully\s+compatible\b/i,
+  /\bcomplete\s+drop-in\b/i,
+  /\b(?:faster|quicker|speedier|snappier)\s+than\s+Vitest\b/i,
+  /\b(?:outperforms|outpaces|outruns|beats)\s+Vitest\b/i,
+];
+
 function expectConcepts(text: string, concepts: readonly RegExp[]) {
   for (const concept of concepts) {
     expect(text).toMatch(concept);
@@ -76,11 +94,47 @@ describe("GocciaScript positioning", () => {
   });
 
   test("never upgrades the compatibility direction into an absolute claim", () => {
-    // The drop-in audit has not closed, and no repository evidence compares
-    // this runner's wall-clock against Vitest. Copy must not imply either.
-    expect(VITEST_COMPATIBILITY_ANSWER).not.toMatch(
-      /\b(100%|exact(ly)? compatible|fully compatible|complete drop-in|faster than Vitest)\b/i,
-    );
+    for (const pattern of FORBIDDEN_CLAIM_PATTERNS)
+      expect(VITEST_COMPATIBILITY_ANSWER).not.toMatch(pattern);
+  });
+
+  // A guard that cannot match the phrasing it forbids is worse than none: it
+  // reads as coverage. `100%` ended in a non-word character, so a trailing
+  // \b required a word character after the percent sign and `100% compatible`
+  // slipped through; the performance rule only knew one verb.
+  test("the forbidden-claim guard matches the phrasings it exists to stop", () => {
+    const forbidden = [
+      "100% compatible with Vitest.",
+      "100%-compatible today.",
+      "It is 100 % compatible.",
+      "The runner is exactly compatible with Vitest.",
+      "The runner is exactly compatible.",
+      "It is fully compatible with Vitest.",
+      "A complete drop-in for Vitest.",
+      "It is faster than Vitest.",
+      "It is much faster than Vitest on every suite.",
+      "It outperforms Vitest.",
+      "The runner beats Vitest on wall-clock.",
+      "It outpaces Vitest.",
+      "Runs quicker than Vitest.",
+    ];
+
+    for (const claim of forbidden)
+      expect(
+        FORBIDDEN_CLAIM_PATTERNS.some((pattern) => pattern.test(claim)),
+      ).toBe(true);
+
+    // The guard must not fire on the copy the answer is allowed to make.
+    const allowed = [
+      "Vitest is the semantics oracle for this runner.",
+      "Compatibility is a direction, not a finished claim.",
+      "About 90 tests exercise the matchers.",
+    ];
+
+    for (const claim of allowed)
+      expect(
+        FORBIDDEN_CLAIM_PATTERNS.some((pattern) => pattern.test(claim)),
+      ).toBe(false);
   });
 
   test("states the complete Delphi support contract", () => {
@@ -101,7 +155,9 @@ describe("GocciaScript positioning", () => {
     expect(canonicalCopy).not.toContain("No traditional loops");
     expect(canonicalCopy).not.toContain("parsed and discarded");
     expect(canonicalCopy).not.toContain("there is no separate type-checker");
-    expect(canonicalCopy).not.toMatch(/\b\d{2,3}(?:\.\d+)?%\b/);
+    // No trailing \b: `%` is not a word character, so requiring a boundary
+    // after it means the pattern only matches a percentage glued to a word.
+    expect(canonicalCopy).not.toMatch(/\b\d{2,3}(?:\.\d+)?\s*%/);
   });
 
   test("structured data reuses the visible positioning FAQ", () => {


### PR DESCRIPTION
## Summary

- Round-2 CodeRabbit fix layer: **14 of 15 findings** across six frozen layers (#1091, #1092, #1093, #1096, #1097, #1098, #1099), landing in one layer per freeze doctrine.
- **Biggest catch, beyond the finding:** fixing `--exit-on-first-failure` for `suiteErrors` revealed the parallel worker never assigned a pool error message — `Pool.CancelOnError` was inert for *every* failure kind. Workers now emit a cancellation sentinel, aggregation preserves the failing file's own numbers, and queue-cancelled files are omitted rather than synthesised as failures (A/B proof: 6 file results without the flag, 2 with).
- Correctness: a failing `beforeEach` carries its message into `failedTests` (previously only the test name reached JSON); the pass summary requires zero suite errors; an aborted collection reports `totalTests: 0`.
- Test-quality (findings that could pass while broken): stdin cases now prove the source executed via per-binary postconditions including a bundler artifact roundtrip; help/compat-flag cases assert process status; the positioning claims-guard regex catches `100%`-style and broader performance phrasings (plus the same defect in a sibling regex); the differential harness guards null skip counts; the `goccia:test` registry test crosses the import/global boundary in both directions.
- **One finding declined with evidence:** the accessor-backed `constructor` proposal would diverge from the oracle — Vitest 4.1.10 compares constructors as ordinary property reads and *fails* that case; implementing "stable type identity" made goccia pass where Vitest fails. Oracle behavior is pinned by new tests in `toStrictEqual.js` and battery D instead (goccia 33p/0f = vitest 33p/0f).

Stack #1083 layer 25.

## Testing

- [x] Verified in end-to-end tests — full suite 12,087/12,087 both modes; CLI harness, differential harness (0 divergences), format, all doc validators, `check-test-structure`, `check-trunc-guards` exit 0; touched Pascal test programs pass (TestingLibrary 168, CLI.Stdin 14)
- [x] Updated documentation — testing-api.md, cli-conventions.md, testing.md
- [x] Optional: native Pascal tests — collection-abort guard proven by reverting it (fails "Expected 1 to be 0")
- [ ] Optional: benchmarks — n/a

Known gap: the full 66-program Pascal sweep (~3h) was not run locally — the two touched programs pass; CI covers the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
