### PR TITLE
chore(release): 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,58 @@
 
 All notable changes to GocciaScript are documented in this file.
 
+## [0.12.0] - 2026-08-10
+
+### 🌐 Website
+
+- feat(website): Vitest drop-in direction on VISION and the homepage (#1096)
+- fix(website): vendored playground versions reach the page and stay fresh (#1087)
+
+### 🏗️ Internal
+
+- test(cli): look up coverage entries by basename, not native path (#1111)
+- test(cli): match boundary lines in containsLine and drop the workarounds (#1110)
+- docs: call them differential suites, not batteries (#1108)
+- test(cli): split coverage keys on both path separators (#1100)
+- ci(testing): gate testing-API suites on a pinned Vitest oracle (#1097)
+- ci(testing): differential suites gate goccia against bun (#1082)
+
+### 🐛 Fixed
+
+- fix(changelog): require website predominance before the Website group (#1115)
+- fix(review): CodeRabbit round-7 findings on the round-6 layer (#1113)
+- fix(review): CodeRabbit round-6 findings across the five unreviewed layers (#1112)
+- fix(review): CodeRabbit round-5 findings across the stack (#1109)
+- fix(coverage): canonicalize report path keys and document the parallel bail (#1107)
+- fix(testing): close the last Vitest and ECMA-262 semantic divergences (#1104)
+- fix(threading): give each run its own cancellation flag after abandonment (#1103)
+- fix(threading): guard the pool cancellation flag behind a lock (#1102)
+- fix(review): CodeRabbit round-2 findings across the stack (#1101)
+- fix(cli): print usage instead of blocking when run without input at a TTY (#1098)
+- fix(gc): root builtin argument collections and re-entry temporaries (#1095)
+- fix(testing): Vitest comparison parity across equality, Set/Map, and errors (#1093)
+- fix(testing): count beforeAll/afterAll hook failures as failures (#1090)
+- fix(parser): bound the arrow return-type probe; hard-gate web-tooling outcomes (#1089)
+- fix(testing): count throwing describe callbacks as failures (#1088)
+- fix(cli): keep JSON envelope stdout clean for every failure shape (#1086)
+- fix(review): CodeRabbit round-1 findings across the stack (#1085)
+- fix(testing): compare Error objects by value in deep equality (#1084)
+- fix(coverage): imply bytecode mode, sum parallel merges, register declaration lines (#1081)
+- fix(testing): bring deep-equality and property matchers to Vitest parity (#1078)
+- fix(testing): apply negation and full argument semantics to toThrow (#1077)
+- fix(engine): check nullish base before property-key coercion (#1076)
+- fix(jsx): guarantee transformer scan progress and positioned errors (#1075)
+
+### 🚀 Added
+
+- feat(testing): make goccia:test importable without injecting globals (#1106)
+- feat(testing): support vi.mock factory-form module mocking (#1105)
+- feat(testing): goccia:test module and default-on vitest compatibility shim (#1099)
+- feat(testing): abort file collection when a describe callback throws (#1092)
+- feat(testing): Vitest-exact suite-error attribution and hook control flow (#1091)
+- feat(runtime): WHATWG EventTarget base with AbortSignal abort events (#1080)
+- feat(parser): parse TS type-syntax edges as annotations (#1079)
+
 ## [0.11.0] - 2026-08-05
 
 ### ⚡ Performance


### PR DESCRIPTION
## Summary

- Release preparation for **0.12.0**. Adds the `0.12.0` changelog section; no other change.
- **Version basis**: last tag `0.11.0`, 38 commits in range, 8 `feat(…)` and **no** breaking changes (`!` or `BREAKING CHANGE`), so a minor bump. `0.12.0` is not present locally or on the remote.
- **No version declaration to bump.** `build.pas:28` derives the version from `git describe --tags --always --match '[0-9]*'` and bakes it into `BAKED_VERSION`. There is no manifest carrying the version, so `CHANGELOG.md` is the entire diff.
- The changelog lands here *before* the tag, so the tag contains its own release notes. The release commit is `chore(release): 0.12.0`, which `cliff.toml` skips.

### Why this is not a full `git-cliff -o CHANGELOG.md` regeneration

The categorization fix in #1115 changes how the website-predominance rule groups commits, and it applies retroactively. A full regeneration rewrote **five already-published sections** (0.11.0 back through 0.8.x), moving ~15 commits out of 🌐 Website into their prefix groups — 47 lines of churn in shipped release notes whose bodies are already published on GitHub Releases and frozen inside their tags.

So the `0.12.0` section is the git-cliff output verbatim (`git cliff --tag 0.12.0`), inserted above `## [0.11.0]` with released history untouched. The diff is **52 insertions, 0 deletions**. If you would rather have `CHANGELOG.md` fully consistent with the corrected rule, say so and I will regenerate — it is one command, and the published GitHub release bodies would then differ from the file.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [x] Updated documentation
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

Release gate observed on this branch, all exit 0:

- `./build.pas testrunner` — built
- `./build/GocciaTestRunner tests` — 12,143/12,143 (100.00%), 0 failed
- `./build/GocciaTestRunner tests --mode=bytecode` — 12,143/12,143 (100.00%), 0 failed
- `./format.pas --check` — 445 files, all formatted correctly
- `markdownlint-cli2 CHANGELOG.md` and all four `check-doc-*` scripts — clean

test262 at this base: **52,281 / 52,489 = 99.60%** (CI artifact from main run `31329942441`). Delta vs the `0.11.0` run is −1 pass, entirely two `staging` timeouts against the 20s ceiling with one FAIL→PASS alongside — no correctness regression, and non-blocking by design.

## Publishing

Do **not** create a GitHub release by hand. Once this squash-merges, pushing the `0.12.0` tag triggers the `ci.yml` `release` job, which is the only place the built platform archives exist; it renders notes with `orhun/git-cliff-action --latest` and publishes via `softprops/action-gh-release`. No workflow creates tags, so tag creation is the only step I own. See `docs/build-system.md` § CI Integration.
