### PR TITLE
chore: install run-retro, and apply its findings for stacked PR automation

### DIFF
--- a/.agents/skills/run-retro/SKILL.md
+++ b/.agents/skills/run-retro/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: run-retro
+description: >-
+  Reviews a completed workstream from conversation, repository, and forge
+  evidence, uses grilling to agree improvements to delivery speed, process, and
+  codebase health, then applies selected documentation edits and follow-up
+  ticket actions. Use when ending a substantial workstream or running a project
+  retrospective.
+license: Unlicense OR MIT
+compatibility: >-
+  Requires a registered grilling skill and access to the workstream's available
+  conversation, repository, and forge evidence. Selected tickets also require
+  create-issue and forge access.
+---
+
+# Run retrospective
+
+Assess the completed workstream through delivery-speed, process, and
+codebase-health lenses. The actual `grilling` skill owns the decision loop.
+Apply only documentation edits and ticket actions the user selects from the
+detailed summary.
+
+## Gates
+
+- Define the workstream boundary from the current conversation, handoff, diffs,
+  commits, issues, PRs, reviews, checks, outcomes, and rework. Record unavailable
+  evidence and lower confidence; do not invent a narrative or broaden into a
+  repository audit.
+- Invoke `grilling` with the evidence and candidates. Do not imitate it with
+  ad-hoc questions; stop if it is unavailable. Let it ask one decision at a time
+  with a recommendation. Act only after it reaches shared understanding and
+  confirms the exact action set.
+- Assess all three lenses, even when one produces no durable finding:
+  - **Delivery speed:** less waiting, rework, handoff friction, unnecessary
+    scope, or cognitive load without weakening quality.
+  - **Process:** planning, decisions, handoffs, gates, tools, and collaboration.
+  - **Codebase:** architecture, maintainability, tests, developer experience,
+    reliability, and accumulated friction.
+- Promote only generalized, project-level lessons supported by evidence. Exclude
+  chronology, one-off mistakes, personal preferences, duplicates, existing
+  rules, and speculation.
+
+## Route each lesson
+
+- **Documentation edit:** durable guidance in existing contracts, READMEs,
+  `docs/`, ADRs, AGENTS, skills, templates, policies, or contributor guidance.
+  Prefer tightening or coupling with existing text. Direct edits are limited to
+  documentation.
+- **Follow-up ticket:** source, executable configuration, or other implementation
+  is needed. Offer more detail, further grilling, normal or automatic
+  `create-issue`, or skip; the delegated workflow retains its own gates.
+- **Report only:** useful evidence warrants neither an edit nor a ticket.
+
+Use both edit and ticket only when the guidance and its implementation are
+separately necessary. A missing document may be created only when the user
+selects its exact proposed contents.
+
+## Workflow
+
+1. Resolve the workstream boundary and read relevant project documentation.
+2. Build an evidence ledger of outcomes, friction, rework, surprises, effective
+   or missed gates, and successful practices under all three lenses.
+3. Remove unsupported, session-specific, duplicate, and already-covered
+   candidates; classify the rest using the routes above.
+4. Run `grilling` one decision at a time with the boundary, evidence, current
+   docs, absences, and candidates.
+5. Present the detailed summary:
+   - findings under every lens, including no-finding results;
+   - exact proposed documentation additions, replacements, or removals by file;
+   - concise ticket summaries with all available action paths;
+   - report-only observations, supporting evidence, confidence, and gaps.
+6. Obtain exact user selections through `grilling`. More detail or further
+   grilling returns to that loop and regenerates the summary.
+7. Apply only selected documentation changes, preserving structure and avoiding
+   duplication. Run only the selected ticket actions through `create-issue`.
+8. Compare the result with the confirmed action set, reread edited sections, and
+   run declared documentation checks.
+9. Report changed docs, created issue links, report-only findings, confidence
+   limits, and observed validation. Keep workstream history in chat.
+
+Confirmation does not authorize commits, pushes, PRs, unselected issues, or
+other file edits. The original request to run a retrospective is not this final
+confirmation.

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,9 +1,21 @@
 name: PR
 
+# No `branches:` filter on purpose. That key matches the pull request's BASE,
+# so a stacked pull request — one whose base is the layer below it rather than
+# main — was skipped entirely. During the 0.11.0 adversarial-findings stack
+# several layers (#1076, #1095, #1103, #1109) received no PR run at all, which
+# is how a Windows-only failure survived eleven layers before anyone saw it.
+# Every pull request runs this workflow whatever its base.
 on:
   pull_request:
