### PR TITLE
feat(fuzz): add fuzz harness and memory-safety CI

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,193 @@
+name: Fuzz and memory safety
+
+# Coverage-blind crash fuzzing plus memory-safety tooling over the JavaScript
+# suite. Scheduled rather than per-PR: a useful fuzz run takes far longer than
+# a PR should wait, and Valgrind slows the suite by roughly an order of
+# magnitude. PR-time coverage stays with the ordinary suite in pr.yml.
+#
+# Cadence: nightly (03:00 UTC). Manual trigger available via workflow_dispatch,
+# where the fuzz duration can be raised for a longer campaign.
+#
+# Reproducing a finding locally is documented in
+# docs/contributing/tooling.md#fuzzing-and-memory-safety.
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+    inputs:
+      fuzz-seconds:
+        description: 'Seconds to fuzz per run'
+        required: false
+        default: '900'
+
+permissions:
+  contents: read
+
+env:
+  FUZZ_SECONDS: ${{ github.event.inputs.fuzz-seconds || '900' }}
+
+jobs:
+  # ── Coverage-blind fuzzing ───────────────────────────────────────────
+  #
+  # FPC emits no AFL instrumentation, so afl-fuzz runs in non-instrumented
+  # (-n) mode. That trades coverage feedback for pure random mutation: it
+  # still finds parser and lexer faults, but it will not discover deep
+  # execution paths on its own. The seed corpus is what carries coverage
+  # here, which is why it is derived from the real test suites.
+  #
+  # Instrumented builds were evaluated and rejected for now: afl-gcc-style
+  # instrumentation requires either an FPC assembler pass rewrite or building
+  # via -Cg + a GCC-compatible IR, neither of which FPC 3.2.2 exposes. The
+  # tractable future path is afl-clang-lto over LLVM bitcode from an LLVM FPC
+  # backend build; recorded as a follow-up rather than attempted here.
+  fuzz:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+
+      - name: Install FPC and AFL++
+        run: |
+          sudo apt-get update
+          sudo apt-get install fpc afl++ -qq > /dev/null
+
+      - name: Build fuzz harness
+        run: ./build.pas fuzzharness
+
+      - name: Build seed corpus
+        run: bun run scripts/build-fuzz-corpus.ts --verbose
+
+      - name: Verify the harness reports faults nonzero
+        # Guards against the harness silently swallowing every outcome, which
+        # would make a green fuzz run meaningless.
+        run: |
+          if ./build/GocciaFuzzHarness --self-test-fault; then
+            echo "::error::Harness self-test returned 0; fault path is broken"
+            exit 1
+          fi
+
+      - name: Sweep the seed corpus
+        # Every seed is known-good input from our own suites, so any nonzero
+        # exit here is a finding even before mutation begins.
+        run: |
+          status=0
+          mkdir -p build/fuzz/findings
+          for seed in build/fuzz/corpus/*.js; do
+            if ! ./build/GocciaFuzzHarness "$seed" > "build/fuzz/findings/$(basename "$seed").log" 2>&1; then
+              echo "::error::Seed sweep fault: $seed"
+              cp "$seed" build/fuzz/findings/
+              status=1
+            else
+              rm -f "build/fuzz/findings/$(basename "$seed").log"
+            fi
+          done
+          exit $status
+
+      - name: Fuzz
+        run: |
+          # AFL refuses to run when the host uses a core-dump handler pipe.
+          echo core | sudo tee /proc/sys/kernel/core_pattern > /dev/null
+          mkdir -p build/fuzz/out
+          # -n: non-instrumented. AFL_SKIP_CPUFREQ/AFL_NO_AFFINITY are the
+          # standard CI accommodations for shared runners.
+          AFL_SKIP_CPUFREQ=1 AFL_NO_AFFINITY=1 AFL_BENCH_UNTIL_CRASH=1 \
+          timeout "${FUZZ_SECONDS}" afl-fuzz -n \
+            -i build/fuzz/corpus \
+            -o build/fuzz/out \
+            -- ./build/GocciaFuzzHarness @@ || true
+
+      - name: Report crashes
+        run: |
+          crashes=$(find build/fuzz/out -path '*/crashes/id:*' 2>/dev/null | wc -l)
+          hangs=$(find build/fuzz/out -path '*/hangs/id:*' 2>/dev/null | wc -l)
+          echo "AFL crashes: $crashes, hangs: $hangs"
+          if [ "$crashes" -gt 0 ]; then
+            echo "::error::afl-fuzz recorded $crashes crashing input(s)"
+            exit 1
+          fi
+
+      - name: Upload reproducers
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: fuzz-reproducers
+          path: |
+            build/fuzz/out/**/crashes/**
+            build/fuzz/out/**/hangs/**
+            build/fuzz/findings/**
+          if-no-files-found: ignore
+          retention-days: 30
+
+  # ── Memory safety over the real suite ────────────────────────────────
+  #
+  # heaptrc and Valgrind answer different questions: heaptrc reports FPC-level
+  # leaks and double-frees from inside the process, Valgrind catches invalid
+  # reads and writes the allocator never sees. Both run the full JavaScript
+  # suite because that is the only workload exercising every builtin.
+  memory-safety:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        mode: [interpreter, bytecode]
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - name: Install FPC and Valgrind
+        run: |
+          sudo apt-get update
+          sudo apt-get install fpc valgrind -qq > /dev/null
+
+      - name: Build test runner with heaptrc
+        # -gh links the heaptrc unit; the trailing summary goes to stderr on
+        # exit and names every unfreed block with its allocation site.
+        run: |
+          ./build.pas testrunner
+          fpc @config.cfg -gh -gl -FUbuild/compiled/targets/testrunner-heaptrc \
+            -obuild/GocciaTestRunnerHeaptrc source/app/GocciaTestRunner.dpr
+
+      - name: Run suite under heaptrc
+        id: heaptrc
+        run: |
+          modeflag=""
+          if [ "${{ matrix.mode }}" = "bytecode" ]; then modeflag="--mode=bytecode"; fi
+          # HEAPTRC halt-on-error would abort mid-suite; capture and inspect
+          # the summary instead so a leak reports alongside the test results.
+          ./build/GocciaTestRunnerHeaptrc tests $modeflag 2> build/heaptrc-${{ matrix.mode }}.log
+          tail -20 build/heaptrc-${{ matrix.mode }}.log
+          if grep -qE '[1-9][0-9]* unfreed memory blocks' build/heaptrc-${{ matrix.mode }}.log; then
+            echo "::warning::heaptrc reported unfreed blocks in ${{ matrix.mode }} mode"
+          fi
+
+      - name: Run suite under Valgrind memcheck
+        # A full suite run under memcheck is slow; --error-exitcode makes any
+        # invalid access fail the job rather than scroll past.
+        run: |
+          modeflag=""
+          if [ "${{ matrix.mode }}" = "bytecode" ]; then modeflag="--mode=bytecode"; fi
+          valgrind \
+            --tool=memcheck \
+            --error-exitcode=42 \
+            --errors-for-leak-kinds=none \
+            --leak-check=no \
+            --track-origins=yes \
+            --log-file=build/valgrind-${{ matrix.mode }}.log \
+            ./build/GocciaTestRunner tests $modeflag
+          tail -40 build/valgrind-${{ matrix.mode }}.log
+
+      - name: Upload memory-safety logs
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: memory-safety-${{ matrix.mode }}
+          path: build/*.log
+          if-no-files-found: ignore
+          retention-days: 30

--- a/build.pas
+++ b/build.pas
@@ -398,6 +398,22 @@ begin
   WriteLn('');
 end;
 
+procedure BuildFuzzHarness;
+var
+  Output: string;
+begin
+  WriteLn('');
+  WriteLn('Building GocciaFuzzHarness...');
+  if not RunCommand('fpc', FPCArgs('source/app/GocciaFuzzHarness.dpr',
+      EnsureUnitOutputDirectory(TargetUnitOutputDirectory('fuzzharness'))),
+      Output) then
+    PrintBuildFailureAndExit(Output, 'GocciaFuzzHarness build failed',
+      'fuzzharness');
+  WriteLn(Output);
+  WriteLn('GocciaFuzzHarness built successfully');
+  WriteLn('');
+end;
+
 procedure BuildTests;
 var
   AllUnitFiles: TStringList;
@@ -557,6 +573,8 @@ begin
     BuildScriptLoaderBare
   else if ATrigger = 'sandboxrunner' then
     BuildSandboxRunner
+  else if ATrigger = 'fuzzharness' then
+    BuildFuzzHarness
   else if ATrigger = 'tests' then
     BuildTests
   else if ATrigger = 'testrunner' then
@@ -623,6 +641,10 @@ begin
     BuildTriggers.Add('loader');
     BuildTriggers.Add('loaderbare');
     BuildTriggers.Add('sandboxrunner');
+    { Built by default so the harness cannot silently rot: it links most of
+      the engine, so a signature change elsewhere breaks the ordinary build
+      rather than the nightly fuzz job days later. }
+    BuildTriggers.Add('fuzzharness');
     BuildTriggers.Add('testrunner');
     BuildTriggers.Add('tomlcompliancerunner');
     BuildTriggers.Add('wasmtestrunner');

--- a/docs/contributing/tooling.md
+++ b/docs/contributing/tooling.md
@@ -205,3 +205,107 @@ end;
 ```
 
 This works because `Int64` and `Double` share the same sign bit position (bit 63) at the integer level, regardless of byte ordering.
+
+## Fuzzing and Memory Safety
+
+`GocciaFuzzHarness` drives a single input through lex, parse, and **both**
+executors under tight instruction, timeout, memory, and stack bounds. It exists
+because the engine is a from-scratch, manually memory-managed implementation
+whose stated purpose is running adversarial input — see
+[VISION.md](../../VISION.md).
+
+The harness classifies every outcome the engine models — parse error, runtime
+error, script throw, instruction limit, timeout, memory limit, denied module —
+as **normal**, and exits `0`. Only an outcome the engine does *not* model
+(an unexpected Pascal exception, an access violation, a heap abort) exits
+nonzero. That is what makes a nonzero exit a finding rather than noise.
+
+### Building and running
+
+```bash
+./build.pas fuzzharness
+./build/GocciaFuzzHarness --verbose path/to/input.js
+```
+
+Read from stdin with `-`. `--verbose` prints the per-executor classification;
+without it the harness is silent and communicates only through its exit code,
+which is what `afl-fuzz` needs.
+
+### Seed corpus
+
+```bash
+bun run scripts/build-fuzz-corpus.ts --verbose
+```
+
+Seeds are derived from `fixtures/`, `tests/`, and `examples/`, deduplicated by
+content hash and capped at 8 KiB, plus a small set of synthetic seeds for
+shapes the repo's own tests avoid by construction (deep nesting, unterminated
+literals, mixed dialect features). Set `TEST262_PATH` to include a strided
+sample of a local test262 checkout:
+
+```bash
+TEST262_PATH=../test262 bun run scripts/build-fuzz-corpus.ts
+```
+
+### Fuzzing locally
+
+```bash
+afl-fuzz -n -i build/fuzz/corpus -o build/fuzz/out -- ./build/GocciaFuzzHarness @@
+```
+
+The `-n` is **not** optional. FPC emits no AFL instrumentation, so AFL++ runs
+in non-instrumented ("dumb") mode: pure random mutation with no coverage
+feedback. Practically this means the seed corpus carries the coverage, which is
+why it is derived from the real suites rather than generated. Instrumented
+builds were evaluated and deferred — `afl-gcc`-style instrumentation needs
+either an FPC assembler-pass rewrite or a GCC-compatible IR, and FPC 3.2.2
+exposes neither. The tractable path is `afl-clang-lto` over bitcode from an
+LLVM-backend FPC build.
+
+### Reproducing a finding
+
+A reproducer from CI or from `build/fuzz/out/default/crashes/` replays directly:
+
+```bash
+./build/GocciaFuzzHarness --verbose build/fuzz/out/default/crashes/id:000000,...
+```
+
+The run is deterministic — same input, same classification, same exit code.
+The harness prints a backtrace on the finding path. On Linux the frames carry
+file and line. On macOS FPC emits DWARF into a separate `.dSYM` it does not
+read back, so frames print as bare addresses; resolve them with:
+
+```bash
+atos -o build/GocciaFuzzHarness 0x102d69c6c
+```
+
+To check the fault path itself is intact — useful when a fuzz run comes back
+suspiciously clean — inject a fault:
+
+```bash
+./build/GocciaFuzzHarness --self-test-fault
+```
+
+That must print a backtrace and exit `1`.
+
+### Modules are denied, deliberately
+
+The harness installs a content provider that refuses every module load. A fuzz
+input must not be able to reach the host filesystem — without this,
+`import "/etc/passwd"` would be a file read driven by attacker-shaped input.
+Inputs containing `import` are therefore classified `module-denied`, and the
+harness does not exercise the module loader.
+
+### Memory safety
+
+The scheduled [fuzz workflow](../../.github/workflows/fuzz.yml) runs the full
+JavaScript suite under two tools that answer different questions:
+
+| Tool | Catches | Invocation |
+|------|---------|-----------|
+| **heaptrc** (`-gh`) | FPC-level leaks, double frees, unfreed blocks with allocation sites | `fpc @config.cfg -gh -gl -oBIN source/app/GocciaTestRunner.dpr` |
+| **Valgrind memcheck** | Invalid reads/writes the allocator never sees, uninitialised values | `valgrind --tool=memcheck --error-exitcode=42 ./build/GocciaTestRunner tests` |
+
+Both run on Linux only. Valgrind slows the suite by roughly an order of
+magnitude, which is why neither runs per-PR. Findings upload as artifacts with
+a 30-day retention.

--- a/scripts/build-fuzz-corpus.ts
+++ b/scripts/build-fuzz-corpus.ts
@@ -1,0 +1,177 @@
+#!/usr/bin/env npx tsx
+/**
+ * build-fuzz-corpus.ts
+ *
+ * Assembles a seed corpus for GocciaFuzzHarness from sources already in the
+ * repo: fixtures/, tests/, and — when a test262 checkout is available — a
+ * minimized sample of its language/ and built-ins/ trees.
+ *
+ * Seeds are deduplicated by content hash and capped in size, because AFL++
+ * spends its early cycles trimming large inputs and a corpus of near-identical
+ * multi-kilobyte test files wastes that budget. Small, syntactically diverse
+ * seeds are what make coverage-blind fuzzing productive here.
+ *
+ * Written in GocciaScript-compatible style (arrow functions, const/let,
+ * for...of, no var, strict equality) so it can be bootstrapped later.
+ *
+ * Usage:
+ *   npx tsx scripts/build-fuzz-corpus.ts
+ *   npx tsx scripts/build-fuzz-corpus.ts --out build/fuzz/corpus
+ *   TEST262_PATH=../test262 npx tsx scripts/build-fuzz-corpus.ts
+ */
+
+import { createHash } from "crypto";
+import { mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "fs";
+import { dirname, join, relative } from "path";
+import { fileURLToPath } from "url";
+
+// ── Config ─────────────────────────────────────────────────────────────
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, "..");
+
+const argOut = process.argv.indexOf("--out");
+const OUT_DIR = argOut === -1 ? join(ROOT, "build", "fuzz", "corpus") : process.argv[argOut + 1];
+const VERBOSE = process.argv.includes("--verbose");
+
+// AFL++ trims inputs it cannot shrink; seeds above this size cost more than
+// they contribute. 8 KiB keeps whole test files while excluding generated
+// data blobs.
+const MAX_SEED_BYTES = 8 * 1024;
+// A seed that is only a copyright header teaches the fuzzer nothing.
+const MIN_SEED_BYTES = 8;
+
+// test262 is a submodule-free optional checkout; skipped silently when absent.
+const TEST262_PATH = process.env.TEST262_PATH ?? "";
+// Sampling stride through test262. The suite is ~50k files; taking every
+// Nth keeps the corpus small while preserving feature spread, since the
+// suite is laid out by feature directory rather than randomly.
+const TEST262_STRIDE = 37;
+
+const SOURCE_EXTENSIONS = new Set([".js", ".mjs", ".jsx", ".ts", ".tsx"]);
+const IGNORE_DIRS = new Set(["node_modules", ".git", "build", "dist", "vendor", "generated"]);
+
+// ── Collection ─────────────────────────────────────────────────────────
+
+/** Recursively yields source files under a directory, skipping ignored trees. */
+const collectFiles = (dir: string, out: string[] = []): string[] => {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    if (IGNORE_DIRS.has(entry)) continue;
+    const full = join(dir, entry);
+    let info;
+    try {
+      info = statSync(full);
+    } catch {
+      continue;
+    }
+    if (info.isDirectory()) {
+      collectFiles(full, out);
+    } else {
+      const dot = entry.lastIndexOf(".");
+      if (dot !== -1 && SOURCE_EXTENSIONS.has(entry.slice(dot))) out.push(full);
+    }
+  }
+  return out;
+};
+
+const shortHash = (content: string): string =>
+  createHash("sha256").update(content).digest("hex").slice(0, 16);
+
+// ── Build ──────────────────────────────────────────────────────────────
+
+const seen = new Set<string>();
+let written = 0;
+let skippedSize = 0;
+let skippedDuplicate = 0;
+
+const addSeed = (content: string, label: string): void => {
+  const bytes = Buffer.byteLength(content, "utf8");
+  if (bytes < MIN_SEED_BYTES || bytes > MAX_SEED_BYTES) {
+    skippedSize += 1;
+    return;
+  }
+  const hash = shortHash(content);
+  if (seen.has(hash)) {
+    skippedDuplicate += 1;
+    return;
+  }
+  seen.add(hash);
+  writeFileSync(join(OUT_DIR, `${label}-${hash}.js`), content, "utf8");
+  written += 1;
+};
+
+const addTree = (dir: string, label: string, stride = 1): void => {
+  const files = collectFiles(dir).sort();
+  let index = 0;
+  for (const file of files) {
+    index += 1;
+    if (index % stride !== 0) continue;
+    let content: string;
+    try {
+      content = readFileSync(file, "utf8");
+    } catch {
+      continue;
+    }
+    addSeed(content, label);
+  }
+  if (VERBOSE) console.log(`  ${label}: scanned ${files.length} file(s) in ${relative(ROOT, dir)}`);
+};
+
+rmSync(OUT_DIR, { recursive: true, force: true });
+mkdirSync(OUT_DIR, { recursive: true });
+
+console.log(`Building fuzz corpus in ${relative(ROOT, OUT_DIR)}`);
+
+addTree(join(ROOT, "fixtures"), "fixture");
+addTree(join(ROOT, "tests"), "test");
+addTree(join(ROOT, "examples"), "example");
+
+if (TEST262_PATH) {
+  for (const sub of ["test/language", "test/built-ins"]) {
+    addTree(join(TEST262_PATH, sub), "test262", TEST262_STRIDE);
+  }
+} else {
+  console.log("  test262: skipped (set TEST262_PATH to include a sample)");
+}
+
+// A handful of hand-written seeds for shapes the repo's own tests avoid by
+// construction: deep nesting, unterminated literals, and mixed dialect
+// features the default parser rejects. These are cheap and reach parser
+// paths that valid test files never do.
+const SYNTHETIC_SEEDS: Record<string, string> = {
+  "deep-nesting": `${"(".repeat(200)}1${")".repeat(200)}`,
+  "deep-array": `${"[".repeat(200)}${"]".repeat(200)}`,
+  "unterminated-string": 'const s = "abc',
+  "unterminated-template": "const t = `abc${",
+  "unterminated-regex": "const r = /abc",
+  "unterminated-comment": "/* abc",
+  "lone-surrogate": 'const s = "\\uD800";',
+  "dialect-mix": "var a = 1; function f() { for (var i in {}) { label: while (a == 1) break label; } } f();",
+  "getter-setter": "const o = { get x() { return 1; }, set x(v) {} }; o.x = o.x;",
+  "class-private": "class C { #x = 1; static { } get x() { return this.#x; } } new C().x;",
+  "destructure": "const [{ a = 1, ...rest }, [b], ...more] = [{}, [2], 3];",
+  "generator-async": "async function* g() { yield await 1; } g().next();",
+  "optional-chain": "const o = {}; o?.a?.[0]?.();",
+  "bigint-typed": "const b = 1n << 64n; new BigInt64Array(1)[0] = b;",
+  "regex-unicode": "const r = /\\p{Script=Greek}+/u; r.test('abc');",
+  "proxy-reflect": "new Proxy({}, { get: (t, k) => Reflect.get(t, k) }).x;",
+};
+
+for (const [name, content] of Object.entries(SYNTHETIC_SEEDS)) {
+  addSeed(content, `synthetic-${name}`);
+}
+
+console.log(
+  `Wrote ${written} seed(s); skipped ${skippedDuplicate} duplicate(s), ${skippedSize} out-of-range`,
+);
+
+if (written === 0) {
+  console.error("No seeds produced — corpus would be empty");
+  process.exit(1);
+}

