### PR TITLE
fix(changelog): require website predominance before the Website group

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -33,9 +33,14 @@ sort_commits = "newest"
 commit_preprocessors = [
   # Keep website release work distinct from language/runtime changes.
   # git-cliff does not expose changed paths to commit_parsers, so prefix the
-  # commit message before parsing when a commit touches website/.
+  # commit message before parsing when a commit is predominantly website work.
+  #
+  # "Predominantly" means at least half the changed paths live under website/.
+  # Matching *any* website/ path (the previous rule) filed cross-stack commits
+  # under Website whenever their diff grazed a single file there — which split
+  # the same `fix(review):` prefix across two changelog groups.
   { pattern = "(?s).*", replace_command = '''
-sh -c 'msg=$(cat); if git diff-tree --no-commit-id --name-only -r "$COMMIT_SHA" | grep -q "^website/"; then printf "Website: %s" "$msg"; else printf "%s" "$msg"; fi'
+sh -c 'msg=$(cat); paths=$(git diff-tree --no-commit-id --name-only -r "$COMMIT_SHA"); total=$(printf "%s" "$paths" | grep -c .); web=$(printf "%s" "$paths" | grep -c "^website/"); if [ "$total" -gt 0 ] && [ "$((web * 2))" -ge "$total" ]; then printf "Website: %s" "$msg"; else printf "%s" "$msg"; fi'
 ''' },
 ]
 commit_parsers = [

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -716,9 +716,9 @@ Commits are categorized by their leading verb into groups:
 | `Replace`, `Optimize`, `Promote`, `Eliminate`, `Bypass`, `Inline` | ⚡ Performance |
 | `Remove` | 🗑️ Removed |
 | `Refactor`, `Extract`, `Update`, `Strip` | 🏗️ Internal |
-| Commits touching `website/` | 🌐 Website |
+| Commits whose changed paths are at least half under `website/` | 🌐 Website |
 
-This table shows common prefixes. See `cliff.toml` for the complete list of patterns, which includes additional verb-specific and phrase-specific matchers. Website commits are detected by changed path before prefix grouping so site changes stay separate from language/runtime changes. Release sections are generated only for semver-style tags such as `0.7.0` or `v0.7.0`; moving tags such as `nightly` are ignored.
+This table shows common prefixes. See `cliff.toml` for the complete list of patterns, which includes additional verb-specific and phrase-specific matchers. Website commits are detected by changed path before prefix grouping so site changes stay separate from language/runtime changes. The path check requires the website to be the *predominant* surface — at least half the commit's changed paths — so a cross-stack change that happens to touch one file under `website/` still lands in its prefix group rather than 🌐 Website. Release sections are generated only for semver-style tags such as `0.7.0` or `v0.7.0`; moving tags such as `nightly` are ignored.
 
 ### Generating the Changelog
 


### PR DESCRIPTION
## Summary

- Release-preparation run ahead of `/create-release`. The full readiness sweep (verify gate, conformance baseline, docs/website currency, generated-data verify-clean, housekeeping) found exactly one issue; this PR is that fix.
- `cliff.toml`'s `commit_preprocessors` prefixed `"Website: "` onto any commit whose diff touched a **single** file under `website/`. Because `{ message = "^Website: ", group = "🌐 Website" }` is matched before the Conventional Commits parsers, cross-stack commits were filed under 🌐 Website instead of their prefix group — and the same `fix(review):` prefix ended up split across two groups depending on whether the diff happened to graze the website.
- The check now requires the website to be the **predominant** surface: at least half the commit's changed paths under `website/`. Four of the six entries in the current `--unreleased` Website section were misfiled and now group correctly:

  | Commit | `website/` share | Was | Now |
  |---|---|---|---|
  | `fix(review):` #1113 | 2/15 | 🌐 Website | 🐛 Fixed |
  | `fix(review):` #1112 | 1/14 | 🌐 Website | 🐛 Fixed |
  | `docs:` #1108 | 1/21 | 🌐 Website | 🏗️ Internal |
  | `fix(review):` #1101 | 1/15 | 🌐 Website | 🐛 Fixed |
  | `feat(website):` #1096 | 7/10 | 🌐 Website | 🌐 Website |
  | `fix(website):` #1087 | 11/12 | 🌐 Website | 🌐 Website |

- **Why "at least half" rather than "all"**: genuine website work is rarely path-pure. #1087 (11/12) and #1096 (7/10) both carry a stray non-website file, and an all-paths rule would evict them. Validated against the shipped 0.11.0 section too — the threshold demotes `fix(security):` #1057 (4/52) while keeping `docs(positioning):` #1052 (12/24) and `feat(website):` #1027 (8/11).
- **Non-goal**: no version bump, no changelog section, no tag. `/create-release` owns all of that; this lands the categorization fix *before* the real changelog is rendered.

### Release readiness (context for the reviewer, no action required here)

- **Verify gate green**: `tests` and `tests --mode=bytecode` both 12,143/12,143 (100%, 1,533 files); `./format.pas --check` clean across 445 files; website `bun test` 204/204, `biome check` and `tsc --noEmit` clean.
- **test262**: 52,281 / 52,489 = **99.60%**, sourced from the CI `test262-results` artifact of main run `31329942441`. Delta vs the `0.11.0` run: −1 pass (−0.01pp), entirely in `staging` — one FAIL→PASS and two PASS→TIMEOUT against the 20s ceiling, no correctness regression. Non-blocking by design.
- **Docs/website currency**: no findings. Every conformance figure on the site is live-sourced; no hand-maintained test262 number exists anywhere. All 194 `--flag` references in docs and website resolve against the source option tables.
- **Generated data**: Unicode 17.0.0, CLDR 45.0.0 regenerate byte-identical at their committed pins. The tzdata 2026c blob differs only in byte count because `scripts/generate-timezone-data.js` shells out to the host `zic` — a known reproducibility gap with an existing issue, not stale data.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [x] Updated documentation
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

`cliff.toml` is release tooling and is not exercised by the Pascal or website suites, so the behavioural evidence is the `git cliff --unreleased` before/after shown above. The JavaScript suite gate and format gate were run on this tree regardless and are green; markdownlint and all four `check-doc-*` scripts pass on the `docs/build-system.md` change. The doc table entry and the paragraph describing the path check were updated to match the new rule.
