### PR TITLE
feat(fetch): pin resolved addresses and add private-range and size policy

### DIFF
--- a/docs/built-ins-fetch.md
+++ b/docs/built-ins-fetch.md
@@ -38,6 +38,57 @@ Without `--allowed-host` or an `"allowed-hosts"` config key in `goccia.json`, an
 
 Host matching is case-insensitive and ignores port, path, and userinfo.
 
+### Address policy and response size
+
+The allowlist answers *which names* a script may reach. Two further options
+answer *what those names may resolve to* and *how much they may return* —
+questions a name-based allowlist cannot express.
+
+| Option | Config key | Default | Effect |
+|--------|-----------|---------|--------|
+| `--fetch-deny-private-ranges` | `fetch-deny-private-ranges` | off | Rejects targets that resolve into RFC1918, loopback, link-local, CGNAT, or IPv6 ULA space |
+| `--fetch-max-response-bytes=<n>` | `fetch-max-response-bytes` | 8388608 (8 MiB) | Hard ceiling on the response body |
+
+Both reject with `TypeError` in script space, matching the existing
+"host not allowed" behavior, and both apply identically in interpreter and
+bytecode modes.
+
+```bash
+./build/GocciaScriptLoader example.js \
+  --allowed-host=api.example.com \
+  --fetch-deny-private-ranges \
+  --fetch-max-response-bytes=1048576
+```
+
+### Threat model notes
+
+These are documented candidly, in the spirit of [VISION.md](../VISION.md): the
+sandbox is a reduced attack surface, not a verified security boundary.
+
+**DNS rebinding is addressed.** The host is resolved **once**, the resolved
+address is validated, and the connection is pinned to that address. Previously
+the allowlist was checked against a *hostname* and the connect re-resolved it,
+so an allowlisted name under attacker DNS control could answer the check with
+a public address and the connect with an internal one. Resolution, validation,
+and pinning are re-applied on **every redirect hop**, not just the initial
+request.
+
+TLS verification still runs against the **hostname**, never the pinned
+literal. Pinning changes which address is dialed, not which identity the peer
+must prove.
+
+**SSRF is reduced, not eliminated.** `--fetch-deny-private-ranges` blocks the
+common targets — cloud instance metadata at `169.254.169.254`, loopback
+services, RFC1918 hosts. It cannot stop a *public* address that proxies to an
+internal one, and it is off by default so existing hosts are unaffected. Turn
+it on for any workload running untrusted script.
+
+Address classification is deliberately deny-biased: anything that is not
+exactly four decimal octets or a recognizable IPv6 form is treated as private
+rather than reinterpreted. Shortened and hex forms (`127.1`, `0x7f.0.0.1`)
+are a standard way to smuggle loopback past a textual filter, so they are
+refused rather than parsed.
+
 ### Runtime behavior and limits
 
 Requests run on fetch-specific background workers and settle promises on the owning runtime thread. `await fetch(...)` synchronously waits by pumping fetch completions; the Promise microtask queue is not a general I/O event loop.

--- a/scripts/fetch-e2e.sh
+++ b/scripts/fetch-e2e.sh
@@ -35,9 +35,57 @@ BASE="http://127.0.0.1:${PORT}"
 echo "=== fetch CLI end-to-end tests (server on port $PORT) ==="
 echo ""
 
