### PR TITLE
test(cli): look up coverage entries by basename, not native path

### DIFF
--- a/scripts/test-cli-apps.ts
+++ b/scripts/test-cli-apps.ts
@@ -39,6 +39,29 @@ import { makeTmpFactory, clean } from "./test-cli/tmpdir";
 
 const makeTmp = makeTmpFactory("goccia-apps-");
 
+/**
+ * Re-key a coverage report by basename.
+ *
+ * Report keys are canonical coverage paths: repo-relative when the file sits
+ * under a repository root, absolute otherwise, always with '/' separators. A
+ * test that knows only the native path it passed on the command line cannot
+ * reconstruct that key — on Windows the separators differ, and whether the
+ * key is relative depends on where the temp directory happens to live. The
+ * basename is the one part both spellings agree on. Splitting on both
+ * separators keeps the helper honest if a key ever reaches it unnormalized.
+ */
+function readCoverageByBasename(path: string): Record<string, any> {
+  const raw = JSON.parse(readFileSync(path, "utf-8"));
+  return Object.fromEntries(
+    Object.entries(raw).map(([file, entry]) => [file.split(/[\\/]/).pop(), entry]),
+  ) as Record<string, any>;
+}
+
+function coverageEntryFor(reportPath: string, sourcePath: string): any {
+  const basename = sourcePath.split(/[\\/]/).pop() as string;
+  return readCoverageByBasename(reportPath)[basename];
+}
+
 const MICROBENCH_MODULE_IMPORT = 'import { bench, group } from "goccia:microbench";';
 
 function microbenchModule(lines: string[]): string {
@@ -2357,8 +2380,7 @@ console.log("Loader: coverage --output=json not corrupted...");
     }
     const functionJsonPath = join(tmp, "function-coverage.json");
     await $`${LOADER} --coverage --coverage-format=json --coverage-output=${functionJsonPath} ${functionSourcePath}`.quiet();
-    const functionJson = JSON.parse(readFileSync(functionJsonPath, "utf-8"));
-    const functionFile = functionJson[functionSourcePath];
+    const functionFile = coverageEntryFor(functionJsonPath, functionSourcePath);
     if (!functionFile) throw new Error("JSON coverage should contain the source file");
     const functionIdsByName = Object.fromEntries(
       Object.entries(functionFile.fnMap).map(([id, entry]: [string, any]) => [entry.name, id]),
@@ -2536,16 +2558,6 @@ console.log("Loader: coverage --output=json not corrupted...");
         "",
       ].join("\n"),
     );
-    // Normalize to basenames: the entry is keyed by the path as typed while
-    // imported modules are keyed by their resolved absolute path. Split on
-    // both separators — on Windows the engine resolves imports through FPC's
-    // ExpandFileName, so coverage keys arrive with backslashes.
-    const readCoverageByBasename = (path: string) => {
-      const raw = JSON.parse(readFileSync(path, "utf-8"));
-      return Object.fromEntries(
-        Object.entries(raw).map(([file, entry]) => [file.split(/[\\/]/).pop(), entry]),
-      ) as Record<string, any>;
-    };
     const implyReports: Record<string, Record<string, any>> = {};
     for (const [label, modeArgs] of [
       ["default", []],

--- a/scripts/test-cli-apps.ts
+++ b/scripts/test-cli-apps.ts
@@ -2911,8 +2911,13 @@ console.log("Loader: coverage --output=json not corrupted...");
       const parallelCoverage = JSON.parse(readFileSync(parallelJsonPath, "utf-8"));
       if (Object.hasOwn(parallelCoverage, "<thread-init>"))
         throw new Error(`Parallel ${mode} coverage should exclude internal <thread-init> source`);
+      // Raw keys above (the internal-source check needs the literal
+      // "<thread-init>"); user sources by basename, since a report key is
+      // canonical and a native path is not.
+      const parallelByBasename = readCoverageByBasename(parallelJsonPath);
       for (const file of [parallelFirst, parallelSecond]) {
-        if (!Object.hasOwn(parallelCoverage, file))
+        const basename = file.split(/[\\/]/).pop() as string;
+        if (!Object.hasOwn(parallelByBasename, basename))
           throw new Error(`Parallel ${mode} coverage should retain user source ${file}`);
       }
     }


### PR DESCRIPTION
Caught by the full-CI run on the completed stack top (run 31223837840): 72/77 jobs green, 3 skipped, and **both Windows `cli` legs red on the same assertion** — `cli (x86_64-win64)` and `cli (i386-win32)`, step "Check app-specific CLI features":

```
error: JSON coverage should contain the source file
      at D:\a\GocciaScript\GocciaScript\scripts\test-cli-apps.ts:2362:34
```

Not a flake and not a Windows engine bug — a test that outlived a contract change made three layers below it.

## Cause

`fix/coverage-paths-and-cleanup` (#1107) made coverage report keys **canonical**: repo-relative when the file sits under a repository root, absolute otherwise, always with `/` separators on every platform. That was the point — genhtml and Codecov mishandle backslashes in an `SF:` record.

The function-coverage assertion still indexed the parsed JSON with the **native** path it had passed on the command line:

```ts
const functionFile = functionJson[functionSourcePath];
```

On macOS and Linux that key happens to be identical to the canonical one — the temp dir is outside any repo and the separators are already `/`, so the lookup kept working and the contract change looked safe. On Windows `join(tmp, …)` yields `D:\…\function-coverage.js` while the report is keyed `D:/…/function-coverage.js`, so the lookup returned `undefined` and the assertion fired. #1100 fixed the *sibling* lookups in this file by splitting on both separators; this one is an exact-key index, so that sweep passed over it.

## Fix

Look the entry up the way the rest of the file already does — by basename, the one spelling both the native path and the canonical key agree on. `readCoverageByBasename` is hoisted from the block where #1100 introduced it to module scope, gains a sibling `coverageEntryFor(reportPath, sourcePath)`, and both call sites share them. Test-side only; no engine change, and the canonical-key contract is unchanged.

The comment moved with the helper is corrected while it moves: it claimed Windows keys "arrive with backslashes", which stopped being true at #1107. Splitting on both separators is kept as a defensive measure, now described as such rather than as a statement about current engine behavior.

## Verification

- `./build.pas` clean, `bun run scripts/test-cli-apps.ts` green locally (the assertion passes on the platform where it always passed, proving the rewrite is not a tautology — see below).
- Both suite modes green, `./format.pas --check` clean.
- The lookup was proven to actually resolve rather than silently pass: `functionFile.f[...]` still asserts `called === 1` and `neverCalled === 0`, which is unreachable if the entry is `undefined`.
- Real verdict comes from CI: this needs a Windows leg to confirm, since macOS could never reproduce it.

Part of the 0.11.0 adversarial-findings stacked-PR train. Merge bottom-up.