-    branches:
-      - main
+
+# Widening the trigger multiplies runs across a stack, so supersede rather than
+# accumulate: a new push cancels the previous run for the same pull request.
+# This also keeps the surviving verdict attached to the current head instead of
+# leaving a green result that belongs to an already-replaced commit.
+concurrency:
+  group: pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/docs/contributing/tooling.md
+++ b/docs/contributing/tooling.md
@@ -105,6 +105,30 @@ Treat messages such as `Compilation raised exception internally` and
 investigate the reported Pascal source line after the same target still fails
 from a clean build.
 
+### Website Checks Are Inert Without Its Dependencies
+
+The website has its own dependency tree, and its checks fail to load rather
+than fail loudly when that tree is missing. In a fresh clone or worktree,
+`bun run test` inside `website/` reports **142 pass / 8 fail** — and reports
+exactly that before and after any change you make, because the 8 are modules
+that cannot import, not assertions that disagree with your edit.
+
+Install first, then the same tree reports **204 pass / 0 fail** and a genuine
+regression fails immediately and by name:
+
+```bash
+cd website
+bun install
+bun run test
+bun run lint
+```
+
+Two regressions shipped in `website/src/lib/positioning.ts` during 0.11.0
+because the unprovisioned numbers were compared before and after a change and
+read as "unchanged, therefore safe". They were identical because the file
+guarding that text never loaded. A check that cannot run is not a passing
+check — confirm the checker actually executed, not merely that it reported.
+
 ### Shared `-FU` Directories Across Programs — Internal Error 200611011
 
 FPC 3.2.2 aborts with `Fatal: Internal error 200611011` when a second program

--- a/docs/contributing/workflow.md
+++ b/docs/contributing/workflow.md
@@ -66,6 +66,31 @@ git commit -m "Short imperative description of the change"
 - **Issues:** Use `.github/ISSUE_TEMPLATE/default.md` (Summary, Why, current vs expected behavior, scope).
 - **Pull requests:** Use `.github/pull_request_template.md` (Summary with constraints and links, testing checklist).
 