+# fetch() refuses to run at all unless an allowlist is configured, so every
+# invocation here has to name the test server's host. Without it the whole
+# script fails with "fetch requires allowed hosts to be configured" long
+# before reaching any assertion.
+ALLOW_HOST="--allowed-host=127.0.0.1"
+
 run_js() {
   echo "$1" > "$TMPFILE"
-  "$LOADER" "$TMPFILE" --compat-asi 2>&1
+  "$LOADER" "$ALLOW_HOST" "$TMPFILE" --compat-asi 2>&1
+}
+
+# Same as run_js, but with extra loader flags before the script path, so the
+# policy flags can be exercised against the same live server.
+run_js_with() {
+  local extra="$1"
+  echo "$2" > "$TMPFILE"
+  # shellcheck disable=SC2086 -- $extra is a deliberate flag list
+  "$LOADER" "$ALLOW_HOST" $extra "$TMPFILE" --compat-asi 2>&1
+}
+
+check_with() {
+  local desc="$1"
+  local extra="$2"
+  local expected_exit="$3"
+  local source="$4"
+  shift 4
+  local expected_output="${1:-}"
+  local actual
+  local exit_code
+
+  actual="$(run_js_with "$extra" "$source")" && exit_code=0 || exit_code=$?
+
+  if [ "$exit_code" -ne "$expected_exit" ]; then
+    echo "FAIL: $desc (exit code: expected $expected_exit, got $exit_code)"
+    echo "  output: $actual"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  if [ -n "$expected_output" ]; then
+    if echo "$actual" | grep -qF "$expected_output"; then
+      PASS=$((PASS + 1))
+    else
+      echo "FAIL: $desc"
+      echo "  expected to contain: $expected_output"
+      echo "  actual: $actual"
+      FAIL=$((FAIL + 1))
+    fi
+  else
+    PASS=$((PASS + 1))
+  fi
 }
 
 check() {
@@ -149,6 +197,54 @@ console.log(r.status, r.ok)
 check "POST is rejected" 1 \
   "fetch('${BASE}/', { method: 'POST' })" \
   "TypeError"
+
+# --- Private-range policy (WP-2) ---
+#
+# The test server listens on loopback, so it is itself a private target. That
+# makes it the honest fixture for this policy: with the flag off the request
+# must still work (no behavior change for existing hosts), and with it on the
+# very same request must be refused.
+
+check_with "loopback reachable without the deny flag" "" 0 "
+const r = await fetch('${BASE}/text')
+console.log(r.status)
+" "200"
+
+check_with "loopback refused with --fetch-deny-private-ranges" \
+  "--fetch-deny-private-ranges" 1 "
+await fetch('${BASE}/text')
+" "TypeError"
+
+# Exits 0: the script catches the rejection, so the assertion is on the
+# message, which must name the address the host actually resolved to.
+check_with "private-range rejection names the resolved address" \
+  "--fetch-deny-private-ranges" 0 "
+try {
+  await fetch('${BASE}/text')
+} catch (e) {
+  console.log(e.message)
+}
+" "127.0.0.1"
+
+# A redirect hop must be resolved and validated exactly like the first
+# request; validating only the initial target would leave the hole open.
+check_with "redirect hop is policy-checked too" \
+  "--fetch-deny-private-ranges" 1 "
+await fetch('${BASE}/redirect')
+" "TypeError"
+
+# --- Response body cap (WP-2) ---
+
+check_with "response under the cap succeeds" \
+  "--fetch-max-response-bytes=1048576" 0 "
+const r = await fetch('${BASE}/text')
+console.log((await r.text()).trim())
+" "hello world"
+
+check_with "response over the cap is refused" \
+  "--fetch-max-response-bytes=4" 1 "
+await fetch('${BASE}/text')
+" "TypeError"
 
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="

--- a/source/app/Goccia.CLI.Application.pas
+++ b/source/app/Goccia.CLI.Application.pas
@@ -147,11 +147,13 @@ uses
   Math,
 
   CLI.Parser,
+  HTTPTypes,
   TextEncoding,
   TextSemantics,
 
   Goccia.CLI.Help,
   Goccia.Coverage,
+  Goccia.FetchManager,
   Goccia.FileExtensions,
   Goccia.GarbageCollector,
   Goccia.JSON,
@@ -627,6 +629,8 @@ procedure ApplyFileConfigToEngine(const AEngine: TGocciaEngine;
 var
   ValueStr: string;
   MemoryLimit: Int64;
+  ResponseLimit: Integer;
+  FetchPolicy: THTTPRequestPolicy;
   GC: TGarbageCollector;
   FileHosts: TStringList;
   HasFileHosts: Boolean;
@@ -711,6 +715,32 @@ begin
     else if AEngineOptions.AllowedHosts.Present then
       AEngine.SetAllowedFetchHosts(AEngineOptions.AllowedHosts.Values);
   end;
+
+  { fetch-deny-private-ranges / fetch-max-response-bytes: CLI flag > per-file
+    config > root config > defaults. Always assigned, for the same reason
+    max-memory is: the fetch manager is process-global, so leaving a previous
+    file's policy in place would silently apply it to the next one. }
+  FetchPolicy := DefaultHTTPPolicy;
+  FetchPolicy.DenyPrivateRanges := ResolveFlagOption(
+    AEngineOptions.FetchDenyPrivateRanges, AFileConfig);
+
+  if AEngineOptions.FetchMaxResponseBytes.FromCommandLine then
+    FetchPolicy.MaxResponseBytes := AEngineOptions.FetchMaxResponseBytes.Value
+  else if FindConfigEntry(AFileConfig, 'fetch-max-response-bytes',
+    ValueStr) then
+  begin
+    if not TryStrToInt(ValueStr, ResponseLimit) then
+      raise Exception.CreateFmt(
+        'Invalid fetch-max-response-bytes value in config: %s', [ValueStr]);
+    FetchPolicy.MaxResponseBytes := ResponseLimit;
+  end
+  else if AEngineOptions.FetchMaxResponseBytes.Present then
+    FetchPolicy.MaxResponseBytes := AEngineOptions.FetchMaxResponseBytes.Value;
+
+  if FetchPolicy.MaxResponseBytes < 0 then
+    raise Exception.Create('fetch-max-response-bytes must be 0 or greater');
+
+  SetFetchRequestPolicy(FetchPolicy);
 end;
 
 procedure TGocciaCLIApplication.ConfigureCreatedEngine(

--- a/source/app/Goccia.CLI.Options.pas
+++ b/source/app/Goccia.CLI.Options.pas
@@ -37,6 +37,8 @@ type
     FStackSize: TIntegerOption;
     FStrictTypes: TFlagOption;
     FAllowedHosts: TRepeatableOption;
+    FFetchDenyPrivateRanges: TFlagOption;
+    FFetchMaxResponseBytes: TIntegerOption;
     FNoHostFilesystem: TFlagOption;
     FInspectDepth: TIntegerOption;
     FModule: TRepeatableOption;
@@ -64,6 +66,8 @@ type
     property StackSize: TIntegerOption read FStackSize;
     property StrictTypes: TFlagOption read FStrictTypes;
     property AllowedHosts: TRepeatableOption read FAllowedHosts;
+    property FetchDenyPrivateRanges: TFlagOption read FFetchDenyPrivateRanges;
+    property FetchMaxResponseBytes: TIntegerOption read FFetchMaxResponseBytes;
     property NoHostFilesystem: TFlagOption read FNoHostFilesystem;
     property InspectDepth: TIntegerOption read FInspectDepth;
     property ModuleDefinitions: TRepeatableOption read FModule;
@@ -118,7 +122,7 @@ function TryApplyCompatibilityFlagArg(const AArg: string;
 implementation
 
 const
-  ENGINE_FIXED_OPTION_COUNT = 19;
+  ENGINE_FIXED_OPTION_COUNT = 21;
 
   SOURCE_COMPATIBILITY_FLAGS: array[TGocciaCompatibility]
     of TGocciaCompatibilityFlagDescriptor = (
@@ -233,6 +237,12 @@ begin
   FAllowedHosts := TRepeatableOption.Create('allowed-host',
     'Hostname allowed for fetch requests (repeatable)', 'Engine');
   FAllowedHosts.ConfigName := 'allowed-hosts';
+  FFetchDenyPrivateRanges := TFlagOption.Create('fetch-deny-private-ranges',
+    'Reject fetch targets resolving to private, loopback, or link-local addresses',
+    'Runtime');
+  FFetchMaxResponseBytes := TIntegerOption.Create('fetch-max-response-bytes',
+    'Maximum fetch response body size in bytes (TypeError on exceed)',
+    'Runtime');
   FNoHostFilesystem := TFlagOption.Create('no-host-filesystem',
     'Disable ambient host-filesystem module loading', 'Runtime');
   FInspectDepth := TIntegerOption.Create('inspect-depth',
@@ -264,6 +274,8 @@ begin
   FStackSize.Free;
   FStrictTypes.Free;
   FAllowedHosts.Free;
+  FFetchDenyPrivateRanges.Free;
+  FFetchMaxResponseBytes.Free;
   FNoHostFilesystem.Free;
   FInspectDepth.Free;
   FModule.Free;
@@ -312,6 +324,10 @@ begin
   Result[Index] := FStrictTypes;
   Inc(Index);
   Result[Index] := FAllowedHosts;
+  Inc(Index);
+  Result[Index] := FFetchDenyPrivateRanges;
+  Inc(Index);
+  Result[Index] := FFetchMaxResponseBytes;
   Inc(Index);
   Result[Index] := FNoHostFilesystem;
   Inc(Index);

--- a/source/shared/HTTPClient.Test.pas
+++ b/source/shared/HTTPClient.Test.pas
@@ -8,6 +8,7 @@ uses
   SysUtils,
 
   HTTPClient,
+  HTTPTypes,
   TestingPascalLibrary,
   TimingUtils;
 
@@ -20,6 +21,11 @@ type
     procedure TestConnectionDeadlineBoundsBlockingWork;
     procedure TestRejectsAmbiguousAuthority;
     procedure TestRejectsRequestTargetControls;
+    procedure TestClassifiesPrivateAddressRanges;
+    procedure TestClassifiesPublicAddressesAsRoutable;
+    procedure TestRejectsObfuscatedLoopbackForms;
+    procedure TestResolvesLiteralAddressWithoutLookup;
+    procedure TestDefaultPolicyPreservesHistoricalBehavior;
   end;
 
 procedure THTTPClientTests.SetupTests;
@@ -30,6 +36,16 @@ begin
     TestConnectionDeadlineBoundsBlockingWork);
   Test('Rejects ambiguous authority', TestRejectsAmbiguousAuthority);
   Test('Rejects request-target controls', TestRejectsRequestTargetControls);
+  Test('Classifies private address ranges',
+    TestClassifiesPrivateAddressRanges);
+  Test('Classifies public addresses as routable',
+    TestClassifiesPublicAddressesAsRoutable);
+  Test('Rejects obfuscated loopback forms',
+    TestRejectsObfuscatedLoopbackForms);
+  Test('Resolves literal address without lookup',
+    TestResolvesLiteralAddressWithoutLookup);
+  Test('Default policy preserves historical behavior',
+    TestDefaultPolicyPreservesHistoricalBehavior);
 end;
 
 procedure THTTPClientTests.TestCanonicalAuthorityParsing;
@@ -104,6 +120,76 @@ begin
       Raised := True;
   end;
   Expect<Boolean>(Raised).ToBe(True);
+end;
+
+{ The ranges --fetch-deny-private-ranges exists to keep a script away from.
+  169.254.169.254 is called out explicitly because the cloud
+  instance-metadata endpoint is the payload SSRF is usually aiming at. }
+procedure THTTPClientTests.TestClassifiesPrivateAddressRanges;
+begin
+  Expect<Boolean>(IsPrivateNetworkAddress('10.0.0.1')).ToBe(True);
+  Expect<Boolean>(IsPrivateNetworkAddress('10.255.255.255')).ToBe(True);
+  Expect<Boolean>(IsPrivateNetworkAddress('172.16.0.1')).ToBe(True);
+  Expect<Boolean>(IsPrivateNetworkAddress('172.31.255.254')).ToBe(True);
+  Expect<Boolean>(IsPrivateNetworkAddress('192.168.1.1')).ToBe(True);
+  Expect<Boolean>(IsPrivateNetworkAddress('127.0.0.1')).ToBe(True);
+  Expect<Boolean>(IsPrivateNetworkAddress('169.254.169.254')).ToBe(True);
+  Expect<Boolean>(IsPrivateNetworkAddress('100.64.0.1')).ToBe(True);
+  Expect<Boolean>(IsPrivateNetworkAddress('0.0.0.0')).ToBe(True);
+  Expect<Boolean>(IsPrivateNetworkAddress('224.0.0.1')).ToBe(True);
+  Expect<Boolean>(IsPrivateNetworkAddress('::1')).ToBe(True);
+  Expect<Boolean>(IsPrivateNetworkAddress('fd00::1')).ToBe(True);
+  Expect<Boolean>(IsPrivateNetworkAddress('fe80::1')).ToBe(True);
+  Expect<Boolean>(IsPrivateNetworkAddress('[::1]')).ToBe(True);
+end;
+
+{ The boundaries matter as much as the ranges: 172.15 and 172.32 sit just
+  outside 172.16/12, and 11.x / 192.169.x are the neighbours of 10/8 and
+  192.168/16. An off-by-one here silently blocks legitimate traffic. }
+procedure THTTPClientTests.TestClassifiesPublicAddressesAsRoutable;
+begin
+  Expect<Boolean>(IsPrivateNetworkAddress('8.8.8.8')).ToBe(False);
+  Expect<Boolean>(IsPrivateNetworkAddress('1.1.1.1')).ToBe(False);
+  Expect<Boolean>(IsPrivateNetworkAddress('172.15.255.255')).ToBe(False);
+  Expect<Boolean>(IsPrivateNetworkAddress('172.32.0.1')).ToBe(False);
+  Expect<Boolean>(IsPrivateNetworkAddress('11.0.0.1')).ToBe(False);
+  Expect<Boolean>(IsPrivateNetworkAddress('192.169.0.1')).ToBe(False);
+  Expect<Boolean>(IsPrivateNetworkAddress('100.63.255.255')).ToBe(False);
+  Expect<Boolean>(IsPrivateNetworkAddress('100.128.0.1')).ToBe(False);
+  Expect<Boolean>(IsPrivateNetworkAddress('2606:4700::1111')).ToBe(False);
+end;
+
+{ Shortened and hex IPv4 forms are the classic way to smuggle loopback past
+  a textual filter. The classifier must not silently reinterpret them as
+  routable — anything it cannot parse as four decimal octets is refused. }
+procedure THTTPClientTests.TestRejectsObfuscatedLoopbackForms;
+begin
+  Expect<Boolean>(IsPrivateNetworkAddress('127.1')).ToBe(True);
+  Expect<Boolean>(IsPrivateNetworkAddress('0x7f.0.0.1')).ToBe(True);
+  Expect<Boolean>(IsPrivateNetworkAddress('2130706433')).ToBe(True);
+  Expect<Boolean>(IsPrivateNetworkAddress('localhost')).ToBe(True);
+  Expect<Boolean>(IsPrivateNetworkAddress('')).ToBe(True);
+  Expect<Boolean>(IsPrivateNetworkAddress('999.1.1.1')).ToBe(True);
+  Expect<Boolean>(IsPrivateNetworkAddress('1.2.3.4.5')).ToBe(True);
+end;
+
+{ A literal target must round-trip unchanged and perform no lookup, so
+  pinning never introduces DNS traffic for a request that had none. }
+procedure THTTPClientTests.TestResolvesLiteralAddressWithoutLookup;
+begin
+  Expect<string>(ResolveHostToAddress('93.184.216.34')).ToBe('93.184.216.34');
+  Expect<string>(ResolveHostToAddress('127.0.0.1')).ToBe('127.0.0.1');
+end;
+
+{ A host that never sets a policy must see exactly the previous behavior:
+  private ranges reachable, 8 MiB body ceiling. }
+procedure THTTPClientTests.TestDefaultPolicyPreservesHistoricalBehavior;
+var
+  Policy: THTTPRequestPolicy;
+begin
+  Policy := DefaultHTTPPolicy;
+  Expect<Boolean>(Policy.DenyPrivateRanges).ToBe(False);
+  Expect<Integer>(Policy.MaxResponseBytes).ToBe(8 * 1024 * 1024);
 end;
 
 begin

--- a/source/shared/HTTPClient.pas
+++ b/source/shared/HTTPClient.pas
@@ -23,13 +23,30 @@ type
   THTTPHeaders = HTTPTypes.THTTPHeaders;
   THTTPResponse = HTTPTypes.THTTPResponse;
   EHTTPError = HTTPTypes.EHTTPError;
+  THTTPRequestPolicy = HTTPTypes.THTTPRequestPolicy;
+
+const
+  DEFAULT_MAX_RESPONSE_BODY_BYTES = HTTPTypes.DEFAULT_MAX_RESPONSE_BODY_BYTES;
 
 function HTTPGet(const AURL: string;
   const AHeaders: THTTPHeaders; const AAllowedHosts: TStrings = nil;
-  const ATimeoutMilliseconds: Integer = 0): THTTPResponse;
+  const ATimeoutMilliseconds: Integer = 0): THTTPResponse; overload;
+function HTTPGet(const AURL: string;
+  const AHeaders: THTTPHeaders; const AAllowedHosts: TStrings;
+  const ATimeoutMilliseconds: Integer;
+  const APolicy: THTTPRequestPolicy): THTTPResponse; overload;
 function HTTPHead(const AURL: string;
   const AHeaders: THTTPHeaders; const AAllowedHosts: TStrings = nil;
-  const ATimeoutMilliseconds: Integer = 0): THTTPResponse;
+  const ATimeoutMilliseconds: Integer = 0): THTTPResponse; overload;
+function HTTPHead(const AURL: string;
+  const AHeaders: THTTPHeaders; const AAllowedHosts: TStrings;
+  const ATimeoutMilliseconds: Integer;
+  const APolicy: THTTPRequestPolicy): THTTPResponse; overload;
+
+{ Exposed for testing: the address-classification and resolution steps that
+  DoRequest performs between validating a destination and connecting to it. }
+function IsPrivateNetworkAddress(const AAddressText: string): Boolean;
+function ResolveHostToAddress(const AHost: string): string;
 function HTTPURLHost(const AURL: string): string;
 function HTTPURLAuditHost(const AURL: string): string;
 function WaitForHTTPConnectionWorkers(
@@ -56,7 +73,6 @@ const
   MAX_HTTP_CONNECTION_WORKERS = 16;
   MAX_REDIRECTS = 20;
   MAX_RESPONSE_HEADER_BYTES = 64 * 1024;
-  MAX_RESPONSE_BODY_BYTES = 8 * 1024 * 1024;
   CRLF = #13#10;
   RECV_BUF_SIZE = 8192;
 
@@ -853,7 +869,8 @@ end;
 
 function ReadResponse(const ASock: TSocket;
   var ATransport: TTransportSecurityConnection;
-  const AIsHead: Boolean; const ADeadlineNs: Int64): TRawHTTPResponse;
+  const AIsHead: Boolean; const ADeadlineNs: Int64;
+  const AMaxBodyBytes: Integer): TRawHTTPResponse;
 var
   Buf: array[0..RECV_BUF_SIZE - 1] of Byte;
   RawHeader: TBytes;
@@ -998,7 +1015,7 @@ begin
         N := Receive(Buf, RECV_BUF_SIZE);
         if N <= 0 then begin Done := True; Break; end;
         AppendBytes(ChunkBuf, @Buf[0], N,
-          MAX_RESPONSE_BODY_BYTES + RECV_BUF_SIZE);
+          AMaxBodyBytes + RECV_BUF_SIZE);
       end;
       if Done then Break;
 
@@ -1013,16 +1030,16 @@ begin
       ChunkSize := StrToIntDef('$' + Trim(Line), 0);
       if ChunkSize = 0 then Break;
       if (ChunkSize < 0) or
-         (Length(Result.Body) > MAX_RESPONSE_BODY_BYTES - ChunkSize) then
+         (Length(Result.Body) > AMaxBodyBytes - ChunkSize) then
         raise EHTTPError.CreateFmt('HTTP response body exceeds %d byte limit',
-          [MAX_RESPONSE_BODY_BYTES]);
+          [AMaxBodyBytes]);
 
       while Length(ChunkBuf) < ChunkSize + 2 do
       begin
         N := Receive(Buf, RECV_BUF_SIZE);
         if N <= 0 then begin Done := True; Break; end;
         AppendBytes(ChunkBuf, @Buf[0], N,
-          MAX_RESPONSE_BODY_BYTES + RECV_BUF_SIZE);
+          AMaxBodyBytes + RECV_BUF_SIZE);
       end;
 
       BodyLen := Length(Result.Body);
@@ -1037,9 +1054,9 @@ begin
 
     if ContentLen >= 0 then
     begin
-      if ContentLen > MAX_RESPONSE_BODY_BYTES then
+      if ContentLen > AMaxBodyBytes then
         raise EHTTPError.CreateFmt('HTTP response body exceeds %d byte limit',
-          [MAX_RESPONSE_BODY_BYTES]);
+          [AMaxBodyBytes]);
       SetLength(Result.Body, ContentLen);
       BodyLen := 0;
 