--- a/scripts/test-cli-apps.ts
+++ b/scripts/test-cli-apps.ts
@@ -33,6 +33,7 @@ import {
   TESTRUNNER,
   BUNDLER,
   BENCHRUNNER,
+  FUZZHARNESS,
 } from "./test-cli/binaries";
 import { containsLine, normalizeLineEndings, runLoaderJson } from "./test-cli/assertions";
 import { makeTmpFactory, clean } from "./test-cli/tmpdir";
@@ -7274,6 +7275,97 @@ await section("TestRunner: globals stay injected and share the imported registry
   } finally {
     clean(tmp);
   }
+});
+
+// ── GocciaFuzzHarness ──────────────────────────────────────────────────
+//
+// The harness's contract is entirely in its exit code: every engine-modelled
+// outcome must be 0, and only an unmodelled fault may be nonzero. If that
+// inverts, a fuzz campaign either reports nothing or reports everything, and
+// in both cases it is worthless. These sections pin the contract.
+
+await section("Fuzz Harness: engine-modelled outcomes exit zero...", async () => {
+  const tmp = makeTmp();
+  try {
+    // One input per outcome class the engine models. All must exit 0.
+    const cases: Record<string, string> = {
+      completed: "const x = 1 + 1;",
+      "parse-error": "const = = = {{{",
+      "runtime-error": "undefinedIdentifier;",
+      "script-throw": "null.x;",
+      timeout: "while (true) {}",
+      "module-denied": 'import { a } from "./nope.js";',
+      "deep-recursion": "const f = () => f(); f();",
+    };
+    for (const [name, source] of Object.entries(cases)) {
+      const file = join(tmp, `${name}.js`);
+      writeFileSync(file, source);
+      const proc = Bun.spawnSync([FUZZHARNESS, "--verbose", file], {
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const output = proc.stdout.toString() + proc.stderr.toString();
+      if (proc.exitCode !== 0)
+        throw new Error(`Fuzz harness treated "${name}" as a fault (exit ${proc.exitCode}):\n${output}`);
+      // Both executors must report, otherwise a mode is silently skipped.
+      if (!output.includes("[interpreter]") || !output.includes("[bytecode]"))
+        throw new Error(`Fuzz harness did not run both executors for "${name}":\n${output}`);
+    }
+  } finally {
+    clean(tmp);
+  }
+});
+
+await section("Fuzz Harness: unmodelled fault exits nonzero with a backtrace...", async () => {
+  const proc = Bun.spawnSync([FUZZHARNESS, "--self-test-fault"], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const output = proc.stdout.toString() + proc.stderr.toString();
+  if (proc.exitCode === 0)
+    throw new Error(`Fuzz harness fault path exited 0; findings would be invisible:\n${output}`);
+  if (!output.includes("unexpected fault"))
+    throw new Error(`Fuzz harness fault path did not report the fault:\n${output}`);
+  // Frames print as symbols on Linux and bare $ addresses on macOS; either
+  // proves a backtrace was captured before the handler unwound.
+  if (!/\$[0-9A-F]{8}|\.pas|\.dpr/i.test(output))
+    throw new Error(`Fuzz harness fault path produced no backtrace:\n${output}`);
+});
+
+await section("Fuzz Harness: modules cannot reach the host filesystem...", async () => {
+  const tmp = makeTmp();
+  try {
+    // A real, readable file on disk. The harness must still refuse it: fuzz
+    // input driving host file reads is the property this guards.
+    const secret = join(tmp, "secret.js");
+    writeFileSync(secret, "globalThis.__leaked = 1; export const a = 1;\n");
+    const entry = join(tmp, "entry.js");
+    writeFileSync(entry, `import { a } from ${JSON.stringify(secret)};\n`);
+    const proc = Bun.spawnSync([FUZZHARNESS, "--verbose", entry], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const output = proc.stdout.toString() + proc.stderr.toString();
+    if (proc.exitCode !== 0)
+      throw new Error(`Fuzz harness faulted on a module import (exit ${proc.exitCode}):\n${output}`);
+    if (!output.includes("module-denied"))
+      throw new Error(`Fuzz harness loaded a host file instead of denying it:\n${output}`);
+  } finally {
+    clean(tmp);
+  }
+});
+
+await section("Fuzz Harness: stdin input path...", async () => {
+  const proc = Bun.spawnSync([FUZZHARNESS, "--verbose", "-"], {
+    stdin: new TextEncoder().encode("const x = 1;\n"),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const output = proc.stdout.toString() + proc.stderr.toString();
+  if (proc.exitCode !== 0)
+    throw new Error(`Fuzz harness stdin path exited ${proc.exitCode}:\n${output}`);
+  if (!output.includes("completed"))
+    throw new Error(`Fuzz harness stdin path did not run the input:\n${output}`);
 });
 
 if (sectionFailures.length > 0) {

--- a/scripts/test-cli/binaries.ts
+++ b/scripts/test-cli/binaries.ts
@@ -12,3 +12,4 @@ export const REPL = `./build/GocciaREPL${ext}`;
 export const TESTRUNNER = `./build/GocciaTestRunner${ext}`;
 export const BUNDLER = `./build/GocciaBundler${ext}`;
 export const BENCHRUNNER = `./build/GocciaBenchmarkRunner${ext}`;
+export const FUZZHARNESS = `./build/GocciaFuzzHarness${ext}`;

--- a/source/app/GocciaFuzzHarness.dpr
+++ b/source/app/GocciaFuzzHarness.dpr
@@ -1,0 +1,444 @@
+program GocciaFuzzHarness;
+
+{ Coverage-blind crash harness for the lexer, parser, and both executors.
+
+  Reads one source input from a file argument or stdin, then drives it
+  through lex -> parse -> interpreter -> bytecode under tight instruction,
+  timeout, memory, and stack bounds. The bounds exist so that a merely slow
+  or merely large input is not reported as a crash: the harness treats every
+  engine-defined limit and every JavaScript-level throw as a NORMAL outcome
+  and exits 0. Only outcomes the engine does not model — an unexpected
+  Pascal exception, an access violation, a heap corruption abort — reach the
+  fuzzer as a nonzero exit.
+
+  Usage:
+    GocciaFuzzHarness <file>          # AFL++ / manual reproduction
+    GocciaFuzzHarness -               # read stdin
+    GocciaFuzzHarness --verbose <f>   # print the classification and detail
+
+  See docs/contributing/tooling.md for the AFL++ and reproduction workflow. }
+
+{$I Goccia.inc}
+
+uses
+  {$IFDEF UNIX}cthreads,{$ENDIF}
+  { Backtrace symbolisation needs no unit here: dev builds pass -gl, which
+    links FPC's DWARF line-info reader automatically (adding lnfodwrf by
+    hand is a duplicate-identifier error). On macOS the frames still print
+    as bare addresses because FPC emits DWARF into a separate .dSYM it does
+    not read back — resolve those with `atos -o build/GocciaFuzzHarness`.
+    The Linux CI job where the fuzzers actually run symbolises directly. }
+  Classes,
+  SysUtils,
+
+  TextSemantics,
+
+  Goccia.CLI.Stdin,
+  Goccia.Engine,
+  Goccia.Error,
+  Goccia.Executor,
+  Goccia.Executor.Bytecode,
+  Goccia.Executor.Interpreter,
+  Goccia.GarbageCollector,
+  Goccia.InstructionLimit,
+  Goccia.Modules.ContentProvider,
+  Goccia.ScriptLoader.Input,
+  Goccia.StackLimit,
+  Goccia.TextFiles,
+  Goccia.Timeout,
+  Goccia.Values.Error,
+  Goccia.VM.Exception;
+
+const
+  FUZZ_PROGRAM_NAME = 'GocciaFuzzHarness';
+
+  { Bounds are deliberately tight. A fuzzer generates far more slow inputs
+    than interesting ones, and every second spent on a runaway loop is a
+    second not spent exploring. These are also what makes an unbounded
+    input distinguishable from a genuine hang. }
+  FUZZ_TIMEOUT_MS = 1000;
+  FUZZ_MAX_INSTRUCTIONS = 5000000;
+  FUZZ_MAX_MEMORY_BYTES = Int64(256) * 1024 * 1024;
+  FUZZ_STACK_DEPTH = 256;
+
+  { A fuzzer will happily feed us a multi-megabyte file. Lexing that is not
+    a useful discovery, so oversized inputs are rejected before the engine
+    ever sees them. }
+  FUZZ_MAX_INPUT_BYTES = 1024 * 1024;
+
+  { Every opt-in dialect flag the engine has. A fuzzer exploring the default
+    dialect would be rejected at the parser for `var`, `while`, traditional
+    `for`, labels, `for...in`, loose equality, and `arguments`, which is most
+    of the interesting grammar. Turning them all on is the widest reachable
+    surface, and matches this harness's job of finding faults rather than
+    exercising the shipped default configuration. }
+  FUZZ_COMPATIBILITY = [cfASI, cfVar, cfFunction, cfTraditionalFor,
+    cfWhileLoops, cfLooseEquality, cfNonStrictMode, cfArgumentsObject,
+    cfLabel, cfForIn];
+
+  EXIT_OK = 0;
+  EXIT_USAGE = 64;
+
+type
+  { How a single run ended. Everything except feUnexpected is a bounded,
+    engine-modelled outcome and must not be reported to the fuzzer. }
+  TFuzzOutcome = (
+    foCompleted,
+    foScriptThrow,
+    foParseError,
+    foRuntimeError,
+    foInstructionLimit,
+    foTimeout,
+    foStackOverflow,
+    foMemoryLimit,
+    foModuleDenied,
+    foInputRejected,
+    foUnexpected
+  );
+
+  TFuzzMode = (fmInterpreted, fmBytecode);
+
+  { Raised instead of loading a module. Typed so the outcome ladder can tell
+    "this input imported something" apart from a genuine stream fault. }
+  EFuzzModuleDenied = class(Exception);
+
+  { Denies every module load.
+
+    Two reasons, both mandatory. First, a fuzz input must never reach the host
+    filesystem — without this, `import "/etc/passwd"` is a file read driven by
+    attacker-shaped input, which is precisely the property this harness exists
+    to protect. Second, the engine's default provider raises a bare
+    EStreamError, an RTL type the harness cannot distinguish from a real
+    stream fault; owning the provider means owning the exception type. }
+  TFuzzDeniedModuleContentProvider = class(TGocciaModuleContentProvider)
+  public
+    function Exists(const APath: string): Boolean; override;
+    function LoadContent(const APath: string): TGocciaModuleContent; override;
+    function TryGetLastModified(const APath: string;
+      out ALastModified: TDateTime): Boolean; override;
+  end;
+
+var
+  GVerbose: Boolean = False;
+
+function TFuzzDeniedModuleContentProvider.Exists(const APath: string): Boolean;
+begin
+  Result := False;
+end;
+
+function TFuzzDeniedModuleContentProvider.LoadContent(
+  const APath: string): TGocciaModuleContent;
+begin
+  raise EFuzzModuleDenied.Create('module loading is disabled: ' + APath);
+end;
+
+function TFuzzDeniedModuleContentProvider.TryGetLastModified(
+  const APath: string; out ALastModified: TDateTime): Boolean;
+begin
+  ALastModified := 0;
+  Result := False;
+end;
+
+function OutcomeName(const AOutcome: TFuzzOutcome): string;
+begin
+  case AOutcome of
+    foCompleted:        Result := 'completed';
+    foScriptThrow:      Result := 'script-throw';
+    foParseError:       Result := 'parse-error';
+    foRuntimeError:     Result := 'runtime-error';
+    foInstructionLimit: Result := 'instruction-limit';
+    foTimeout:          Result := 'timeout';
+    foStackOverflow:    Result := 'stack-overflow';
+    foMemoryLimit:      Result := 'memory-limit';
+    foModuleDenied:     Result := 'module-denied';
+    foInputRejected:    Result := 'input-rejected';
+  else
+    Result := 'UNEXPECTED';
+  end;
+end;
+
+function ModeName(const AMode: TFuzzMode): string;
+begin
+  if AMode = fmInterpreted then
+    Result := 'interpreter'
+  else
+    Result := 'bytecode';
+end;
+
+procedure Report(const AMode: TFuzzMode; const AOutcome: TFuzzOutcome;
+  const ADetail: string);
+begin
+  if not GVerbose then
+    Exit;
+  if ADetail = '' then
+    WriteLn(ErrOutput, Format('[%s] %s', [ModeName(AMode),
+      OutcomeName(AOutcome)]))
+  else
+    WriteLn(ErrOutput, Format('[%s] %s: %s', [ModeName(AMode),
+      OutcomeName(AOutcome), ADetail]));
+end;
+
+{ Renders the frames of the exception currently being handled. Kept separate
+  from the report so the capture happens before the handler unwinds. }
+function CaptureBackTrace: string;
+var
+  Frames: PPointer;
+  I: Integer;
+begin
+  Result := '';
+  Frames := ExceptFrames;
+  for I := 0 to ExceptFrameCount - 1 do
+    Result := Result + BackTraceStrFunc(Frames[I]) + LineEnding;
+end;
+
+function CreateExecutorForMode(const AMode: TFuzzMode): TGocciaExecutor;
+begin
+  if AMode = fmInterpreted then
+    Result := TGocciaInterpreterExecutor.Create
+  else
+    Result := TGocciaBytecodeExecutor.Create;
+end;
+
+{ Runs one source through one executor and classifies the outcome.
+
+  The except ladder is the whole point of this harness, so it is exhaustive
+  by construction: every engine-defined error type is named explicitly and
+  the bare `on E: Exception` fallback is what a genuine finding looks like.
+  Do not add a blanket handler above the specific ones. }
+function RunOnce(const ASource: TStringList; const AMode: TFuzzMode;
+  out ADetail: string): TFuzzOutcome;
+var
+  Engine: TGocciaEngine;
+  Executor: TGocciaExecutor;
+  GC: TGarbageCollector;
+begin
+  ADetail := '';
+  StartExecutionTimeout(FUZZ_TIMEOUT_MS);
+  StartInstructionLimit(FUZZ_MAX_INSTRUCTIONS);
+  SetMaxStackDepth(FUZZ_STACK_DEPTH);
+  try
+    Executor := CreateExecutorForMode(AMode);
+    try
+      Engine := TGocciaEngine.Create(FUZZ_PROGRAM_NAME, ASource, Executor);
+      try
+        { Widen the accepted grammar as far as the engine allows. The default
+          dialect rejects `var`, `while`, traditional `for`, labels, and more,
+          which would wall the fuzzer off from most of the parser. Compatibility
+          must be assigned after Create — the source pipeline runs at Execute,
+          which is also why syntax errors are classified by type below rather
+          than by which call raised them. }
+        Engine.Compatibility := FUZZ_COMPATIBILITY;
+        Engine.LabelStatementsEnabled := True;
+        Engine.ForInLoopsEnabled := True;
+        Engine.ModuleLoader.SetContentProvider(
+          TFuzzDeniedModuleContentProvider.Create, True);
+
+        GC := TGarbageCollector.Instance;
+        if Assigned(GC) then
+          GC.MaxBytes := FUZZ_MAX_MEMORY_BYTES;
+        try
+          Engine.Execute;
+          Result := foCompleted;
+        except
+          on E: EGocciaBytecodeThrow do
+          begin
+            Result := foScriptThrow;
+            ADetail := 'bytecode throw';
+          end;
+          on E: TGocciaThrowValue do
+          begin
+            Result := foScriptThrow;
+            ADetail := E.Message;
+          end;
+          on E: TGocciaInstructionLimitError do
+          begin
+            Result := foInstructionLimit;
+            ADetail := E.Message;
+          end;
+          on E: TGocciaTimeoutError do
+          begin
+            Result := foTimeout;
+            ADetail := E.Message;
+          end;
+          on E: EFuzzModuleDenied do
+          begin
+            Result := foModuleDenied;
+            ADetail := E.Message;
+          end;
+          on E: TGocciaSyntaxError do
+          begin
+            { Covers TGocciaLexerError too — both are rejections of the input
+              text, which is the single most common fuzz outcome. }
+            Result := foParseError;
+            ADetail := E.Message;
+          end;
+          on E: TGocciaError do
+          begin
+            Result := foRuntimeError;
+            ADetail := E.Message;
+          end;
+        end;
+      finally
+        Engine.Free;
+      end;
+    finally
+      Executor.Free;
+    end;
+  finally
+    ClearInstructionLimit;
+    ClearExecutionTimeout;
+  end;
+end;
+
+function ReadInput(const AFileName: string; out ASource: TStringList;
+  out ADetail: string): Boolean;
+var
+  SourceText: string;
+begin
+  ADetail := '';
+  ASource := nil;
+  try
+    if (AFileName = '') or (AFileName = '-') then
+    begin
+      ASource := ReadSourceFromText(Input);
+      Exit(True);
+    end;
+    if not FileExists(AFileName) then
+    begin
+      ADetail := 'no such input file: ' + AFileName;
+      Exit(False);
+    end;
+    SourceText := ReadUTF8FileText(AFileName);
+  except
+    { Unreadable or undecodable bytes are an input-selection problem, not an
+      engine finding. }
+    on E: Exception do
+    begin
+      ADetail := E.Message;
+      Exit(False);
+    end;
+  end;
+
+  if Length(SourceText) > FUZZ_MAX_INPUT_BYTES then
+  begin
+    ADetail := Format('input exceeds %d bytes', [FUZZ_MAX_INPUT_BYTES]);
+    Exit(False);
+  end;
+
+  ASource := CreateFileTextLines(SourceText);
+  Result := True;
+end;
+
+procedure PrintUsage;
+begin
+  WriteLn(ErrOutput, 'Usage: ', FUZZ_PROGRAM_NAME, ' [--verbose] <file>|-');
+  WriteLn(ErrOutput);
+  WriteLn(ErrOutput, 'Drives one input through lex, parse, and both ' +
+    'executors under tight bounds.');
+  WriteLn(ErrOutput, 'Exits 0 for every engine-modelled outcome; nonzero ' +
+    'only for an unexpected fault.');
+end;
+
+var
+  I: Integer;
+  Arg, FileName, Detail, Trace: string;
+  Source: TStringList;
+  Mode: TFuzzMode;
+  Outcome: TFuzzOutcome;
+  Failed, SelfTestFault: Boolean;
+begin
+  FileName := '';
+  Failed := False;
+  SelfTestFault := False;
+  Trace := '';
+
+  for I := 1 to ParamCount do
+  begin
+    Arg := ParamStr(I);
+    if (Arg = '--verbose') or (Arg = '-v') then
+      GVerbose := True
+    else if Arg = '--self-test-fault' then
+      SelfTestFault := True
+    else if (Arg = '--help') or (Arg = '-h') then
+    begin
+      PrintUsage;
+      Halt(EXIT_OK);
+    end
+    else
+      FileName := Arg;
+  end;
+
+  { Proves the finding path end to end without needing a live engine bug:
+    the fault is raised where an engine fault would be, so the classification,
+    the backtrace, and the nonzero exit are all exercised. Regression-tested
+    in tests/fuzz-harness.test.js. }
+  if SelfTestFault then
+  begin
+    try
+      raise Exception.Create('injected self-test fault');
+    except
+      on E: Exception do
+      begin
+        WriteLn(ErrOutput, Format(
+          '%s: unexpected fault in %s executor: %s: %s',
+          [FUZZ_PROGRAM_NAME, ModeName(fmInterpreted), E.ClassName,
+           E.Message]));
+        WriteLn(ErrOutput, BackTraceStrFunc(ExceptAddr) + LineEnding +
+          CaptureBackTrace);
+      end;
+    end;
+    Halt(1);
+  end;
+
+  if (FileName = '') and IsInputTerminal then
+  begin
+    PrintUsage;
+    Halt(EXIT_USAGE);
+  end;
+
+  if not ReadInput(FileName, Source, Detail) then
+  begin
+    Report(fmInterpreted, foInputRejected, Detail);
+    Halt(EXIT_OK);
+  end;
+
+  try
+    for Mode := Low(TFuzzMode) to High(TFuzzMode) do
+    begin
+      try
+        Outcome := RunOnce(Source, Mode, Detail);
+      except
+        { The finding path. Anything that escapes RunOnce's typed ladder is
+          by definition not an outcome the engine models. Keep the message
+          on stderr and the reproduction in the fuzzer's crash directory.
+          The backtrace is captured here, at the raise site, because the
+          handler below unwinds past it. Dev builds compile with -gl/-gw so
+          the frames carry file and line. }
+        on E: Exception do
+        begin
+          Outcome := foUnexpected;
+          Detail := E.ClassName + ': ' + E.Message;
+          Trace := BackTraceStrFunc(ExceptAddr) + LineEnding +
+            CaptureBackTrace;
+        end;
+      end;
+
+      if Outcome = foUnexpected then
+      begin
+        WriteLn(ErrOutput, Format('%s: unexpected fault in %s executor: %s',
+          [FUZZ_PROGRAM_NAME, ModeName(Mode), Detail]));
+        WriteLn(ErrOutput, Trace);
+        Failed := True;
+      end
+      else
+        Report(Mode, Outcome, Detail);
+    end;
+  finally
+    Source.Free;
+  end;
+
+  if Failed then
+    ExitCode := 1
+  else
+    ExitCode := EXIT_OK;
+end.


### PR DESCRIPTION
## Summary

Adds a crash-fuzzing harness and memory-safety CI. **WP-1** of the sandbox-hardening series; the safety net the later layers rely on.

The engine is a from-scratch, manually memory-managed implementation whose stated purpose is running adversarial input, but it had no coverage-guided crash fuzzing and no memory-safety tooling in CI. Differential testing and test262 cover *semantics*; neither covers *does this input fault the process*.

- **`GocciaFuzzHarness`** (`source/app/GocciaFuzzHarness.dpr`) drives one input through lex → parse → **both** executors under tight instruction, timeout, memory, and stack bounds. Every outcome the engine models exits `0`; only an unmodelled fault exits nonzero. That inversion is the entire contract — a harness that reports slow or malformed input as a crash reports nothing useful — so it is pinned by tests, including a `--self-test-fault` injection proving the nonzero path still works.
- **Modules are denied.** The harness installs its own content provider that refuses every load. A fuzz input must not reach the host filesystem: without this, `import "/etc/passwd"` is a file read driven by attacker-shaped input. It also gives the harness a typed exception it owns rather than the bare `EStreamError` the engine's default provider raises.
- **Seed corpus** (`scripts/build-fuzz-corpus.ts`) derives 1,534 seeds from `fixtures/`, `tests/`, and `examples/`, deduplicated by content hash and capped at 8 KiB, plus 16 synthetic seeds for shapes the suite avoids by construction. Optional strided test262 sample via `TEST262_PATH`.
- **CI** (`.github/workflows/fuzz.yml`) runs nightly, not per-PR: a useful fuzz run outlasts a PR wait, and Valgrind slows the suite by roughly an order of magnitude.

### Non-goals and constraints

FPC emits no AFL instrumentation, so `afl-fuzz` runs in non-instrumented (`-n`) mode and **the corpus carries the coverage** — which is why it is derived from the real suites rather than generated. Instrumented builds were evaluated and deferred: `afl-gcc`-style instrumentation needs either an FPC assembler-pass rewrite or a GCC-compatible IR, and FPC 3.2.2 exposes neither. The tractable path is `afl-clang-lto` over bitcode from an LLVM-backend FPC build.

heaptrc and Valgrind both run because they answer different questions — allocator-level leaks vs. invalid access the allocator never sees — over both execution modes.

### Found during initial runs

Sweeping the corpus surfaced one engine observation, filed separately rather than fixed here per the work package's "file, don't fix" rule: with no content provider configured, an `import` escapes as a raw `EStreamError` instead of a catchable JavaScript error. Any embedder running untrusted script without installing a provider gets an RTL exception through their engine boundary.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [x] Updated documentation

`./build.pas` · `./build/GocciaTestRunner tests` **12143/12143** · `--mode=bytecode` **12143/12143** · `./format.pas --check` clean · corpus sweep 1534 seeds, 0 findings · 4 new `test-cli-apps.ts` sections.

Docs: `docs/contributing/tooling.md` — building, seeding, fuzzing, reproducing (incl. the macOS `.dSYM` symbolisation caveat), and the memory-safety tooling table.
