### PR TITLE
fix(threading): give each run its own cancellation flag after abandonment

### DIFF
--- a/source/units/Goccia.Threading.Test.pas
+++ b/source/units/Goccia.Threading.Test.pas
@@ -30,6 +30,7 @@ type
     procedure TestPoolCancelOnErrorStopsOnFailure;
     procedure TestCancellationFlagLifecycle;
     procedure TestPoolCancelOnErrorBoundsWorkAcrossWorkers;
+    procedure TestResumedAbandonedWorkerCannotCancelLaterRun;
     procedure TestPoolResetsCancelledBetweenRuns;
     procedure TestPoolHandlesEmptyFileList;
     procedure TestPoolSingleWorker;
@@ -87,7 +88,53 @@ type
     procedure CountingFailWorker(const AFileName: string;
       const AIndex: Integer; out AConsoleOutput: string;
       out AErrorMessage: string; AData: Pointer);
+    { Blocks on 'stall.js' until the main thread releases it, then fails —
+      the shape the watchdog abandons, resuming only once a later run is
+      already in flight. }
+    procedure StallThenFailWorker(const AFileName: string;
+      const AIndex: Integer; out AConsoleOutput: string;
+      out AErrorMessage: string; AData: Pointer);
+    { Deliberately slow so a later run stays in flight long enough for a
+      resumed zombie's cancellation to be observable if it leaked in. }
+    procedure SlowCountingWorker(const AFileName: string;
+      const AIndex: Integer; out AConsoleOutput: string;
+      out AErrorMessage: string; AData: Pointer);
   end;
+
+{ Release gate for the stalling worker.  Guarded rather than a bare
+  Boolean: this file is the regression suite for an unsynchronised
+  cross-thread flag, so the test must not reintroduce one. }
+var
+  GStallReleased: Boolean;
+
+procedure ReleaseStalledWorker;
+begin
+  CriticalSectionEnter(GWorkerLock);
+  try
+    GStallReleased := True;
+  finally
+    CriticalSectionLeave(GWorkerLock);
+  end;
+end;
+
+function StallReleased: Boolean;
+begin
+  CriticalSectionEnter(GWorkerLock);
+  try
+    Result := GStallReleased;
+  finally
+    CriticalSectionLeave(GWorkerLock);
+  end;
+end;
+
+{ Worker-thread exits observed so far.  SentinelWorkerCleanup increments
+  this from every worker's ShutdownThreadRuntime, which is the only
+  externally visible signal that an abandoned thread has fully retired. }
+function WorkerExitCount: Integer;
+begin
+  ReadMemoryBarrier;
+  Result := GSentinelWorkerCount;
+end;
 
 procedure TTestWorkerHost.CountingWorker(const AFileName: string;
   const AIndex: Integer; out AConsoleOutput: string;
@@ -133,6 +180,36 @@ begin
     AErrorMessage := '';
 end;
 
+procedure TTestWorkerHost.StallThenFailWorker(const AFileName: string;
+  const AIndex: Integer; out AConsoleOutput: string;
+  out AErrorMessage: string; AData: Pointer);
+begin
+  AConsoleOutput := '';
+  AErrorMessage := '';
+  if AFileName <> 'stall.js' then
+    Exit;
+  // Stand in for a worker wedged in native code: the pool's watchdog sees
+  // no progress and abandons this thread while it is still alive here.
+  while not StallReleased do
+    Sleep(1);
+  AErrorMessage := 'deliberate failure after resuming';
+end;
+
+procedure TTestWorkerHost.SlowCountingWorker(const AFileName: string;
+  const AIndex: Integer; out AConsoleOutput: string;
+  out AErrorMessage: string; AData: Pointer);
+begin
+  AConsoleOutput := '';
+  AErrorMessage := '';
+  Sleep(5);
+  CriticalSectionEnter(GWorkerLock);
+  try
+    Inc(GWorkerCallCount);
+  finally
+    CriticalSectionLeave(GWorkerLock);
+  end;
+end;
+
 { TTestThreading }
 
 procedure TTestThreading.SetupTests;
@@ -152,6 +229,12 @@ begin
   Test('Pool single worker processes all files', TestPoolSingleWorker);
   Test('ThreadCleanupRegistry runs registered callbacks', TestThreadCleanupRegistryRunsRegistered);
   Test('ShutdownThreadRuntime drains registry once per worker', TestShutdownThreadRuntimeDrainsRegistryPerWorker);
+  { Registered last: this is the only case that deliberately strands a
+    worker thread.  It joins that thread before returning, but running it
+    after the registry tests keeps their exact sentinel counts out of
+    reach of a straggler even if that join ever regressed. }
+  Test('Resumed abandoned worker cannot cancel a later run',
+    TestResumedAbandonedWorkerCannotCancelLaterRun);
 end;
 
 procedure TTestThreading.TestWorkQueueDrainsAllItems;
@@ -419,6 +502,90 @@ begin
       finally
         Pool.Free;
       end;
+    end;
+  finally
+    Files.Free;
+    Host.Free;
+  end;
+end;
+
+{ Regression guard for cancellation-flag ownership across an abandonment.
+  The flag is a pool field, so a run that abandons a worker used to hand
+  the zombie a pointer to the very object the NEXT run would reset and
+  reuse.  A zombie that later unsticks, finishes its old file and fails
+  then calls Cancel — landing on an unrelated run and silently skipping
+  files nobody asked to stop.  Here run 1 strands a worker, run 2 starts
+  on what must be a fresh flag, and the zombie is released so its failure
+  lands squarely inside run 2.  If the two runs share a flag, run 2's
+  files are marked cancelled instead of executed and both assertions
+  below fail loudly. }
+procedure TTestThreading.TestResumedAbandonedWorkerCannotCancelLaterRun;
+const
+  STALL_WATCHDOG_MS = 200;
+  LATER_RUN_FILES = 200;
+  { Run 1 spawns 2 workers (one strands, one finds no work) and run 2
+    spawns 2 more; every worker thread increments the exit counter from
+    ShutdownThreadRuntime as it retires. }
+  EXPECTED_WORKER_EXITS = 4;
+var
+  Pool: TGocciaThreadPool;
+  Files: TStringList;
+  Host: TTestWorkerHost;
+  ExitBaseline, I, WaitedMs: Integer;
+  AllSucceeded: Boolean;
+begin
+  ResetWorkerState;
+  GStallReleased := False;
+  ExitBaseline := WorkerExitCount;
+  Host := TTestWorkerHost.Create;
+  Files := TStringList.Create;
+  try
+    { Run 1 — the only file wedges its worker, so the watchdog abandons
+      that thread and RunAll returns while it is still alive.  Its queue
+      is left empty, so once released it finishes and exits promptly. }
+    Files.Add('stall.js');
+    Pool := TGocciaThreadPool.Create(2);
+    try
+      // CancelOnError must be armed here: the zombie captured this at
+      // construction, and it is what makes its later failure call Cancel.
+      Pool.CancelOnError := True;
+      Pool.RunAll(Files, Host.StallThenFailWorker, nil, STALL_WATCHDOG_MS);
+
+      { Run 2 — a long, entirely healthy batch on the same pool. }
+      Files.Clear;
+      for I := 1 to LATER_RUN_FILES do
+        Files.Add('later' + IntToStr(I) + '.js');
+      ResetWorkerState;
+
+      // Let the zombie resume and fail while run 2 is in flight.
+      ReleaseStalledWorker;
+      Pool.RunAll(Files, Host.SlowCountingWorker);
+
+      // Nothing in run 2 failed, so nothing may have cancelled it.
+      Expect<Boolean>(Pool.Cancelled).ToBe(False);
+      // Every file must have reached the callback — a leaked-in cancel
+      // shows up as dequeued-but-skipped files, not as an error.
+      Expect<Integer>(GWorkerCallCount).ToBe(LATER_RUN_FILES);
+      AllSucceeded := True;
+      for I := 0 to High(Pool.Results) do
+        if not Pool.Results[I].Success then
+          AllSucceeded := False;
+      Expect<Boolean>(AllSucceeded).ToBe(True);
+
+      { Retire the zombie before leaving: it drains the shared cleanup
+        registry on its way out, and the registry tests assert exact
+        counts.  Its exit is observable only through that same counter. }
+      WaitedMs := 0;
+      while (WorkerExitCount - ExitBaseline < EXPECTED_WORKER_EXITS)
+          and (WaitedMs < 5000) do
+      begin
+        Sleep(10);
+        Inc(WaitedMs, 10);
+      end;
+      Expect<Integer>(WorkerExitCount - ExitBaseline)
+        .ToBe(EXPECTED_WORKER_EXITS);
+    finally
+      Pool.Free;
     end;
   finally
     Files.Free;

--- a/source/units/Goccia.Threading.pas
+++ b/source/units/Goccia.Threading.pas
@@ -159,10 +159,16 @@ type
     // exit; the alternative of TerminateThread is unsafe across FPC
     // platforms and would corrupt the shared GC's bookkeeping anyway.
     FAbandoned: array of Boolean;
-    { The single shared stop signal handed to every worker.  Owned here,
-      but leaked instead of freed once a worker has been abandoned —
-      that thread is still alive in native code and still reads it. }
+    { The stop signal handed to every worker of the CURRENT run.  Owned
+      here and freed with the pool, except once a worker has been
+      abandoned: that thread is still alive and still reads the flag it
+      was given, so the flag is leaked to it and the next run starts on a
+      replacement.  One flag therefore never spans an abandonment. }
     FCancelFlag: TGocciaCancellationFlag;
+    { True while FCancelFlag belongs to an abandoned worker rather than to
+      this pool.  Set when a run abandons, cleared when the next run mints
+      a replacement — so the destructor frees exactly the flags the pool
+      still owns and never one a zombie is reading. }
     FCancelFlagLeaked: Boolean;
     FCancelOnError: Boolean;
     FEnableCoverage: Boolean;
@@ -488,8 +494,10 @@ end;
 destructor TGocciaThreadPool.Destroy;
 begin
   // Same rule as the work queue: an abandoned worker is still running and
-  // still calls IsCancelled on this flag, so freeing it would be a
-  // use-after-free.  Leak it and let the OS reclaim it on process exit.
+  // still calls IsCancelled on the flag it holds, so freeing that one
+  // would be a use-after-free.  Leak it and let the OS reclaim it on
+  // process exit.  Any flag replaced by a later run was already leaked
+  // under this same rule, so every owned flag is freed exactly once.
   if not FCancelFlagLeaked then
     FCancelFlag.Free;
   FCancelFlag := nil;
@@ -513,7 +521,20 @@ var
   StalledFiles: TGocciaWorkerResultArray;
   SnapshotResults: TGocciaWorkerResultArray;
 begin
-  FCancelFlag.Reset;
+  if FCancelFlagLeaked then
+  begin
+    // A previous run abandoned a worker that is still alive and still
+    // reads the flag it was handed.  That flag now belongs to the zombie
+    // alone — resetting it here would re-arm a signal the zombie can
+    // still fire: if it ever unsticks, finishes its old file and fails,
+    // its Cancel would land on THIS run and skip files that were never
+    // asked to stop.  Give it up for good (it is leaked, never freed)
+    // and dispatch this run on a fresh flag we own.
+    FCancelFlag := TGocciaCancellationFlag.Create;
+    FCancelFlagLeaked := False;
+  end
+  else
+    FCancelFlag.Reset;
   FMemoryStats := DefaultCLIJSONMemoryStats;
   AnyAbandoned := False;
   FileCount := AFiles.Count;
@@ -639,11 +660,12 @@ begin
         'they will be reclaimed on process exit.');
 
     // Only free the queue when no abandoned workers remain — they
-    // still hold a reference to it via FQueue.  The shared cancellation
-    // flag is reached the same way (FCancelFlag), so an abandonment also
-    // takes it out of this pool's ownership for good; a later RunAll on
-    // this pool keeps using the same flag object, exactly as before, so
-    // the zombie never sees freed memory.
+    // still hold a reference to it via FQueue.  Each run builds its own
+    // queue, so a leaked one belongs to that run's zombie and can never
+    // reach a later run.  The cancellation flag is different: it is a
+    // pool field that every run would otherwise share, so marking it
+    // leaked here only settles ownership for THIS run — the next RunAll
+    // replaces it with a fresh instance rather than reusing it.
     if AnyAbandoned then
       FCancelFlagLeaked := True
     else


### PR DESCRIPTION
## Summary

- Closes the follow-on defect #1102's review found in its own fix: leaking the cancellation flag to an abandoned worker kept that pointer valid (the use-after-free fix) but left the **pool** using the same object, so `RunAll`'s reset re-armed a signal the zombie could still fire — a resumed worker failing its old file cancelled an unrelated later run.
- Ownership is now unambiguous: an abandoned run's flag belongs solely to that zombie (never reset, never freed, never handed to another run); each later run mints a fresh owned flag and clears the leaked marker. Across any sequence of runs — including chained abandonments — every owned flag is freed exactly once and no leaked flag ever is.
- **Verified, not assumed:** the work queue does *not* share this property (it's a `RunAll` local, so a leaked queue is unreachable from later runs); `FWorkers`/`FAbandoned`/`FResults` checked too. The misleading "same rule" comment that produced this bug now records the distinction.
- Regression drives a **real** watchdog abandonment (blocking callback, 200ms watchdog, stderr warnings prove the path) then runs 200 healthy files with the zombie released mid-run, asserting `Cancelled = False` and all 200 completing. Pre-fix evidence: reverting one hunk fails it on `Pool.Cancelled` with run 2 truncated from ~823ms to 308ms; the other 14 tests still pass, so it's specific.

Stack #1083 layer 27.

## Testing

- [x] Verified in end-to-end tests — full suite 12,087/12,087 both modes; **all 66 Pascal programs exit 0**, `Goccia.Threading.Test` 15/15; CLI harness, differential harness (0 divergences), format, all doc validators exit 0
- [x] Updated documentation — the leak-rule comment now distinguishes queue from flag
- [x] Optional: native Pascal tests — new `Resumed abandoned worker cannot cancel a later run`
- [ ] Optional: benchmarks — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)