@@ -1077,15 +1094,190 @@ begin
         N := Receive(Buf, RECV_BUF_SIZE);
         if N <= 0 then Break;
         BodyLen := Length(Result.Body);
-        if BodyLen > MAX_RESPONSE_BODY_BYTES - N then
+        if BodyLen > AMaxBodyBytes - N then
           raise EHTTPError.CreateFmt(
             'HTTP response body exceeds %d byte limit',
-            [MAX_RESPONSE_BODY_BYTES]);
+            [AMaxBodyBytes]);
         SetLength(Result.Body, BodyLen + N);
         Move(Buf[0], Result.Body[BodyLen], N);
       until False;
     end;
   end;
+end;
+
+// ---------------------------------------------------------------------------
+// Destination resolution and address policy
+// ---------------------------------------------------------------------------
+
+{ Parses dotted-quad IPv4 text. Deliberately strict: anything that is not
+  exactly four decimal octets is not an IPv4 literal, so shortened forms
+  ("10.1", "0x7f.1") and octal-looking octets are rejected rather than
+  reinterpreted. Those forms are a classic way to smuggle a loopback address
+  past a naive textual filter, and both platform resolvers here are AF_INET
+  so we never have to accept them. }
+function TryParseIPv4(const AValue: string; out AOctets: array of Byte): Boolean;
+var
+  I, Part, Digits, Value: Integer;
+  Ch: Char;
+begin
+  Part := 0;
+  Value := 0;
+  Digits := 0;
+  for I := 1 to Length(AValue) do
+  begin
+    Ch := AValue[I];
+    if (Ch >= '0') and (Ch <= '9') then
+    begin
+      Inc(Digits);
+      if Digits > 3 then
+        Exit(False);
+      Value := Value * 10 + (Ord(Ch) - Ord('0'));
+      if Value > 255 then
+        Exit(False);
+    end
+    else if Ch = '.' then
+    begin
+      if (Digits = 0) or (Part > 2) then
+        Exit(False);
+      AOctets[Part] := Byte(Value);
+      Inc(Part);
+      Value := 0;
+      Digits := 0;
+    end
+    else
+      Exit(False);
+  end;
+  if (Digits = 0) or (Part <> 3) then
+    Exit(False);
+  AOctets[3] := Byte(Value);
+  Result := True;
+end;
+
+{ True when the address belongs to a range that is not routable on the public
+  internet and is therefore reachable only from inside the host's own network
+  position — which is exactly what an SSRF payload is after. The cloud
+  instance-metadata endpoint (169.254.169.254) falls under link-local. }
+function IsPrivateNetworkAddress(const AAddressText: string): Boolean;
+var
+  Octets: array[0..3] of Byte;
+  Normalized: string;
+begin
+  Normalized := LowerCase(Trim(AAddressText));
+  if Normalized = '' then
+    Exit(True);
+
+  { Strip the brackets an IPv6 authority carries in a URL. }
+  if (Length(Normalized) >= 2) and (Normalized[1] = '[') and
+     (Normalized[Length(Normalized)] = ']') then
+    Normalized := Copy(Normalized, 2, Length(Normalized) - 2);
+
+  if TryParseIPv4(Normalized, Octets) then
+  begin
+    Result :=
+      (Octets[0] = 10) or                                        // 10/8
+      (Octets[0] = 127) or                                       // loopback
+      (Octets[0] = 0) or                                         // this host
+      ((Octets[0] = 172) and (Octets[1] >= 16) and
+       (Octets[1] <= 31)) or                                     // 172.16/12
+      ((Octets[0] = 192) and (Octets[1] = 168)) or               // 192.168/16
+      ((Octets[0] = 169) and (Octets[1] = 254)) or               // link-local
+      ((Octets[0] = 100) and (Octets[1] >= 64) and
+       (Octets[1] <= 127)) or                                    // CGNAT
+      ((Octets[0] = 192) and (Octets[1] = 0) and
+       (Octets[2] = 0)) or                                       // IETF proto
+      (Octets[0] >= 224);                                        // multicast +
+    Exit;
+  end;
+
+  { IPv6. Neither platform connect path requests AF_INET6 today, so this is
+    defensive: it keeps the classifier correct if a literal reaches it, and
+    stays deny-biased for anything it cannot parse. }
+  if Pos(':', Normalized) > 0 then
+  begin
+    Result :=
+      (Normalized = '::1') or                                    // loopback
+      (Normalized = '::') or                                     // unspecified
+      (Copy(Normalized, 1, 2) = 'fc') or                         // ULA fc00::/7
+      (Copy(Normalized, 1, 2) = 'fd') or
+      (Copy(Normalized, 1, 4) = 'fe80') or                       // link-local
+      (Copy(Normalized, 1, 7) = '::ffff:');                      // v4-mapped
+    Exit;
+  end;
+
+  { Not an address literal at all. Callers pass a resolved address here, so
+    reaching this means resolution produced something unexpected; refuse it
+    rather than let an unclassifiable target through. }
+  Result := True;
+end;
+
+{ Resolves a hostname to a single numeric address, once.
+
+  This is the fix for the check-then-use window: DoRequest used to validate a
+  *hostname* and then hand that same hostname to connect, which resolved it
+  again. An allowlisted name under attacker DNS control could answer the first
+  lookup with a public address and the second with 169.254.169.254. Resolving
+  here and connecting to the returned literal means the address that was
+  checked is the address that is used.
+
+  An input that is already a literal is returned unchanged, so no lookup
+  happens for numeric targets. }
+function ResolveHostToAddress(const AHost: string): string;
+{$IFDEF UNIX}
+var
+  Octets: array[0..3] of Byte;
+  HostEntry: THostEntry;
+{$ENDIF}
+{$IFDEF MSWINDOWS}
+var
+  Octets: array[0..3] of Byte;
+  Hints, Res: PAddrInfo;
+  HostBytes: TBytes;
+  ErrorOffset: Integer;
+  SockAddr: PSockAddrIn;
+{$ENDIF}
+begin
+  if AHost = '' then
+    raise EHTTPError.Create('Failed to resolve host: (empty)');
+  if TryParseIPv4(AHost, Octets) then
+    Exit(AHost);
+
+  {$IFDEF UNIX}
+  if not ResolveHostByName(AHost, HostEntry) then
+    raise EHTTPError.CreateFmt('Failed to resolve host: %s', [AHost]);
+  Result := NetAddrToStr(HostEntry.Addr);
+  {$ENDIF}
+  {$IFDEF MSWINDOWS}
+  EnsureWinSockInit;
+  New(Hints);
+  try
+    FillChar(Hints^, SizeOf(TAddrInfo), 0);
+    Hints^.ai_family := AF_INET;
+    Hints^.ai_socktype := SOCK_STREAM;
+    Hints^.ai_protocol := IPPROTO_TCP;
+    if not TryEncodeASCIINullTerminated(AHost, HostBytes, ErrorOffset) then
+      raise EHTTPError.CreateFmt(
+        'HTTP host contains a non-ASCII code unit at offset %d',
+        [ErrorOffset]);
+    Res := nil;
+    if Getaddrinfo(PAnsiChar(@HostBytes[0]), nil, Hints, Res) <> 0 then
+      raise EHTTPError.CreateFmt('Failed to resolve host: %s', [AHost]);
+    try
+      if not Assigned(Res) or not Assigned(Res^.ai_addr) then
+        raise EHTTPError.CreateFmt('Failed to resolve host: %s', [AHost]);
+      SockAddr := PSockAddrIn(Res^.ai_addr);
+      Result := Format('%d.%d.%d.%d', [
+        SockAddr^.sin_addr.S_un_b.s_b1, SockAddr^.sin_addr.S_un_b.s_b2,
+        SockAddr^.sin_addr.S_un_b.s_b3, SockAddr^.sin_addr.S_un_b.s_b4]);
+    finally
+      Freeaddrinfo(Res);
+    end;
+  finally
+    Dispose(Hints);
+  end;
+  {$ENDIF}
+
+  if Result = '' then
+    raise EHTTPError.CreateFmt('Failed to resolve host: %s', [AHost]);
 end;
 
 // ---------------------------------------------------------------------------
