### PR TITLE
fix(threading): guard the pool cancellation flag behind a lock

### DIFF
--- a/docs/contributing/cli-conventions.md
+++ b/docs/contributing/cli-conventions.md
@@ -12,7 +12,7 @@
 
 ## The no-argument rule
 
-Several binaries take their program source from standard input when no path is given. Without a guard, running one bare at a terminal blocks inside `ReadLn` until the user presses Ctrl-D — the command looks hung, with no output explaining why.
+Several binaries take their program source from standard input when no path is given. Without a guard, running one bare at a terminal blocks inside `ReadLn` until the user signals end of input — Ctrl-D on a Unix console, Ctrl-Z then Enter on a Windows one — and the command looks hung, with no output explaining why. `EndOfInputKeys` in `Goccia.CLI.Stdin` is the single source for that key sequence, so the hint printed at runtime always names the right one for the platform.
 
 [The Command Line Interface Guidelines](https://clig.dev/) state the rule plainly: if a command expects something piped to it and stdin is an interactive terminal, it should display help immediately and quit, rather than just hanging the way `cat` does.
 

--- a/source/app/Goccia.CLI.Application.pas
+++ b/source/app/Goccia.CLI.Application.pas
@@ -1573,7 +1573,8 @@ begin
     { clig.dev: "If your command is expecting to have something piped
       to it and stdin is an interactive terminal, display help
       immediately and quit."  Without this, a bare invocation at a
-      terminal blocks on ReadLn until Ctrl-D and looks stuck.  Help
+      terminal blocks on ReadLn until the platform's end-of-input keys
+      (EndOfInputKeys) are pressed and looks stuck.  Help
       goes to stderr because this is an error, not a request for help,
       which also keeps stdout clean for --output=json callers. }
     if (StdinUsage <> suNone) and

--- a/source/units/Goccia.Threading.Test.pas
+++ b/source/units/Goccia.Threading.Test.pas
@@ -28,6 +28,8 @@ type
     procedure TestPoolResultsInFileOrder;
     procedure TestPoolCancelSkipsRemaining;
     procedure TestPoolCancelOnErrorStopsOnFailure;
+    procedure TestCancellationFlagLifecycle;
+    procedure TestPoolCancelOnErrorBoundsWorkAcrossWorkers;
     procedure TestPoolResetsCancelledBetweenRuns;
     procedure TestPoolHandlesEmptyFileList;
     procedure TestPoolSingleWorker;
@@ -80,6 +82,11 @@ type
     procedure FailOnSecondWorker(const AFileName: string;
       const AIndex: Integer; out AConsoleOutput: string;
       out AErrorMessage: string; AData: Pointer);
+    { Counts every invocation and fails on 'fail.js', so a test can assert
+      how much work actually reached the worker callback after a cancel. }
+    procedure CountingFailWorker(const AFileName: string;
+      const AIndex: Integer; out AConsoleOutput: string;
+      out AErrorMessage: string; AData: Pointer);
   end;
 
 procedure TTestWorkerHost.CountingWorker(const AFileName: string;
@@ -109,6 +116,23 @@ begin
     AErrorMessage := '';
 end;
 
+procedure TTestWorkerHost.CountingFailWorker(const AFileName: string;
+  const AIndex: Integer; out AConsoleOutput: string;
+  out AErrorMessage: string; AData: Pointer);
+begin
+  AConsoleOutput := '';
+  CriticalSectionEnter(GWorkerLock);
+  try
+    Inc(GWorkerCallCount);
+  finally
+    CriticalSectionLeave(GWorkerLock);
+  end;
+  if AFileName = 'fail.js' then
+    AErrorMessage := 'deliberate failure'
+  else
+    AErrorMessage := '';
+end;
+
 { TTestThreading }
 
 procedure TTestThreading.SetupTests;
@@ -120,6 +144,9 @@ begin
   Test('Pool results in file order', TestPoolResultsInFileOrder);
   Test('Pool Cancel skips remaining', TestPoolCancelSkipsRemaining);
   Test('Pool CancelOnError stops on failure', TestPoolCancelOnErrorStopsOnFailure);
+  Test('CancellationFlag cancels and resets', TestCancellationFlagLifecycle);
+  Test('Pool CancelOnError bounds work across workers',
+    TestPoolCancelOnErrorBoundsWorkAcrossWorkers);
   Test('Pool resets Cancelled between runs', TestPoolResetsCancelledBetweenRuns);
   Test('Pool handles empty file list', TestPoolHandlesEmptyFileList);
   Test('Pool single worker processes all files', TestPoolSingleWorker);
@@ -321,6 +348,77 @@ begin
       Expect<Boolean>(CancelledCount > 0).ToBe(True);
     finally
       Pool.Free;
+    end;
+  finally
+    Files.Free;
+    Host.Free;
+  end;
+end;
+
+{ The flag is the pool's only stop signal and every thread reaches it
+  through these three methods, so its state machine is worth pinning
+  directly rather than only through a pool run. }
+procedure TTestThreading.TestCancellationFlagLifecycle;
+var
+  Flag: TGocciaCancellationFlag;
+begin
+  Flag := TGocciaCancellationFlag.Create;
+  try
+    Expect<Boolean>(Flag.IsCancelled).ToBe(False);
+    Flag.Cancel;
+    Expect<Boolean>(Flag.IsCancelled).ToBe(True);
+    // Cancel is idempotent — a second failing file must not un-cancel.
+    Flag.Cancel;
+    Expect<Boolean>(Flag.IsCancelled).ToBe(True);
+    Flag.Reset;
+    Expect<Boolean>(Flag.IsCancelled).ToBe(False);
+  finally
+    Flag.Free;
+  end;
+end;
+
+{ Regression guard for the shared-cancellation-flag data race: the flag
+  used to be a plain Boolean written and read by several threads without
+  synchronisation, so a worker could observe a stale False after a peer
+  had already failed and keep pulling queued files.  With the failing
+  file first in a long queue and eight workers, only the handful of files
+  already in flight may reach the callback; a worker that misses the
+  cancel drains the rest of the queue and blows the bound.  Repeated
+  because a lost update is timing-dependent and a single run proves
+  little. }
+procedure TTestThreading.TestPoolCancelOnErrorBoundsWorkAcrossWorkers;
+const
+  FILE_COUNT = 2000;
+  WORKER_COUNT = 8;
+  { Generous: the true in-flight set is at most WORKER_COUNT.  The bound
+    only has to separate "cancelled promptly" from "drained the queue". }
+  MAX_EXECUTED = 200;
+var
+  Pool: TGocciaThreadPool;
+  Files: TStringList;
+  Host: TTestWorkerHost;
+  Iteration, I: Integer;
+begin
+  Host := TTestWorkerHost.Create;
+  Files := TStringList.Create;
+  try
+    Files.Add('fail.js');
+    for I := 1 to FILE_COUNT - 1 do
+      Files.Add('ok' + IntToStr(I) + '.js');
+
+    for Iteration := 1 to 10 do
+    begin
+      ResetWorkerState;
+      Pool := TGocciaThreadPool.Create(WORKER_COUNT);
+      try
+        Pool.CancelOnError := True;
+        Pool.RunAll(Files, Host.CountingFailWorker);
+        Expect<Boolean>(Pool.Cancelled).ToBe(True);
+        Expect<Boolean>(GWorkerCallCount >= 1).ToBe(True);
+        Expect<Boolean>(GWorkerCallCount <= MAX_EXECUTED).ToBe(True);
+      finally
+        Pool.Free;
+      end;
     end;
   finally
     Files.Free;

--- a/source/units/Goccia.Threading.pas
+++ b/source/units/Goccia.Threading.pas
@@ -80,13 +80,37 @@ type
     function TryDequeue(out AItem: TGocciaWorkItem): Boolean;
   end;
 
+  { Shared cancellation flag — the pool's stop signal, read and written
+    from the main thread and from every worker.  The Boolean itself is
+    private and reachable only through these three methods, so there is
+    no way to touch it outside the lock; a plain shared Boolean let a
+    worker observe a stale False after a peer had already cancelled and
+    run further queued files.  The lock is the same critical-section
+    idiom TGocciaWorkQueue uses, and it is taken once per dequeued file
+    — nothing next to the cost of running one. }
+  TGocciaCancellationFlag = class
+  private
+    FCancelled: Boolean;
+    FLock: TGocciaCriticalSection;
+  public
+    constructor Create;
+    destructor Destroy; override;
+    { True once Cancel has been called and Reset has not. }
+    function IsCancelled: Boolean;
+    procedure Cancel;
+    { Clears the flag for a fresh run. Main thread only, before workers start. }
+    procedure Reset;
+  end;
+
   TGocciaFileWorker = class(TThread)
   private
     FQueue: TGocciaWorkQueue;
     FResults: TGocciaWorkerResultArray;
     FResultCount: Integer;
     FWorkerProc: TGocciaWorkerProc;
-    FCancelled: PBoolean;
+    { Not owned — the pool owns this flag and outlives the worker, except
+      for abandoned workers, for which the pool deliberately leaks it. }
+    FCancelFlag: TGocciaCancellationFlag;
     FCancelOnError: Boolean;
     FEnableCoverage: Boolean;
     FMaxBytes: Int64;
@@ -110,7 +134,7 @@ type
     procedure Execute; override;
   public
     constructor Create(AQueue: TGocciaWorkQueue;
-      AWorkerProc: TGocciaWorkerProc; ACancelled: PBoolean;
+      AWorkerProc: TGocciaWorkerProc; ACancelFlag: TGocciaCancellationFlag;
       ACancelOnError: Boolean; AEnableCoverage: Boolean; AMaxBytes: Int64;
       AData: Pointer);
     property Results: TGocciaWorkerResultArray read FResults;
@@ -135,13 +159,19 @@ type
     // exit; the alternative of TerminateThread is unsafe across FPC
     // platforms and would corrupt the shared GC's bookkeeping anyway.
     FAbandoned: array of Boolean;
-    FCancelled: Boolean;
+    { The single shared stop signal handed to every worker.  Owned here,
+      but leaked instead of freed once a worker has been abandoned —
+      that thread is still alive in native code and still reads it. }
+    FCancelFlag: TGocciaCancellationFlag;
+    FCancelFlagLeaked: Boolean;
     FCancelOnError: Boolean;
     FEnableCoverage: Boolean;
     FMaxBytes: Int64;
     FMemoryStats: TCLIJSONMemoryStats;
+    function GetCancelled: Boolean;
   public
     constructor Create(AWorkerCount: Integer);
+    destructor Destroy; override;
 
     { Execute AFiles across worker threads. Blocks until all complete.
       AWorkerProc is called on each worker thread for each file.
@@ -166,7 +196,9 @@ type
     property Results: TGocciaWorkerResultArray read FResults;
     property MemoryStats: TCLIJSONMemoryStats read FMemoryStats;
     property WorkerCount: Integer read FWorkerCount;
-    property Cancelled: Boolean read FCancelled;
+    { Reads the shared flag under its lock, so callers never see a torn
+      or stale value while workers are still running. }
+    property Cancelled: Boolean read GetCancelled;
     { When True, the first worker error automatically cancels remaining files. }
     property CancelOnError: Boolean read FCancelOnError write FCancelOnError;
     { When True, each worker initialises a per-thread coverage tracker.
@@ -285,10 +317,55 @@ begin
   end;
 end;
 
+{ TGocciaCancellationFlag }
+
+constructor TGocciaCancellationFlag.Create;
+begin
+  inherited Create;
+  FCancelled := False;
+  CriticalSectionInit(FLock);
+end;
+
+destructor TGocciaCancellationFlag.Destroy;
+begin
+  CriticalSectionDone(FLock);
+  inherited;
+end;
+
+function TGocciaCancellationFlag.IsCancelled: Boolean;
+begin
+  CriticalSectionEnter(FLock);
+  try
+    Result := FCancelled;
+  finally
+    CriticalSectionLeave(FLock);
+  end;
+end;
+
+procedure TGocciaCancellationFlag.Cancel;
+begin
+  CriticalSectionEnter(FLock);
+  try
+    FCancelled := True;
+  finally
+    CriticalSectionLeave(FLock);
+  end;
+end;
+
+procedure TGocciaCancellationFlag.Reset;
+begin
+  CriticalSectionEnter(FLock);
+  try
+    FCancelled := False;
+  finally
+    CriticalSectionLeave(FLock);
+  end;
+end;
+
 { TGocciaFileWorker }
 
 constructor TGocciaFileWorker.Create(AQueue: TGocciaWorkQueue;
-  AWorkerProc: TGocciaWorkerProc; ACancelled: PBoolean;
+  AWorkerProc: TGocciaWorkerProc; ACancelFlag: TGocciaCancellationFlag;
   ACancelOnError: Boolean; AEnableCoverage: Boolean; AMaxBytes: Int64;
   AData: Pointer);
 const
@@ -298,7 +375,7 @@ begin
   FreeOnTerminate := False;
   FQueue := AQueue;
   FWorkerProc := AWorkerProc;
-  FCancelled := ACancelled;
+  FCancelFlag := ACancelFlag;
   FCancelOnError := ACancelOnError;
   FEnableCoverage := AEnableCoverage;
   FMaxBytes := AMaxBytes;
@@ -331,7 +408,7 @@ begin
       FCurrentFileIndex := Item.Index;
       FLastActivityNs := GetNanoseconds;
 
-      if FCancelled^ then
+      if FCancelFlag.IsCancelled then
       begin
         Idx := FResultCount;
         Inc(FResultCount);
@@ -379,7 +456,7 @@ begin
 
       { Cancel remaining files across all workers on first error. }
       if FCancelOnError and (not FResults[Idx].Success) then
-        FCancelled^ := True;
+        FCancelFlag.Cancel;
     end;
   finally
     // Refresh the timestamp as we exit the work loop so the watchdog
@@ -400,11 +477,28 @@ constructor TGocciaThreadPool.Create(AWorkerCount: Integer);
 begin
   inherited Create;
   FWorkerCount := Max(1, AWorkerCount);
-  FCancelled := False;
+  FCancelFlag := TGocciaCancellationFlag.Create;
+  FCancelFlagLeaked := False;
   FCancelOnError := False;
   FEnableCoverage := False;
   FMaxBytes := 0;
   FMemoryStats := DefaultCLIJSONMemoryStats;
+end;
+
+destructor TGocciaThreadPool.Destroy;
+begin
+  // Same rule as the work queue: an abandoned worker is still running and
+  // still calls IsCancelled on this flag, so freeing it would be a
+  // use-after-free.  Leak it and let the OS reclaim it on process exit.
+  if not FCancelFlagLeaked then
+    FCancelFlag.Free;
+  FCancelFlag := nil;
+  inherited;
+end;
+
+function TGocciaThreadPool.GetCancelled: Boolean;
+begin
+  Result := FCancelFlag.IsCancelled;
 end;
 
 procedure TGocciaThreadPool.RunAll(const AFiles: TStringList;
@@ -419,7 +513,7 @@ var
   StalledFiles: TGocciaWorkerResultArray;
   SnapshotResults: TGocciaWorkerResultArray;
 begin
-  FCancelled := False;
+  FCancelFlag.Reset;
   FMemoryStats := DefaultCLIJSONMemoryStats;
   AnyAbandoned := False;
   FileCount := AFiles.Count;
@@ -454,7 +548,7 @@ begin
     for I := 0 to FWorkerCount - 1 do
     begin
       FWorkers[I] := TGocciaFileWorker.Create(Queue, AWorkerProc,
-        @FCancelled, FCancelOnError, FEnableCoverage, FMaxBytes, AData);
+        FCancelFlag, FCancelOnError, FEnableCoverage, FMaxBytes, AData);
       FWorkers[I].Start;
     end;
   finally
@@ -545,8 +639,14 @@ begin
         'they will be reclaimed on process exit.');
 
     // Only free the queue when no abandoned workers remain — they
-    // still hold a reference to it via FQueue.
-    if not AnyAbandoned then
+    // still hold a reference to it via FQueue.  The shared cancellation
+    // flag is reached the same way (FCancelFlag), so an abandonment also
+    // takes it out of this pool's ownership for good; a later RunAll on
+    // this pool keeps using the same flag object, exactly as before, so
+    // the zombie never sees freed memory.
+    if AnyAbandoned then
+      FCancelFlagLeaked := True
+    else
       Queue.Free;
   end;
 
@@ -629,7 +729,7 @@ end;
 
 procedure TGocciaThreadPool.Cancel;
 begin
-  FCancelled := True;
+  FCancelFlag.Cancel;
 end;
 
 procedure TGocciaThreadPool.MergeCoverageInto(ATarget: TObject);


### PR DESCRIPTION
## Summary

- Fixes both findings from #1101's review, one of them a **data race the round-2 layer introduced**: the pool's shared cancel flag was a raw `PBoolean` read and written across threads with no synchronization (disassembly: bare `ldrb`/`strb`, no barriers), so a worker could observe a stale `False` after the first failure and keep draining the queue.
- It becomes a small lock-owning `TGocciaCancellationFlag` on the unit's existing critical-section idiom — the Boolean is private, reachable only through three locked methods, so no future access site can bypass it. All seven sites are covered (worker read/write, pool init, `RunAll` reset, `Cancel`, the `Cancelled` property getter, worker handoff).
- **Bonus defect closed:** the old `@FCancelled` pointed into the pool object, so an abandoned watchdog-stalled worker kept dereferencing it after `Pool.Free` — a use-after-free every caller could hit. The flag now follows the work queue's established leak rule.
- Evidence, since a passing suite proves nothing about races: 400 stress files with a failure at index 8 under `--exit-on-first-failure` — pre-fix the post-cancel file count wobbled (jobs=4: 9–12; jobs=8: 10–16), post-fix it pins at the analytic minimum `8 + jobs` across 25/25 runs per job count. Two new threading regressions, one bounding executed files so a missed cancel blows the assert.
- Audited the rest of the round-2 layer's cross-thread surface: no second instance. Two pre-existing best-effort watchdog fields (`FLastActivityNs`, `FCurrentFileIndex`) are flagged, not silently widened into scope.
- Minor: end-of-input docs are platform-neutral (Ctrl-D / Ctrl-Z+Enter), matching the runtime strings, plus a stale code comment.

Stack #1083 layer 26.

## Testing

- [x] Verified in end-to-end tests — full suite 12,087/12,087 both modes; **all 66 Pascal test programs exit 0** including `Goccia.Threading.Test` (14/14); CLI harness, differential harness (0 divergences), format, all doc validators exit 0
- [x] Updated documentation — cli-conventions.md end-of-input guidance
- [x] Optional: native Pascal tests — flag state-machine test + `Pool CancelOnError bounds work across workers` (8 workers, 2000 files, 10 repeats)
- [ ] Optional: benchmarks — n/a (lock is on the per-file boundary, not a hot path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
