### PR TITLE
docs(contributing): record the probe invariant and the PR-title rule

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,26 @@ add deferred features without an explicit project decision. See
 [docs/language.md](docs/language.md) for the implementation, profile, and
 compatibility-path detail.
 
+### 5. Speculative Parser Probes Must Be Able to Back Out
+
+The parser decides several constructs by trying one reading, then rewinding when
+it does not fit — generic arrow functions, arrow return types, and call-site type
+arguments all work this way. A probe runs over source whose shape is not yet
+known, so **code reached from inside a probe must never raise**. Report the
+problem from the committed parse instead, once the parser has decided what it is
+looking at.
+
+Raising inside a probe turns valid JavaScript into a `SyntaxError`. The
+arrow-return-type probe reaches the ternary `c ? (a, b) : d << 2`, collects
+`d << 2` as a would-be return type, and rewinds; a validator that rejected
+`<<` there failed the whole file. Minified bundles are full of such shapes, so
+the first sign of this is usually a third-party corpus that stops parsing rather
+than a first-party test.
+
+Type annotations already carry the committed/probed distinction: pass
+`ARequireType` when the call site has consumed a `:` and is no longer guessing,
+and validate only then. See [docs/type-annotations.md](docs/type-annotations.md).
+
 ## Quick reference
 
 See [Build System](docs/build-system.md) for the full build, run, test,

--- a/docs/contributing/workflow.md
+++ b/docs/contributing/workflow.md
@@ -65,6 +65,13 @@ git commit -m "Short imperative description of the change"
 
 - **Issues:** Use `.github/ISSUE_TEMPLATE/default.md` (Summary, Why, current vs expected behavior, scope).
 - **Pull requests:** Use `.github/pull_request_template.md` (Summary with constraints and links, testing checklist).
+- **Pull request titles are Conventional Commits.** Pull requests are
+  squash-merged, so the title — not the branch's commits — becomes the commit
+  subject on `main`, and `cliff.toml` parses that subject to build the changelog.
+  A title that does not match `type(scope): summary` still merges and is then
+  silently absent from the release notes. Pick the type from the change as a
+  whole: `feat` when the net effect is new capability, even if most of the
+  commits under it are fixes.
 
 ### Stacked pull requests
 


### PR DESCRIPTION
## Summary

Two rules this project already relies on, neither of them written down anywhere. Both come out of the [#1126](https://github.com/frostney/GocciaScript/pull/1126) retrospective, and each cost a CI round or a review round there.

**A speculative parser probe must be able to back out.** The parser decides generic arrows, arrow return types and call-site type arguments by trying a reading and rewinding when it does not fit. Code reached from inside a probe therefore must not raise. In #1126 a type-annotation validator rejected `<<` from inside the arrow-return-type probe, which turned the ordinary ternary `c ? (a, b) : d << 2` into a `SyntaxError` and stopped a minified bundle parsing. Nothing in the first-party suite contains that shape, so it surfaced only in the Web Tooling corpus in CI. Added as critical rule 5, next to the other engine invariants, and pointed at the committed/probed distinction the annotation collector already carries.

**Pull request titles are Conventional Commits.** Pull requests here are squash-merged, so the title — not the branch's commits — becomes the commit subject on `main`, and `cliff.toml` parses that subject to build the changelog. A non-conforming title merges cleanly and is then silently absent from the release notes. `git-workflow` requires Conventional Commit subjects and mandates squash-merge, but nothing connected the two to the PR title.

Documentation only; no source or test changes.

### Non-goals

The retrospective's other findings are handled elsewhere: a missing minified-JS parser fixture and an outcome-misclassification in `scripts/web-tooling-driver.js` are filed as issues, and the generic half of the PR-title rule goes upstream to the shared skills in `frostney/known-good-route` rather than being restated per project.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [x] Updated documentation
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

Documentation-only, so the relevant gates are the documentation ones: `check-doc-length` (CONTRIBUTING and workflow both stay within limits), `check-doc-links` (630 links, 0 broken), `check-doc-symbols` (all valid), and `check-doc-duplication` (no new clusters). No code changed, so the JS suites are unaffected.