@@ -1095,9 +1287,12 @@ end;
 function DoRequest(const AMethod, AURL: string;
   const AHeaders: THTTPHeaders;
   const AMaxRedirects: Integer; const AAllowedHosts: TStrings;
-  const ATimeoutMilliseconds: Integer): THTTPResponse;
+  const ATimeoutMilliseconds: Integer;
+  const APolicy: THTTPRequestPolicy): THTTPResponse;
 var
   Parsed: THTTPParsedURL;
+  ResolvedAddress: string;
+  MaxBodyBytes: Integer;
   Sock: TSocket;
   Transport: TTransportSecurityConnection;
   Request: TBytes;
@@ -1123,12 +1318,28 @@ var
     Result := Integer((RemainingNs + 999999) div 1000000);
   end;
 
-  procedure ValidateDestination(const AParsed: THTTPParsedURL);
+  { Resolves the destination once and validates both the name and the address
+    it resolved to, returning the address the caller must connect to.
+
+    Order matters. The name check runs first so an off-allowlist host is
+    rejected without a DNS lookup, which keeps a denied request from becoming
+    an observable side effect. The address check runs on the resolved value,
+    because that is the only form in which "is this target internal" is a
+    meaningful question. }
+  function ResolveAndValidateDestination(
+    const AParsed: THTTPParsedURL): string;
   begin
     if Assigned(AAllowedHosts) and
        (AAllowedHosts.IndexOf(AParsed.Host) < 0) then
       raise EHTTPError.CreateFmt('fetch host not allowed: %s',
         [AParsed.Host]);
