### PR TITLE
style(pascal): quote JavaScript in star-parenthesis comments, drop the switch

### DIFF
--- a/docs/contributing/code-style.md
+++ b/docs/contributing/code-style.md
@@ -203,15 +203,9 @@ The **language tables** (`docs/language-tables.md`) are the one place where edit
 Use `(* ... *)` rather than brace delimiters for any comment containing a
 JavaScript brace. A brace comment ends at the first `}` inside it, and the
 compiler then reports an "illegal character" at whatever token follows — a
-column with no relation to the cause, which is easy to spend a rebuild cycle
-chasing.
+column with no relation to the cause.
 
-Nested brace comments are deliberately not enabled: no `$NESTEDCOMMENTS`
-directive exists on either compiler, and FPC's modeswitch of that name is
-FPC-only, so relying on it would let a comment compile under FreePascal and
-break the Delphi build. `(* ... *)` behaves the same on both.
-
-Comments of the same kind still do not nest, so a comment that discusses these
+Neither comment form nests with itself, so a comment that discusses these
 delimiters spells them out in words instead of quoting the characters.
 
 ### No Abbreviations

--- a/docs/contributing/code-style.md
+++ b/docs/contributing/code-style.md
@@ -198,6 +198,22 @@ In the **built-in documentation** (`docs/built-ins*.md`), do not annotate featur
 
 The **language tables** (`docs/language-tables.md`) are the one place where edition years are listed, as a feature-provenance reference. **Source code** annotations (`// ES2026 §X.Y.Z`) always use the current edition year per the rules above.
 
+### Comments That Quote JavaScript
+
+Use `(* ... *)` rather than brace delimiters for any comment containing a
+JavaScript brace. A brace comment ends at the first `}` inside it, and the
+compiler then reports an "illegal character" at whatever token follows — a
+column with no relation to the cause, which is easy to spend a rebuild cycle
+chasing.
+
+Nested brace comments are deliberately not enabled: no `$NESTEDCOMMENTS`
+directive exists on either compiler, and FPC's modeswitch of that name is
+FPC-only, so relying on it would let a comment compile under FreePascal and
+break the Delphi build. `(* ... *)` behaves the same on both.
+
+Comments of the same kind still do not nest, so a comment that discusses these
+delimiters spells them out in words instead of quoting the characters.
+
 ### No Abbreviations
 
 Class names, function names, method names, and type names must use **full words** — do not abbreviate. This keeps the codebase consistent and self-documenting.

--- a/source/shared/Shared.inc
+++ b/source/shared/Shared.inc
@@ -59,24 +59,24 @@
   {$modeswitch advancedrecords}
 {$ENDIF}
 
-{ Nested comments, on both compilers.
+(* Comments quoting JavaScript use star-parenthesis delimiters, not braces.
 
-  This is a JavaScript engine written in Pascal, so comments quote JavaScript
-  constantly, and JavaScript is full of braces. Without this, a comment
-  containing an export clause or an empty block ends at the first closing
-  brace inside it, and the compiler then reports an "illegal character" at
-  whatever token follows — a column unrelated to the real cause.
+   This is a JavaScript engine written in Pascal, so comments quote JavaScript
+   constantly and JavaScript is full of braces. A brace comment ends at the
+   first closing brace inside it, and the compiler then reports an "illegal
+   character" at whatever token follows — a column unrelated to the cause.
 
-  Nesting fixes the balanced case, which is the one that occurs in practice.
-  A lone unmatched closing brace still ends the comment, so keep braces in
-  comment prose balanced or spell them out in words.
+   Nested brace comments are deliberately NOT enabled to paper over this.
+   Neither compiler takes a $NESTEDCOMMENTS directive: FPC answers "Illegal
+   compiler directive" and carries on, and it is absent from Embarcadero's
+   directive index, so a Delphi branch would silently do nothing while brace
+   comments broke that build — and Delphi is validated locally rather than in
+   CI, so the divergence would surface late. FPC's modeswitch of the same name
+   does work, but is FPC-only, which creates that divergence from the other
+   side.
 
-  The spelling differs per compiler: FPC takes a modeswitch, Delphi a
-  directive. Define GOCCIA_NO_NESTED_COMMENTS to opt out. }
-{$IFNDEF GOCCIA_NO_NESTED_COMMENTS}
-  {$IFDEF FPC}
-    {$modeswitch nestedcomments}
-  {$ELSE}
-    {$NESTEDCOMMENTS ON}
-  {$ENDIF}
-{$ENDIF}
+   Star-parenthesis delimiters need no switch and behave the same on both
+   compilers, which is what Embarcadero's documentation recommends for a
+   comment containing other comments. Note that these do not nest with each
+   other either, so a comment quoting one uses words rather than the literal
+   characters. *)