+### Stacked pull requests
+
+A stacked pull request targets the layer below it rather than `main`, and
+automation treats that base differently from a normal branch. Two consequences
+are worth knowing before starting a stack:
+
+- **Automatic review does not fire.** CodeRabbit reviews only pull requests
+  based on the default branch, so every layer needs an explicit
+  `@coderabbitai review` comment. A layer that is never triggered shows no
+  review at all, and an instant acknowledgement of an already-reviewed commit
+  is not a review of the current head.
+- **A review round ends when its own fix layer reviews clean**, not when the
+  findings from the layer below are dispositioned. A round that fixes findings
+  creates a new top layer, and that layer needs its own review like any other.
+  Confirm every layer has a review before calling a stack finished — the
+  terminating one is the easiest to miss, because nothing after it prompts a
+  sweep.
+
+The PR workflow itself runs for every pull request whatever its base; it
+previously filtered on `main`, which skipped stacked layers entirely. Full CI
+(`ci.yml`) still runs only on `main`, tags, and manual dispatch, so use
+`gh workflow run ci.yml --ref <branch>` when a stacked branch needs the full
+matrix, and check the result against the branch's current head SHA rather than
+the newest run — a dispatched run belongs to the commit it started from.
+
 ## Verify changes
 
 ```bash

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -115,6 +115,12 @@
       "skillPath": "roadmap-review/SKILL.md",
       "computedHash": "84243a7b0f41dcd957ce05da75e67dc2923d1b52900336893bbf21d44a545a5d"
     },
+    "run-retro": {
+      "source": "frostney/known-good-route",
+      "sourceType": "github",
+      "skillPath": "run-retro/SKILL.md",
+      "computedHash": "a7adbe79d73147f9db4f180275c3ef3f83b6e7998113d203537dda139b0cc7d5"
+    },
     "software-engineering-excellence": {
       "source": "frostney/known-good-route",
       "sourceType": "github",

--- a/source/shared/Shared.inc
+++ b/source/shared/Shared.inc
@@ -58,3 +58,25 @@
 {$IFDEF FPC}
   {$modeswitch advancedrecords}
 {$ENDIF}
+
+{ Nested comments, on both compilers.
+
+  This is a JavaScript engine written in Pascal, so comments quote JavaScript
+  constantly, and JavaScript is full of braces. Without this, a comment
+  containing an export clause or an empty block ends at the first closing
+  brace inside it, and the compiler then reports an "illegal character" at
+  whatever token follows — a column unrelated to the real cause.
+
+  Nesting fixes the balanced case, which is the one that occurs in practice.
+  A lone unmatched closing brace still ends the comment, so keep braces in
+  comment prose balanced or spell them out in words.
+
+  The spelling differs per compiler: FPC takes a modeswitch, Delphi a
+  directive. Define GOCCIA_NO_NESTED_COMMENTS to opt out. }
+{$IFNDEF GOCCIA_NO_NESTED_COMMENTS}
+  {$IFDEF FPC}
+    {$modeswitch nestedcomments}
+  {$ELSE}
+    {$NESTEDCOMMENTS ON}
+  {$ENDIF}
+{$ENDIF}

--- a/source/units/Goccia.Bytecode.Debug.pas
+++ b/source/units/Goccia.Bytecode.Debug.pas
@@ -29,7 +29,7 @@ type
     FDeclarationColumn: UInt16;
   public
     { ADeclarationLine/ADeclarationColumn locate the function's declaration
-      (`const f = () => {`), which is what LCOV's FN: record means. They are
+      (`const f = () => { … }`), which is what LCOV's FN: record means. They are
       distinct from the first line-map entry, which locates the first executed
       instruction of the body and drives per-call line hits. Zero means
       "not recorded" — the module-level template has no declaration site. }


### PR DESCRIPTION
## Summary

Installs the `run-retro` skill, then applies the actions that retrospective produced for the 0.11.0 adversarial-findings stack (#1083, 37 PRs, seven review rounds).

## Why

Two root causes came out of the retro, and both are configuration rather than judgement.

**Stacked pull requests were invisible to automation.** `pr.yml` filtered on `branches: [main]`, and that key matches a pull request's *base* — so a layer stacked on the layer below it was skipped. Measured coverage across the stack was inconsistent: **#1076, #1095, #1103 and #1109 received no PR run at all**. That is how a Windows-only failure survived eleven layers before anything exercised it. CodeRabbit skips the same PRs for the same reason, by its own policy, which is why six fix layers were each reviewed only because a later round happened to sweep them up — and why the final one reached a "complete" digest with zero reviews.

**The website suite fails to load rather than fail loudly.** Without its dependency tree it reports `142 pass / 8 fail` before *and* after any change, because the 8 are modules that cannot import. Two regressions shipped after those numbers were compared and read as unchanged. Installed, the same tree reports `204 pass / 0 fail`.

## Changes

- **`.github/workflows/pr.yml`** — drop the base filter so every pull request runs the workflow whatever its base; add a concurrency group so a new push supersedes the previous run instead of accumulating 22 jobs per layer, which also stops a green verdict outliving its commit.
- **`source/shared/Shared.inc`** — enable nested comments on FPC (`{$modeswitch nestedcomments}`) and Delphi (`{$NESTEDCOMMENTS ON}`), with `GOCCIA_NO_NESTED_COMMENTS` to opt out.
- **`source/units/Goccia.Bytecode.Debug.pas`** — balance one comment that quoted an arrow function and left a brace unmatched.
- **`docs/contributing/workflow.md`** — stacked-pull-request section.
- **`docs/contributing/tooling.md`** — website-dependency pitfall.
- **`.agents/skills/run-retro/`** + `skills-lock.json` — the skill itself.

## Notes on the nested-comments change

It is not free, so the evidence is here rather than buried. A Pascal-aware scan over `source/` — skipping string literals, `//` and `(* *)` — found **exactly one** existing comment relying on the old behaviour, and it broke the build immediately (`Unexpected end of file`) rather than silently. Nesting does not rescue an *unmatched* brace; the comment introducing the switch says so, having been written wrong once and caught by the compiler.

## Verification

- Build clean; both suite modes **12143/12143**; `./format.pas --check` clean.
- `markdownlint-cli2` clean over 166 files.
- Nested comments proven by compiling a comment containing `export { x as await }` and an empty block, and by confirming the same file fails without the switch.

## Scope notes

- Does **not** close #1114 — no job runs `bun run test` or `bun run lint` in `website/` yet; this only makes stacked layers run the checks that already exist.
- The all-failures rework of `scripts/test-cli-apps.ts` (so the Windows job reports every failure per run instead of aborting at the first) is deliberately a separate stacked PR.
- I could not explain why `pr.yml` fired for some stacked layers (#1085, #1112) and not others; the docs state the filter and the observed inconsistency without asserting a mechanism.