+
+    Result := ResolveHostToAddress(AParsed.Host);
+
+    if APolicy.DenyPrivateRanges and IsPrivateNetworkAddress(Result) then
+      raise EHTTPError.CreateFmt(
+        'fetch destination not allowed: %s resolves to private address %s',
+        [AParsed.Host, Result]);
   end;
 
   procedure ValidateRequestText(const AValue, AKind: string;
@@ -1147,6 +1358,9 @@ var
 begin
   if ATimeoutMilliseconds < 0 then
     raise EHTTPError.Create('Invalid HTTP timeout');
+  MaxBodyBytes := APolicy.MaxResponseBytes;
+  if MaxBodyBytes <= 0 then
+    MaxBodyBytes := DEFAULT_MAX_RESPONSE_BODY_BYTES;
   if ATimeoutMilliseconds > 0 then
     DeadlineNs := GetNanoseconds +
       Int64(ATimeoutMilliseconds) * 1000000
@@ -1161,13 +1375,23 @@ begin
   while True do
   begin
     Parsed := ParseHTTPURL(CurrentURL);
-    ValidateDestination(Parsed);
+    { Runs on every pass of this loop, so a redirect hop is resolved,
+      validated, and pinned exactly like the initial request. }
+    ResolvedAddress := ResolveAndValidateDestination(Parsed);
     ValidateRequestText(Parsed.Path, 'request target', False);
     FillChar(Transport, SizeOf(Transport), 0);
-    Sock := ConnectSocket(Parsed.Host, Parsed.Port,
+    { Connect to the address that was just validated, not to the name. Both
+      platform connect paths take a numeric fast path for a literal, so this
+      performs no second lookup and there is no window in which DNS can
+      answer differently. }
+    Sock := ConnectSocket(ResolvedAddress, Parsed.Port,
       RemainingTimeoutMilliseconds);
     try
       ConfigureSocketTimeout(Sock, RemainingTimeoutMilliseconds);
+      { TLS still verifies against the hostname. Pinning changes which
+        address we dial, never which identity we require the peer to prove —
+        handing the literal here would break certificate validation and
+        silently downgrade the connection's guarantees. }
       if Parsed.Scheme = 'https' then
         StartTransportSecurity(Transport, Sock, Parsed.Host);
 
@@ -1211,7 +1435,8 @@ begin
         Request := EncodeUTF8WithReplacement(RequestText);
 
         SendAll(Sock, Transport, Request);
-        Raw := ReadResponse(Sock, Transport, IsHead, DeadlineNs);
+        Raw := ReadResponse(Sock, Transport, IsHead, DeadlineNs,
+          MaxBodyBytes);
       finally
         CloseTransportSecurity(Transport);
       end;
@@ -1269,7 +1494,25 @@ function HTTPGet(const AURL: string;
   const ATimeoutMilliseconds: Integer): THTTPResponse;
 begin
   Result := DoRequest('GET', AURL, AHeaders, MAX_REDIRECTS, AAllowedHosts,
-    ATimeoutMilliseconds);
+    ATimeoutMilliseconds, DefaultHTTPPolicy);
+end;
+
+function HTTPGet(const AURL: string;
+  const AHeaders: THTTPHeaders; const AAllowedHosts: TStrings;
+  const ATimeoutMilliseconds: Integer;
+  const APolicy: THTTPRequestPolicy): THTTPResponse;
+begin
+  Result := DoRequest('GET', AURL, AHeaders, MAX_REDIRECTS, AAllowedHosts,
+    ATimeoutMilliseconds, APolicy);
+end;
+
+function HTTPHead(const AURL: string;
+  const AHeaders: THTTPHeaders; const AAllowedHosts: TStrings;
+  const ATimeoutMilliseconds: Integer;
+  const APolicy: THTTPRequestPolicy): THTTPResponse;
+begin
+  Result := DoRequest('HEAD', AURL, AHeaders, MAX_REDIRECTS, AAllowedHosts,
+    ATimeoutMilliseconds, APolicy);
 end;
 
 function HTTPHead(const AURL: string;
@@ -1277,7 +1520,7 @@ function HTTPHead(const AURL: string;
   const ATimeoutMilliseconds: Integer): THTTPResponse;
 begin
   Result := DoRequest('HEAD', AURL, AHeaders, MAX_REDIRECTS, AAllowedHosts,
-    ATimeoutMilliseconds);
+    ATimeoutMilliseconds, DefaultHTTPPolicy);
 end;
 
 end.

--- a/source/shared/HTTPTypes.pas
+++ b/source/shared/HTTPTypes.pas
@@ -34,6 +34,40 @@ type
 
   EHTTPError = class(Exception);
 
+  { Per-request network policy.
+
+    Separate from the allowlist because the allowlist answers "which names may
+    this script reach" while these answer "what may those names resolve to,
+    and how much may they return" — questions the allowlist cannot express.
+    Use DefaultHTTPPolicy to get the historical behavior.
+
+    Lives here rather than in HTTPClient for the same reason THTTPHeaders
+    does: the fetch manager's abstract base carries a policy in its interface
+    and must not pull the socket implementation into its unit closure. }
+  THTTPRequestPolicy = record
+    { Reject targets that resolve into RFC1918, loopback, link-local, CGNAT,
+      or IPv6 ULA/loopback space. Applied to the *resolved address*, on the
+      initial request and on every redirect hop. }
+    DenyPrivateRanges: Boolean;
+    { Hard ceiling on the response body, in bytes. Zero selects
+      DEFAULT_MAX_RESPONSE_BODY_BYTES. }
+    MaxResponseBytes: Integer;
+  end;
+
+const
+  { Ceiling on a response body when the caller states no preference. Matches
+    the limit that was hard-coded in HTTPClient before it became configurable,
+    so an embedder that never sets a policy sees no behavior change. }
+  DEFAULT_MAX_RESPONSE_BODY_BYTES = 8 * 1024 * 1024;
+
+function DefaultHTTPPolicy: THTTPRequestPolicy;
+
 implementation
+
+function DefaultHTTPPolicy: THTTPRequestPolicy;
+begin
+  Result.DenyPrivateRanges := False;
+  Result.MaxResponseBytes := DEFAULT_MAX_RESPONSE_BODY_BYTES;
+end;
 
 end.

--- a/source/units/Goccia.FetchManager.pas
+++ b/source/units/Goccia.FetchManager.pas
@@ -33,7 +33,25 @@ type
     function WaitForPromise(const APromise: TGocciaPromiseValue): Boolean; virtual; abstract;
     procedure WaitForIdle; virtual; abstract;
     procedure DiscardPending; virtual; abstract;
+
+    { Network policy applied to every request this manager starts: resolved
+      address restrictions and the response-body ceiling.
+
+      Carried on the manager rather than passed per call because it is host
+      configuration, not a property of an individual fetch — script space must
+      not be able to vary it, and StartFetch is reachable from script space.
+      Defaults to DefaultHTTPPolicy, so a host that never sets it keeps the
+      historical behavior. }
+    function GetRequestPolicy: THTTPRequestPolicy; virtual; abstract;
+    procedure SetRequestPolicy(
+      const APolicy: THTTPRequestPolicy); virtual; abstract;
+    property RequestPolicy: THTTPRequestPolicy
+      read GetRequestPolicy write SetRequestPolicy;
   end;
+
+{ Applies a policy to the process-wide fetch manager, creating it if needed.
+  The CLI and embedding hosts use this rather than reaching for Instance. }
+procedure SetFetchRequestPolicy(const APolicy: THTTPRequestPolicy);
 
 procedure DrainMicrotasksAndFetchCompletions;
 function WaitForFetchPromise(const APromise: TGocciaPromiseValue): Boolean;
@@ -139,13 +157,15 @@ type
     FHeaders: THTTPHeaders;
     FAllowedHosts: TStringList;
     FTimeoutMilliseconds: Integer;
+    FPolicy: THTTPRequestPolicy;
   protected
     procedure Execute; override;
   public
     constructor Create(const AState: TGocciaFetchState;
       const ALimiter: TGocciaFetchLimiter; const ARequestID: Integer;
       const AURL, AMethod: string; const AHeaders: THTTPHeaders;
-      const AAllowedHosts: TStrings; const ATimeoutMilliseconds: Integer);
+      const AAllowedHosts: TStrings; const ATimeoutMilliseconds: Integer;
+      const APolicy: THTTPRequestPolicy);
     destructor Destroy; override;
   end;
 
@@ -155,6 +175,7 @@ type
     FLimiter: TGocciaFetchLimiter;
     FPending: TList<TGocciaPendingFetch>;
     FNextRequestID: Integer;
+    FPolicy: THTTPRequestPolicy;
     function PopCompletion(out ACompletion: TGocciaFetchCompletion): Boolean;
     function FindPendingIndex(const ARequestID: Integer): Integer;
     function RejectAbortedFetches: Integer;
@@ -174,6 +195,9 @@ type
     function WaitForPromise(const APromise: TGocciaPromiseValue): Boolean; override;
     procedure WaitForIdle; override;
     procedure DiscardPending; override;
+    function GetRequestPolicy: THTTPRequestPolicy; override;
+    procedure SetRequestPolicy(
+      const APolicy: THTTPRequestPolicy); override;
   end;
 
 {$ENDIF}
@@ -333,7 +357,8 @@ end;
 constructor TGocciaFetchWorker.Create(const AState: TGocciaFetchState;
   const ALimiter: TGocciaFetchLimiter; const ARequestID: Integer;
   const AURL, AMethod: string; const AHeaders: THTTPHeaders;
-  const AAllowedHosts: TStrings; const ATimeoutMilliseconds: Integer);
+  const AAllowedHosts: TStrings; const ATimeoutMilliseconds: Integer;
+  const APolicy: THTTPRequestPolicy);
 begin
   inherited Create(True, FETCH_WORKER_STACK_SIZE);
   FreeOnTerminate := True;