--- a/source/shared/Shared.inc
+++ b/source/shared/Shared.inc
@@ -58,25 +58,3 @@
 {$IFDEF FPC}
   {$modeswitch advancedrecords}
 {$ENDIF}
-
-(* Comments quoting JavaScript use star-parenthesis delimiters, not braces.
-
-   This is a JavaScript engine written in Pascal, so comments quote JavaScript
-   constantly and JavaScript is full of braces. A brace comment ends at the
-   first closing brace inside it, and the compiler then reports an "illegal
-   character" at whatever token follows — a column unrelated to the cause.
-
-   Nested brace comments are deliberately NOT enabled to paper over this.
-   Neither compiler takes a $NESTEDCOMMENTS directive: FPC answers "Illegal
-   compiler directive" and carries on, and it is absent from Embarcadero's
-   directive index, so a Delphi branch would silently do nothing while brace
-   comments broke that build — and Delphi is validated locally rather than in
-   CI, so the divergence would surface late. FPC's modeswitch of the same name
-   does work, but is FPC-only, which creates that divergence from the other
-   side.
-
-   Star-parenthesis delimiters need no switch and behave the same on both
-   compilers, which is what Embarcadero's documentation recommends for a
-   comment containing other comments. Note that these do not nest with each
-   other either, so a comment quoting one uses words rather than the literal
-   characters. *)

--- a/source/units/Goccia.Bytecode.Debug.pas
+++ b/source/units/Goccia.Bytecode.Debug.pas
@@ -28,11 +28,11 @@ type
     FDeclarationLine: UInt32;
     FDeclarationColumn: UInt16;
   public
-    { ADeclarationLine/ADeclarationColumn locate the function's declaration
-      (`const f = () => { … }`), which is what LCOV's FN: record means. They are
-      distinct from the first line-map entry, which locates the first executed
-      instruction of the body and drives per-call line hits. Zero means
-      "not recorded" — the module-level template has no declaration site. }
+    (* ADeclarationLine/ADeclarationColumn locate the function's declaration
+       (`const f = () => {`), which is what LCOV's FN: record means. They are
+       distinct from the first line-map entry, which locates the first executed
+       instruction of the body and drives per-call line hits. Zero means
+       "not recorded" — the module-level template has no declaration site. *)
     constructor Create(const ASourceFile: string;
       const ADeclarationLine: UInt32 = 0;
       const ADeclarationColumn: UInt16 = 0);


### PR DESCRIPTION
Stacked on #1123 (stack #1124). Resolves the review finding on #1122 without pushing to a frozen layer.

## Summary

Removes the nested-comments switch added in #1122 and converts comments that quote JavaScript to star-parenthesis delimiters instead.

## Why the switch was wrong

The Delphi half of it was not merely unverified — it was a directive that exists on neither compiler. Compiling a minimal file locally:

```
fpcdir.pas(3,2) Warning: Illegal compiler directive "$NESTEDCOMMENTS"
fpcdir.pas(4,24) Fatal: Syntax error, "BEGIN" expected but "identifier STILL" found
```

FPC answers with a warning and carries on; the directive is likewise absent from Embarcadero's directive index. Since an unknown brace directive is a warning rather than an error, the Delphi branch would have done nothing while brace comments quietly broke that build. No Delphi compiler exists on this host or in CI, so it could not have been checked before it shipped — which is the part that should have stopped it going in.

FPC's `{$modeswitch nestedcomments}` does work, but only on FPC. Keeping it would leave a comment that compiles under FreePascal and fails under Delphi, found late because Delphi is validated locally rather than in CI.

Star-parenthesis delimiters need no switch, behave identically on both compilers, and are what Embarcadero's documentation recommends for a comment containing another.

## Changes

- `source/shared/Shared.inc` — nested-comments block removed; replaced by a comment explaining why it is deliberately not enabled.
- `source/units/Goccia.Bytecode.Debug.pas` — the JavaScript-quoting comment converted; its brace returns to the natural unbalanced form.
- `docs/contributing/code-style.md` — the convention, since the reasoning otherwise lives only in `Shared.inc`, which nobody reads before writing a comment in some other unit.

Both the doc and the `Shared.inc` comment spell the delimiters out in words rather than quoting them: comments of the same kind do not nest either, so a comment discussing them ends early. That mistake was made twice while writing this change, once in each delimiter style.

## Verification

- Brace-aware scan over `source/` (skipping string literals, `//`, and star-parenthesis comments): **zero** brace comments containing an inner brace.
- Build clean on this tree; both suite modes **12143/12143**; `./format.pas --check` clean; markdownlint clean.
- The FPC directive result above is from an actual compile, not documentation.

## Scope notes

- #1122 and #1123 are green-frozen, so this lands as a new layer rather than a push onto either.
- The Delphi claim in the original review thread was itself unverified against Delphi 12; this PR does not rely on it. The evidence used here is the FPC compile plus the absence of the directive from Embarcadero's index.