@@ -346,6 +371,7 @@ begin
   if Assigned(AAllowedHosts) then
     FAllowedHosts.Assign(AAllowedHosts);
   FTimeoutMilliseconds := ATimeoutMilliseconds;
+  FPolicy := APolicy;
   FState := AState;
   FState.AddRef;
   FLimiter := ALimiter;
@@ -374,10 +400,10 @@ begin
     try
       if FMethod = 'HEAD' then
         Completion.Response := HTTPHead(FURL, FHeaders, FAllowedHosts,
-          FTimeoutMilliseconds)
+          FTimeoutMilliseconds, FPolicy)
       else
         Completion.Response := HTTPGet(FURL, FHeaders, FAllowedHosts,
-          FTimeoutMilliseconds);
+          FTimeoutMilliseconds, FPolicy);
       Completion.Success := True;
     except
       on E: EHTTPError do
@@ -426,6 +452,7 @@ begin
   FLimiter := TGocciaFetchLimiter.Create;
   FPending := TList<TGocciaPendingFetch>.Create;
   FNextRequestID := 1;
+  FPolicy := DefaultHTTPPolicy;
 end;
 
 destructor TGocciaFetchManagerImpl.Destroy;
@@ -521,7 +548,7 @@ begin
 
     Worker := TGocciaFetchWorker.Create(FState, FLimiter,
       Pending.RequestID, AURL, AMethod, AHeaders, AAllowedHosts,
-      RequestTimeoutMilliseconds);
+      RequestTimeoutMilliseconds, FPolicy);
     LimitAcquired := False;
 
     if (TGarbageCollector.Instance <> nil) then
@@ -767,6 +794,17 @@ begin
   DrainMicrotasksAndFetchCompletions;
 end;
 
+function TGocciaFetchManagerImpl.GetRequestPolicy: THTTPRequestPolicy;
+begin
+  Result := FPolicy;
+end;
+
+procedure TGocciaFetchManagerImpl.SetRequestPolicy(
+  const APolicy: THTTPRequestPolicy);
+begin
+  FPolicy := APolicy;
+end;
+
 procedure TGocciaFetchManagerImpl.DiscardPending;
 var
   I: Integer;
@@ -875,6 +913,21 @@ begin
   Manager := TGocciaFetchManager.Instance;
   if Assigned(Manager) then
     Manager.DiscardPending;
+end;
+
+procedure SetFetchRequestPolicy(const APolicy: THTTPRequestPolicy);
+var
+  Manager: TGocciaFetchManager;
+begin
+  { Initialize first: a host that configures policy before any script runs
+    would otherwise set it on a nil manager and silently get the default when
+    the manager is lazily created on the first fetch. On the LAKON lane
+    Initialize leaves Instance nil because there is no socket backend, and
+    there is nothing to configure — hence the guard rather than an assert. }
+  TGocciaFetchManager.Initialize;
+  Manager := TGocciaFetchManager.Instance;
+  if Assigned(Manager) then
+    Manager.RequestPolicy := APolicy;
 end;
 
 end.


### PR DESCRIPTION
## Summary

Closes the DNS-rebinding window in `fetch`, adds an opt-in private-range policy, and makes the response cap configurable. **WP-2** of the sandbox-hardening series. Stacked on #1130.

The allowlist was validated by **hostname string match**, and the connect that followed **re-resolved that hostname independently**. An allowlisted name under attacker DNS control could answer the check with a public address and the connect with an internal one — `169.254.169.254` being the usual target. The window reopened on every redirect hop.

- **Resolve once, validate, pin.** `DoRequest` now resolves the host a single time, validates the resolved address, and connects to that literal. Both platform connect paths already take a numeric fast path, so pinning adds no lookup and leaves no gap between check and use. Resolution, validation, and pinning are re-applied **per redirect hop**.
- **TLS still verifies against the hostname**, never the pinned literal. Pinning decides which address is dialed, not which identity the peer must prove; handing the literal to `StartTransportSecurity` would silently downgrade the connection's guarantees.
- **`--fetch-deny-private-ranges`** rejects targets resolving into RFC1918, loopback, link-local, CGNAT, or IPv6 ULA space, after resolution and on every hop. Opt-in — existing hosts see no change.
- **`--fetch-max-response-bytes`** makes the body ceiling configurable.

### Correction to the work package

The WP stated there is "no enforced response-body size cap visible in the request path." **There already was one** — an 8 MiB constant enforced across all three body paths (chunked, content-length, read-to-close), plus a 64 KiB header cap. It was *hard-coded*, not absent. This PR makes it configurable and keeps 8 MiB as the default, so behavior is unchanged unless a host opts in. The DNS-pinning and private-range halves of the WP stood exactly as written.

### Implementation constraints

Address classification is deliberately **deny-biased**: anything not exactly four decimal octets or a recognizable IPv6 form is treated as private rather than reinterpreted, because shortened and hex forms (`127.1`, `0x7f.0.0.1`) are a standard way to smuggle loopback past a textual filter.

Rejections raise `EHTTPError`, which the fetch manager already maps to a `TypeError` in script space, so all three surfaces match the existing "host not allowed" behavior in both execution modes.

`THTTPRequestPolicy` lives in `HTTPTypes`, not `HTTPClient`: the fetch manager's abstract base carries it in its interface and must not pull the socket implementation into its unit closure on the LAKON lane.

### Incidental fix

`scripts/fetch-e2e.sh` was **already failing on `main`** (1 passed / 10 failed) — every invocation lacked `--allowed-host`, so the run died before reaching any assertion. Fixed here because the new policy tests cannot run otherwise.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [x] Updated documentation
- [x] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests

`./build/GocciaTestRunner tests` **12143/12143** · `--mode=bytecode` **12143/12143** · `./format.pas --check` clean · `HTTPClient.Test` **10/10** (5 new: range classification, boundary cases, obfuscated-loopback rejection, literal round-trip, default-policy preservation) · `scripts/fetch-e2e.sh` **17/17** against a live server, including loopback-reachable-without-flag, loopback-refused-with-flag, redirect-hop-checked, and both cap directions.

Docs: `docs/built-ins-fetch.md` — options table plus a candid threat-model section (rebinding addressed; SSRF *reduced, not eliminated* — a public address proxying to an internal one is still out of reach).
