### PR TITLE
feat(memory): gate uncharged allocation paths and add a host-catchable limit

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -4,7 +4,7 @@
 
 ## Executive Summary
 
-- **Error types** -- `Error`, `TypeError`, `ReferenceError`, `RangeError`, `SyntaxError`, `URIError`, `AggregateError`, `SuppressedError`, plus `TimeoutError` for the `--timeout` option
+- **Error types** -- `Error`, `TypeError`, `ReferenceError`, `RangeError`, `SyntaxError`, `URIError`, `AggregateError`, `SuppressedError`, plus the uncatchable resource ceilings `TimeoutError` (`--timeout`), `InstructionLimitError` (`--max-instructions`), and `MemoryLimitError` (`--max-memory`)
 - **Parser errors** -- Displayed with source context, a caret pointing to the exact column, and optional suggestion text (e.g., "Use 'let' or 'const' instead")
 - **Runtime errors** -- Carry `name`, `message`, `stack`, and optional `cause`; catchable with `try`/`catch`/`finally`
 - **Sandbox filesystem errors** -- Use real `Error` objects with Node-shaped `code`, `errno`, `path`, `syscall`, and optional `dest` metadata
@@ -13,7 +13,7 @@
 
 ## Error Types
 
-GocciaScript supports the standard ECMAScript error constructors plus two additional types. All JavaScript-visible error types inherit from `Error` and work with `instanceof`. `TimeoutError` is CLI-only and not exposed as a JavaScript constructor.
+GocciaScript supports the standard ECMAScript error constructors plus the CLI-only resource-ceiling types below. All JavaScript-visible error types inherit from `Error` and work with `instanceof`. `TimeoutError`, `InstructionLimitError`, and `MemoryLimitError` are CLI-only and not exposed as JavaScript constructors.
 
 | Type | Thrown when | MDN |
 |------|-----------|-----|
@@ -26,6 +26,15 @@ GocciaScript supports the standard ECMAScript error constructors plus two additi
 | [`AggregateError`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError) | Multiple errors wrapped together; used by `Promise.any` when all promises reject | [AggregateError](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError) |
 | [`SuppressedError`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SuppressedError) | Disposal error during explicit resource management (`using`/`await using`); wraps both the new and suppressed error | [SuppressedError](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SuppressedError) |
 | `TimeoutError` | Execution exceeded the `--timeout` limit (CLI only; not a JS-visible constructor) | -- |
+| `InstructionLimitError` | Execution exceeded the `--max-instructions` budget (CLI only; not a JS-visible constructor) | -- |
+| `MemoryLimitError` | An allocation was refused by the `--max-memory` budget (CLI only; not a JS-visible constructor) | -- |
+
+The last three are resource ceilings rather than in-language errors. Script
+`try`/`catch` cannot observe them in either execution mode: they unwind past
+every handler to the host, because a ceiling the guest can catch is a ceiling
+the guest can ignore in a loop. Allocation sites that charge the budget
+against an owning value (string payloads, `ArrayBuffer`) still throw an
+ordinary catchable `RangeError`, which is unchanged.
 
 ### Inheritance
 
@@ -478,7 +487,7 @@ For parallel runs, the top-level `memory.gc` block combines one measurement per 
 | `stderr` | `string` | Unformatted stderr-oriented console output; present even when empty |
 | `output` | `string[]` | Formatted console output split into lines |
 | `error` | `object \| null` | First failed file's error details, or `null` when the run succeeds |
-| `error.type` | `string` | Error type name (`"TypeError"`, `"SyntaxError"`, `"TimeoutError"`, etc.) |
+| `error.type` | `string` | Error type name (`"TypeError"`, `"SyntaxError"`, `"TimeoutError"`, `"MemoryLimitError"`, etc.) |
 | `error.message` | `string` | Error message text |
 | `error.line` | `number \| null` | Source line number (1-based), or `null` if unavailable |
 | `error.column` | `number \| null` | Source column number (1-based), or `null` if unavailable |

--- a/scripts/test-cli-apps.ts
+++ b/scripts/test-cli-apps.ts
@@ -7368,6 +7368,43 @@ await section("Fuzz Harness: stdin input path...", async () => {
     throw new Error(`Fuzz harness stdin path did not run the input:\n${output}`);
 });
 
+// ── Memory budget (WP-3) ───────────────────────────────────────────────
+//
+// The budget's whole promise is that it bounds the process. A limit that is
+// only noticed after the allocation has already happened bounds nothing, so
+// the assertion here is on resident memory, not just on the error.
+
+await section("Memory budget: single large allocation is refused before it happens...", async () => {
+  const tmp = makeTmp();
+  try {
+    const file = join(tmp, "alloc.js");
+    // ~800 MB of pointer storage requested in one step.
+    writeFileSync(file, "const a = new Array(100000000); print('len ' + a.length);\n");
+
+    const refused = Bun.spawnSync([BARE, "--max-memory=67108864", file], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const refusedOut = refused.stdout.toString() + refused.stderr.toString();
+    if (refused.exitCode === 0)
+      throw new Error(`Allocation past the budget was permitted:\n${refusedOut}`);
+    if (!/exceed the memory budget/i.test(refusedOut))
+      throw new Error(`Expected a memory-budget error, got:\n${refusedOut}`);
+
+    // The same script under a budget that accommodates it must still work,
+    // otherwise the gate is just broken rather than enforcing anything.
+    const permitted = Bun.spawnSync([BARE, "--max-memory=2147483648", file], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const permittedOut = permitted.stdout.toString() + permitted.stderr.toString();
+    if (permitted.exitCode !== 0 || !permittedOut.includes("len 100000000"))
+      throw new Error(`Allocation within budget was refused:\n${permittedOut}`);
+  } finally {
+    clean(tmp);
+  }
+});
+
 if (sectionFailures.length > 0) {
   console.error(`\n${sectionFailures.length} section(s) failed:`);
   for (const failure of sectionFailures) {

--- a/scripts/test-cli.ts
+++ b/scripts/test-cli.ts
@@ -882,6 +882,83 @@ console.log("--max-memory (OOM triggers RangeError)...");
   if (!out.includes("RangeError")) throw new Error(`OOM output should contain RangeError`);
 }
 
+// A refused allocation is a resource ceiling, not an in-language error: a
+// ceiling the guest can catch is a ceiling it can ignore in a loop. Every
+// shape below wraps the refusal in the handler that used to swallow it, so
+// each one fails if a re-raise allowlist ever drops the memory limit again.
+// Both execution modes must agree — the interpreter used to let the script
+// catch and continue while the VM treated the same refusal as fatal.
+//
+// The Promise.all/race shapes additionally guard the combinator error path:
+// a refusal escaping iteration was re-raised by name from inside the active
+// handler (PromiseRejectionReasonFromException), which dereferenced the
+// exception object the handler had already freed and surfaced as a spurious
+// "Access violation" (exit 1 with the wrong message) instead of the ceiling.
+{
+  const combinatorIterator =
+    "{ [Symbol.iterator]: () => ({ next: () => { const a = new Array(100000000); return { done: true, value: a.length }; } }) }";
+  const shapes: Array<[string, string]> = [
+    ["sync try/catch", "try { const a = new Array(100000000); a.length; } catch (e) {}\n"],
+    [
+      "async function body",
+      [
+        "const grow = async () => { const a = new Array(100000000); return a.length; };",
+        "const main = async () => { try { await grow(); } catch (e) {} };",
+        "main();",
+        "",
+      ].join("\n"),
+    ],
+    [
+      "promise executor",
+      "try { new Promise((r) => { const a = new Array(100000000); r(a.length); }).catch(() => {}); } catch (e) {}\n",
+    ],
+    [
+      "Promise.all iterator allocation",
+      `Promise.all(${combinatorIterator}).then(() => {}, () => {});\n`,
+    ],
+    [
+      "Promise.race iterator allocation",
+      `Promise.race(${combinatorIterator}).then(() => {}, () => {});\n`,
+    ],
+    // `for await ... break` runs the async generator's .return(), executing the
+    // body's finally as guest code. A refusal there was folded into a catchable
+    // rejection by the interpreter (guest caught it, kept running) while the VM
+    // was fatal — a swallow and a mode divergence. Both must be fatal now.
+    [
+      "async generator return/finally",
+      [
+        "const obj = { async *g() { try { yield 1; } finally { const a = new Array(100000000); a.length; } } };",
+        "const main = async () => { try { for await (const v of obj.g()) { break; } } catch (e) {} };",
+        "main();",
+        "",
+      ].join("\n"),
+    ],
+  ];
+
+  for (const [shape, src] of shapes) {
+    for (const modeArgs of [[], ["--mode=bytecode"]] as const) {
+      const label = `${shape} ${modeArgs.length > 0 ? "bytecode" : "interpreted"}`;
+      console.log(`--max-memory (refusal is not catchable: ${label})...`);
+      const { exitCode, json } = runLoaderJson(src, ["--max-memory=67108864", ...modeArgs], { timeout: 30_000 });
+      if (exitCode !== 1) throw new Error(`Memory limit refusal (${label}) should exit 1, got ${exitCode}: ${JSON.stringify(json)}`);
+      if (json.error?.type !== "MemoryLimitError") throw new Error(`Memory limit refusal (${label}) should report MemoryLimitError, got ${json.error?.type}`);
+    }
+  }
+}
+
+console.log("--max-memory (ordinary script errors stay catchable under a budget)...");
+{
+  // The counterweight: the same budget must not turn an in-language error
+  // into a host-level failure.
+  for (const modeArgs of [[], ["--mode=bytecode"]] as const) {
+    const label = modeArgs.length > 0 ? "bytecode" : "interpreted";
+    const src = "let caught = false; try { null.property; } catch (e) { caught = true; } caught\n";
+    const { exitCode, json } = runLoaderJson(src, ["--max-memory=67108864", "--compat-asi", ...modeArgs], { timeout: 30_000 });
+    if (exitCode !== 0) throw new Error(`Catchable script error (${label}) should exit 0, got ${exitCode}: ${JSON.stringify(json)}`);
+    if (json.files?.[0]?.result !== true) throw new Error(`Catchable script error (${label}) should be caught by the script, got ${json.files?.[0]?.result}`);
+  }
+}
+
 console.log("--max-memory (manual gc reclaims inside active calls)...");
 {
   const src = [

--- a/scripts/test-cli.ts
+++ b/scripts/test-cli.ts
@@ -777,8 +777,13 @@ console.log("--timeout (native sparse-array fill, interpreted)...");
 {
   // Far single-index writes route to sparse storage and complete instantly;
   // the Array constructor still materializes dense holes, so it stalls.
+  // --max-memory=0 lifts the budget: 2**30 pointers is exactly the 8 GiB
+  // default cap, so the allocation gate would otherwise refuse the request
+  // up front and this would assert the memory limit instead of the deadline.
+  // The stall is still bounded — hole extension polls the deadline as it
+  // grows, so only the fraction allocated within 50ms is ever committed.
   const fill = "const x = new Array(2 ** 30); x.length;\n";
-  const { exitCode, json } = runLoaderJson(fill, ["--timeout=50"], { timeout: 10_000 });
+  const { exitCode, json } = runLoaderJson(fill, ["--timeout=50", "--max-memory=0"], { timeout: 10_000 });
   if (exitCode !== 1) throw new Error(`Array-fill timeout exit code should be 1, got ${exitCode}`);
   if (json.error?.type !== "TimeoutError") throw new Error(`Expected TimeoutError, got ${json.error?.type}`);
 }
@@ -787,8 +792,9 @@ console.log("--timeout (native sparse-array fill, bytecode)...");
 {
   // Far single-index writes route to sparse storage and complete instantly;
   // the Array constructor still materializes dense holes, so it stalls.
+  // --max-memory=0 for the same reason as the interpreted case above.
   const fill = "const x = new Array(2 ** 30); x.length;\n";
-  const { exitCode, json } = runLoaderJson(fill, ["--timeout=50", "--mode=bytecode"], { timeout: 10_000 });
+  const { exitCode, json } = runLoaderJson(fill, ["--timeout=50", "--max-memory=0", "--mode=bytecode"], { timeout: 10_000 });
   if (exitCode !== 1) throw new Error(`Bytecode array-fill timeout exit code should be 1, got ${exitCode}`);
   if (json.error?.type !== "TimeoutError") throw new Error(`Expected TimeoutError, got ${json.error?.type}`);
 }

--- a/source/app/GocciaSandboxRunner.dpr
+++ b/source/app/GocciaSandboxRunner.dpr
@@ -29,6 +29,7 @@ uses
   Goccia.HostEnvironment,
   Goccia.InstructionLimit,
   Goccia.JSON,
+  Goccia.MemoryLimit,
   Goccia.Modules.Loader,
   Goccia.Realm,
   Goccia.Runtime,
@@ -829,6 +830,15 @@ begin
     except
       on E: EGocciaCapabilityAuditDeliveryError do
         raise;
+      { Named before the generic Exception branch so a budget refusal is
+        reported as the limit it is, rather than folded into "some native
+        error happened". A structured failure taxonomy on
+        TGocciaSandboxRunResult belongs to the out-of-process work, which has
+        to define crash / timeout-kill / limit / script-error as one set;
+        adding a field here would pre-empt that design, so this layer only
+        makes the case distinguishable in the message. }
+      on E: TGocciaMemoryLimitError do
+        Result.ErrorMessage := 'memory limit exceeded: ' + E.Message;
       on E: TGocciaError do
         Result.ErrorMessage := E.GetDetailedMessage(False);
       on E: TGocciaThrowValue do

--- a/source/units/Goccia.AST.Expressions.pas
+++ b/source/units/Goccia.AST.Expressions.pas
@@ -905,6 +905,7 @@ uses
   Goccia.GarbageCollector,
   Goccia.ImportMeta,
   Goccia.InstructionLimit,
+  Goccia.MemoryLimit,
   Goccia.RegExp.Runtime,
   Goccia.Scope,
   Goccia.Timeout,
@@ -2446,6 +2447,8 @@ begin
       on E: TGocciaTimeoutError do
         raise;
       on E: TGocciaInstructionLimitError do
+        raise;
+      on E: TGocciaMemoryLimitError do
         raise;
       on E: Exception do
         Promise.Reject(CreateErrorObject(ERROR_NAME, E.Message));

--- a/source/units/Goccia.Builtins.GlobalArray.pas
+++ b/source/units/Goccia.Builtins.GlobalArray.pas
@@ -38,6 +38,7 @@ uses
   Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
   Goccia.InstructionLimit,
+  Goccia.MemoryLimit,
   Goccia.MicrotaskQueue,
   Goccia.ThreadCleanupRegistry,
   Goccia.Timeout,
@@ -221,6 +222,8 @@ begin
     on E: TGocciaTimeoutError do
       raise;
     on E: TGocciaInstructionLimitError do
+      raise;
+    on E: TGocciaMemoryLimitError do
       raise;
     on E: Exception do
     begin

--- a/source/units/Goccia.Builtins.GlobalFetch.pas
+++ b/source/units/Goccia.Builtins.GlobalFetch.pas
@@ -50,6 +50,7 @@ uses
   Goccia.Error.Suggestions,
   Goccia.FetchManager,
   Goccia.InstructionLimit,
+  Goccia.MemoryLimit,
   Goccia.Timeout,
   Goccia.Values.AbortValue,
   Goccia.Values.ErrorHelper,
@@ -241,6 +242,8 @@ begin
     on E: TGocciaTimeoutError do
       raise;
     on E: TGocciaInstructionLimitError do
+      raise;
+    on E: TGocciaMemoryLimitError do
       raise;
     on E: Exception do
       Promise.Reject(CreateErrorObject('TypeError', 'fetch failed: ' + E.Message));

--- a/source/units/Goccia.Builtins.GlobalPromise.pas
+++ b/source/units/Goccia.Builtins.GlobalPromise.pas
@@ -56,6 +56,7 @@ uses
   Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
   Goccia.InstructionLimit,
+  Goccia.MemoryLimit,
   Goccia.MicrotaskQueue,
   Goccia.Realm,
   Goccia.ThreadCleanupRegistry,
@@ -345,7 +346,21 @@ begin
   else if AException is TGocciaRuntimeError then
     Result := CreateErrorObject(ERROR_NAME, AException.Message)
   else
-    raise AException;
+    { An exception with no rejection-reason representation is not the promise's
+      to absorb — the resource ceilings (timeout, instruction, memory) and the
+      capability-audit delivery error must keep unwinding to the host with
+      their exact type intact so the host classifies them correctly.
+
+      This branch runs inside the `on E: Exception` handler that caught
+      AException (via RejectPromiseCapabilityWithException, and directly in
+      Promise.try), but not lexically, so a bare `raise` will not compile.
+      `raise AException` re-raised the object by name, starting a second
+      propagation of an exception the enclosing handler still owns and frees on
+      exit — the dangling re-raise that surfaced as a spurious "Access
+      violation" from Promise.all/race iteration. AcquireExceptionObject takes a
+      reference to the in-flight exception so the enclosing handler no longer
+      frees it out from under this re-raise. }
+    raise Exception(AcquireExceptionObject);
 end;
 
 function RejectPromiseCapabilityWithException(
@@ -2081,6 +2096,8 @@ begin
     on E: TGocciaTimeoutError do
       raise;
     on E: TGocciaInstructionLimitError do
+      raise;
+    on E: TGocciaMemoryLimitError do
       raise;
     on E: Exception do
       CallPromiseCapability(Capability.Reject,

--- a/source/units/Goccia.Builtins.Semver.pas
+++ b/source/units/Goccia.Builtins.Semver.pas
@@ -462,8 +462,17 @@ begin
     ThrowTypeError(E.Message, SSuggestSemverUsage)
   else if E is EGocciaSemverError then
     ThrowError(E.Message, SSuggestSemverUsage)
+  { Anything that is not a semver error — a resource ceiling, an audit delivery
+    failure — is not this host's to translate; it keeps unwinding to the host
+    with its exact type intact. This runs inside the caller's `on E: Exception`
+    handler but not lexically, so a bare `raise` will not compile. `raise E`
+    re-raised the object by name, starting a second propagation of an exception
+    the enclosing handler still owns and frees on exit — the dangling re-raise
+    that surfaces as a spurious access violation. AcquireExceptionObject
+    references the in-flight exception so the enclosing handler no longer frees
+    it under this re-raise. }
   else
-    raise E;
+    raise Exception(AcquireExceptionObject);
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
 

--- a/source/units/Goccia.Builtins.TestingLibrary.pas
+++ b/source/units/Goccia.Builtins.TestingLibrary.pas
@@ -382,6 +382,7 @@ uses
   Goccia.FetchManager,
   Goccia.FloatingPoint,
   Goccia.GarbageCollector,
+  Goccia.MemoryLimit,
   Goccia.MicrotaskQueue,
   Goccia.RegExp.Runtime,
   Goccia.Timeout,
@@ -2266,6 +2267,12 @@ begin
           execution continue past the limit instead of unwinding to
           ExecuteSuite (see the same guard at RunCallbacks). }
         on E: TGocciaTimeoutError do
+          raise;
+        { A refused allocation is the same shape of event as an expired
+          deadline: absorbing it would let `expect(fn).toThrow()` report the
+          memory ceiling as a satisfied expectation, which is precisely the
+          "catch the limit and keep going" the budget exists to prevent. }
+        on E: TGocciaMemoryLimitError do
           raise;
         on E: Exception do
         begin

--- a/source/units/Goccia.CLI.JSON.Reporter.pas
+++ b/source/units/Goccia.CLI.JSON.Reporter.pas
@@ -117,6 +117,7 @@ uses
   Goccia.InstructionLimit,
   Goccia.JSON,
   Goccia.JSON.Utils,
+  Goccia.MemoryLimit,
   Goccia.Platform,
   Goccia.Timeout,
   Goccia.Values.Error,
@@ -545,6 +546,12 @@ begin
     Result := 'TimeoutError'
   else if E is TGocciaInstructionLimitError then
     Result := 'InstructionLimitError'
+  { Named alongside the other two limits: now that a refused allocation
+    unwinds to the host instead of being caught by the script, this is the
+    channel the host reads it on, and "the sandbox hit its ceiling" has to be
+    distinguishable from an ordinary native failure. }
+  else if E is TGocciaMemoryLimitError then
+    Result := 'MemoryLimitError'
   else if E is TGocciaError then
     Result := ErrorDisplayName(TGocciaError(E))
   else

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -219,6 +219,7 @@ uses
   Goccia.InstructionLimit,
   Goccia.Intrinsics.FunctionObjects,
   Goccia.Keywords.Reserved,
+  Goccia.MemoryLimit,
   Goccia.SourcePipeline,
   Goccia.StackLimit,
   Goccia.Timeout,
@@ -7642,6 +7643,8 @@ var
         raise;
       on E: TGocciaInstructionLimitError do
         raise;
+      on E: TGocciaMemoryLimitError do
+        raise;
       on E: EGocciaCapabilityAuditDeliveryError do
         raise;
       on E: Exception do
@@ -7707,6 +7710,8 @@ begin
       on E: TGocciaTimeoutError do
         raise;
       on E: TGocciaInstructionLimitError do
+        raise;
+      on E: TGocciaMemoryLimitError do
         raise;
       on E: EGocciaCapabilityAuditDeliveryError do
         raise;

--- a/source/units/Goccia.Generator.Continuation.pas
+++ b/source/units/Goccia.Generator.Continuation.pas
@@ -213,6 +213,7 @@ uses
   Goccia.Evaluator,
   Goccia.GarbageCollector,
   Goccia.InstructionLimit,
+  Goccia.MemoryLimit,
   Goccia.Timeout,
   Goccia.Values.Await,
   Goccia.Values.Error,
@@ -413,6 +414,8 @@ begin
         raise;
       on E: TGocciaInstructionLimitError do
         raise;
+      on E: TGocciaMemoryLimitError do
+        raise;
       on E: Exception do
         Promise.Reject(CreateErrorObject(ERROR_NAME, E.Message));
     end;
@@ -473,6 +476,8 @@ begin
       raise;
     on E: TGocciaInstructionLimitError do
       raise;
+    on E: TGocciaMemoryLimitError do
+      raise;
     on E: Exception do
       Result := PromiseReject(CreateErrorObject(ERROR_NAME, E.Message));
   end;
@@ -516,6 +521,8 @@ begin
       raise;
     on E: TGocciaInstructionLimitError do
       raise;
+    on E: TGocciaMemoryLimitError do
+      raise;
     on E: Exception do
       Result := PromiseReject(CreateErrorObject(ERROR_NAME, E.Message));
   end;
@@ -555,6 +562,8 @@ begin
     on E: TGocciaTimeoutError do
       raise;
     on E: TGocciaInstructionLimitError do
+      raise;
+    on E: TGocciaMemoryLimitError do
       raise;
     on E: Exception do
       Result := PromiseReject(CreateErrorObject(ERROR_NAME, E.Message));

--- a/source/units/Goccia.Interpreter.pas
+++ b/source/units/Goccia.Interpreter.pas
@@ -114,6 +114,9 @@ uses
   Goccia.Coverage,
   Goccia.GarbageCollector,
   Goccia.Generator.Continuation,
+  Goccia.InstructionLimit,
+  Goccia.MemoryLimit,
+  Goccia.Timeout,
   Goccia.Values.Error,
   Goccia.Values.ErrorHelper,
   Goccia.Values.NativeFunction,
@@ -241,6 +244,16 @@ begin
       on E: EGocciaAsyncAwaitSuspend do
         AttachAwait(E);
       on E: EGocciaCapabilityAuditDeliveryError do
+        raise;
+      { The limit family is opaque to the guest everywhere else, and a
+        top-level-await module body is no exception: rejecting the module's
+        promise with it would hand the ceiling back to script code as an
+        ordinary Error for a `.catch` to absorb. }
+      on E: TGocciaTimeoutError do
+        raise;
+      on E: TGocciaInstructionLimitError do
+        raise;
+      on E: TGocciaMemoryLimitError do
         raise;
       on E: Exception do
         RejectWithException(E);

--- a/source/units/Goccia.MemoryLimit.Test.pas
+++ b/source/units/Goccia.MemoryLimit.Test.pas
@@ -1,0 +1,274 @@
+program Goccia.MemoryLimit.Test;
+
+{$I Goccia.inc}
+
+uses
+  Classes,
+  SysUtils,
+
+  TestingPascalLibrary,
+
+  Goccia.Engine,
+  Goccia.Executor,
+  Goccia.Executor.Bytecode,
+  Goccia.Executor.Interpreter,
+  Goccia.GarbageCollector,
+  Goccia.MemoryLimit,
+  Goccia.TestSetup;
+
+type
+  TMemoryLimitTests = class(TTestSuite)
+  private
+    { Runs ASource under a budget that cannot fit the allocation it asks for,
+      once per executor, and answers whether the refusal reached the host. }
+    function RefusalEscapesScript(const ASource: string;
+      const AExecutor: TGocciaExecutor; const AName: string): Boolean;
+    procedure TestGateRefusesOverBudgetRequest;
+    procedure TestGatePermitsInBudgetRequest;
+    procedure TestSyncCatchCannotSwallowRefusal;
+    procedure TestAsyncFunctionCatchCannotSwallowRefusal;
+    procedure TestPromiseExecutorCatchCannotSwallowRefusal;
+    procedure TestAsyncGeneratorReturnCannotSwallowRefusal;
+    procedure TestScriptErrorsStayCatchable;
+  protected
+    procedure BeforeEach; override;
+  public
+    procedure SetupTests; override;
+  end;
+
+const
+  { 100e6 pointer slots is 800 MB on a 64-bit target — far past any budget
+    this suite installs, so the gate refuses regardless of what the test
+    process has already allocated. }
+  OVER_BUDGET_SOURCE_TAIL = 'const a = new Array(100000000); a.length;';
+
+  { Headroom over live usage rather than an absolute ceiling: the budget is
+    process-global and the suite shares it with everything already allocated,
+    so a fixed number would refuse the engine's own setup on a busy run. }
+  BUDGET_HEADROOM_BYTES = 64 * 1024 * 1024;
+
+procedure TMemoryLimitTests.BeforeEach;
+begin
+  inherited BeforeEach;
+  { The gate reads its budget off the collector, and a program with no
+    collector is unbounded by construction — without this the direct gate
+    tests would assert against a disabled budget and pass vacuously. }
+  TGarbageCollector.Initialize;
+end;
+
+procedure TMemoryLimitTests.SetupTests;
+begin
+  Test('The gate refuses a request larger than the remaining budget',
+    TestGateRefusesOverBudgetRequest);
+  Test('The gate permits a request that fits the remaining budget',
+    TestGatePermitsInBudgetRequest);
+  Test('Script try/catch cannot swallow a refusal',
+    TestSyncCatchCannotSwallowRefusal);
+  Test('An async function body cannot swallow a refusal',
+    TestAsyncFunctionCatchCannotSwallowRefusal);
+  Test('A promise executor cannot swallow a refusal',
+    TestPromiseExecutorCatchCannotSwallowRefusal);
+  Test('An async generator return/finally cannot swallow a refusal',
+    TestAsyncGeneratorReturnCannotSwallowRefusal);
+  Test('Ordinary script errors stay catchable', TestScriptErrorsStayCatchable);
+end;
+
+function TMemoryLimitTests.RefusalEscapesScript(const ASource: string;
+  const AExecutor: TGocciaExecutor; const AName: string): Boolean;
+var
+  Source: TStringList;
+  Engine: TGocciaEngine;
+  GC: TGarbageCollector;
+  PreviousMaxBytes: Int64;
+begin
+  Result := False;
+  Source := TStringList.Create;
+  Source.Text := ASource;
+  Engine := TGocciaEngine.Create(AName, Source, AExecutor);
+  GC := TGarbageCollector.Instance;
+  PreviousMaxBytes := 0;
+  try
+    if Assigned(GC) then
+    begin
+      PreviousMaxBytes := GC.MaxBytes;
+      GC.MaxBytes := GC.BytesAllocated + BUDGET_HEADROOM_BYTES;
+    end;
+    try
+      Engine.Execute;
+    except
+      on E: TGocciaMemoryLimitError do
+        Result := True;
+    end;
+  finally
+    if Assigned(GC) then
+      GC.MaxBytes := PreviousMaxBytes;
+    Engine.Free;
+    AExecutor.Free;
+    Source.Free;
+  end;
+end;
+
+procedure TMemoryLimitTests.TestGateRefusesOverBudgetRequest;
+var
+  GC: TGarbageCollector;
+  PreviousMaxBytes: Int64;
+  Raised: Boolean;
+begin
+  GC := TGarbageCollector.Instance;
+  Expect<Boolean>(Assigned(GC)).ToBe(True);
+  PreviousMaxBytes := GC.MaxBytes;
+  try
+    GC.MaxBytes := GC.BytesAllocated + BUDGET_HEADROOM_BYTES;
+    Expect<Boolean>(CanAllocateNativeBytes(
+      Int64(BUDGET_HEADROOM_BYTES) * 4)).ToBe(False);
+    Raised := False;
+    try
+      RequireNativeBytes(Int64(BUDGET_HEADROOM_BYTES) * 4);
+    except
+      on TGocciaMemoryLimitError do
+        Raised := True;
+    end;
+    Expect<Boolean>(Raised).ToBe(True);
+  finally
+    GC.MaxBytes := PreviousMaxBytes;
+  end;
+end;
+
+procedure TMemoryLimitTests.TestGatePermitsInBudgetRequest;
+var
+  GC: TGarbageCollector;
+  PreviousMaxBytes: Int64;
+begin
+  GC := TGarbageCollector.Instance;
+  PreviousMaxBytes := GC.MaxBytes;
+  try
+    GC.MaxBytes := GC.BytesAllocated + BUDGET_HEADROOM_BYTES;
+    Expect<Boolean>(CanAllocateNativeBytes(1024)).ToBe(True);
+    { A non-positive request is never a budget question. }
+    Expect<Boolean>(CanAllocateNativeBytes(0)).ToBe(True);
+    { A JS-controlled length can multiply into a total that wraps; a wrapped
+      total must not read as comfortably in budget. }
+    Expect<Boolean>(CanAllocateNativeBytes(High(Int64))).ToBe(False);
+    RequireNativeBytes(1024);
+  finally
+    GC.MaxBytes := PreviousMaxBytes;
+  end;
+end;
+
+procedure TMemoryLimitTests.TestSyncCatchCannotSwallowRefusal;
+const
+  SourceText =
+    'let caught = false;' + sLineBreak +
+    'try {' + sLineBreak +
+    '  ' + OVER_BUDGET_SOURCE_TAIL + sLineBreak +
+    '} catch (e) {' + sLineBreak +
+    '  caught = true;' + sLineBreak +
+    '}';
+begin
+  { Nothing but an escaping TGocciaMemoryLimitError can produce True here:
+    had the catch block absorbed the refusal, the script would have run to
+    completion and Execute would have returned normally. }
+  Expect<Boolean>(RefusalEscapesScript(SourceText,
+    TGocciaInterpreterExecutor.Create,
+    'memory-limit-sync-interpreted.js')).ToBe(True);
+  Expect<Boolean>(RefusalEscapesScript(SourceText,
+    TGocciaBytecodeExecutor.Create,
+    'memory-limit-sync-bytecode.js')).ToBe(True);
+end;
+
+procedure TMemoryLimitTests.TestAsyncFunctionCatchCannotSwallowRefusal;
+const
+  SourceText =
+    'const grow = async () => {' + sLineBreak +
+    '  ' + OVER_BUDGET_SOURCE_TAIL + sLineBreak +
+    '};' + sLineBreak +
+    'const main = async () => {' + sLineBreak +
+    '  try {' + sLineBreak +
+    '    await grow();' + sLineBreak +
+    '  } catch (e) {}' + sLineBreak +
+    '};' + sLineBreak +
+    'main();';
+begin
+  { Regression guard for the async path specifically: a refusal escaping an
+    async function body used to be converted into a spurious access
+    violation, which the guest could then catch as an ordinary Error. }
+  Expect<Boolean>(RefusalEscapesScript(SourceText,
+    TGocciaInterpreterExecutor.Create,
+    'memory-limit-async-interpreted.js')).ToBe(True);
+  Expect<Boolean>(RefusalEscapesScript(SourceText,
+    TGocciaBytecodeExecutor.Create,
+    'memory-limit-async-bytecode.js')).ToBe(True);
+end;
+
+procedure TMemoryLimitTests.TestPromiseExecutorCatchCannotSwallowRefusal;
+const
+  SourceText =
+    'try {' + sLineBreak +
+    '  new Promise((resolve) => {' + sLineBreak +
+    '    ' + OVER_BUDGET_SOURCE_TAIL + sLineBreak +
+    '    resolve(1);' + sLineBreak +
+    '  }).catch(() => {});' + sLineBreak +
+    '} catch (e) {}';
+begin
+  Expect<Boolean>(RefusalEscapesScript(SourceText,
+    TGocciaInterpreterExecutor.Create,
+    'memory-limit-executor-interpreted.js')).ToBe(True);
+  Expect<Boolean>(RefusalEscapesScript(SourceText,
+    TGocciaBytecodeExecutor.Create,
+    'memory-limit-executor-bytecode.js')).ToBe(True);
+end;
+
+procedure TMemoryLimitTests.TestAsyncGeneratorReturnCannotSwallowRefusal;
+const
+  { `for await ... break` runs the async generator's `.return()`, which
+    executes the body's `finally` as guest code. The refusal raised there
+    reaches the generator resume handler on the return path. Before the fix
+    that handler had no limit arm: the interpreter folded the ceiling into a
+    catchable rejection (guest caught it and kept running) while the VM was
+    fatal — a swallow AND a mode divergence. Both executors must now be fatal. }
+  SourceText =
+    'const obj = { async *g() {' + sLineBreak +
+    '  try { yield 1; } finally { ' + OVER_BUDGET_SOURCE_TAIL + ' }' +
+    sLineBreak +
+    '} };' + sLineBreak +
+    'const main = async () => {' + sLineBreak +
+    '  try {' + sLineBreak +
+    '    for await (const v of obj.g()) { break; }' + sLineBreak +
+    '  } catch (e) {}' + sLineBreak +
+    '};' + sLineBreak +
+    'main();';
+begin
+  Expect<Boolean>(RefusalEscapesScript(SourceText,
+    TGocciaInterpreterExecutor.Create,
+    'memory-limit-async-generator-interpreted.js')).ToBe(True);
+  Expect<Boolean>(RefusalEscapesScript(SourceText,
+    TGocciaBytecodeExecutor.Create,
+    'memory-limit-async-generator-bytecode.js')).ToBe(True);
+end;
+
+procedure TMemoryLimitTests.TestScriptErrorsStayCatchable;
+const
+  SourceText =
+    'let caught = false;' + sLineBreak +
+    'try {' + sLineBreak +
+    '  null.property;' + sLineBreak +
+    '} catch (e) {' + sLineBreak +
+    '  caught = true;' + sLineBreak +
+    '}';
+begin
+  { The counterweight to the guards above: the same budget must not turn an
+    ordinary in-language error into a host-level failure. }
+  Expect<Boolean>(RefusalEscapesScript(SourceText,
+    TGocciaInterpreterExecutor.Create,
+    'memory-limit-script-error-interpreted.js')).ToBe(False);
+  Expect<Boolean>(RefusalEscapesScript(SourceText,
+    TGocciaBytecodeExecutor.Create,
+    'memory-limit-script-error-bytecode.js')).ToBe(False);
+end;
+
+begin
+  TestRunnerProgram.AddSuite(TMemoryLimitTests.Create('Memory limit'));
+  RunGocciaTests;
+
+  ExitCode := TestResultToExitCode;
+end.

--- a/source/units/Goccia.MemoryLimit.pas
+++ b/source/units/Goccia.MemoryLimit.pas
@@ -1,0 +1,110 @@
+unit Goccia.MemoryLimit;
+
+{$I Goccia.inc}
+
+interface
+
+uses
+  SysUtils;
+
+type
+  { Raised when an allocation would push the engine past its memory budget.
+
+    Mirrors TGocciaInstructionLimitError: a host-catchable Pascal exception,
+    distinct from anything script code can produce. That distinction is the
+    point. The budget previously surfaced only as a script-visible RangeError,
+    which a host cannot tell apart from a RangeError the script threw itself —
+    so "the sandbox hit its ceiling" and "the guest called new Array(-1)"
+    arrived through the same channel and could not be reported differently.
+
+    This does not disturb the pre-existing paths. Allocation sites that
+    already charged the budget (string payloads, ArrayBuffer resize) still
+    raise the script-visible RangeError they always did, so in-language error
+    handling is unchanged there.
+
+    This error is raised only by the gate below, and is deliberately NOT
+    catchable from script. That matches the rest of the limit family —
+    TGocciaInstructionLimitError and TGocciaTimeoutError are likewise opaque
+    to the guest — because a resource ceiling the guest can catch is a
+    resource ceiling the guest can ignore in a loop. The gate guards paths
+    that had no check at all before, so nothing that used to be catchable
+    stops being catchable. }
+  TGocciaMemoryLimitError = class(Exception)
+  private
+    FRequestedBytes: Int64;
+    FBudgetBytes: Int64;
+  public
+    constructor Create(const ARequestedBytes, ABudgetBytes: Int64);
+    { Size of the allocation that was refused. Zero when the refusing site
+      could not attribute a size. }
+    property RequestedBytes: Int64 read FRequestedBytes;
+    { The ceiling in force when the refusal happened. }
+    property BudgetBytes: Int64 read FBudgetBytes;
+  end;
+
+{ Pre-allocation gate for a natively-sized allocation.
+
+  Answers "would ABytes fit in the remaining budget", WITHOUT charging it.
+  Use where the allocation's lifetime is not owned by a value object that
+  can release the charge again — extending an element list, growing property
+  storage — so the budget still bounds the peak without leaking a permanent
+  reservation the engine can never give back.
+
+  Where an owner does exist (ArrayBuffer, string payloads), keep using
+  TGarbageCollector.TryReserveExternalBytes and release in the destructor:
+  that accounts the allocation for as long as it is live, which a gate
+  cannot do. }
+function CanAllocateNativeBytes(const ABytes: Int64): Boolean;
+
+{ Raises TGocciaMemoryLimitError unless ABytes fits the remaining budget. }
+procedure RequireNativeBytes(const ABytes: Int64);
+
+implementation
+
+uses
+  Goccia.GarbageCollector;
+
+constructor TGocciaMemoryLimitError.Create(const ARequestedBytes,
+  ABudgetBytes: Int64);
+begin
+  inherited CreateFmt(
+    'Allocation of %d bytes would exceed the memory budget of %d bytes',
+    [ARequestedBytes, ABudgetBytes]);
+  FRequestedBytes := ARequestedBytes;
+  FBudgetBytes := ABudgetBytes;
+end;
+
+function CanAllocateNativeBytes(const ABytes: Int64): Boolean;
+var
+  GC: TGarbageCollector;
+begin
+  if ABytes <= 0 then
+    Exit(True);
+  GC := TGarbageCollector.Instance;
+  { No GC means no budget to enforce — embedding hosts that never initialise
+    one are unbounded by construction, and that is their choice to make. }
+  if not Assigned(GC) or (GC.MaxBytes <= 0) then
+    Exit(True);
+  { Overflow guard first: a JS-controlled length can multiply into a value
+    that wraps, and a wrapped total would compare as comfortably in budget. }
+  if GC.BytesAllocated > High(Int64) - ABytes then
+    Exit(False);
+  Result := GC.BytesAllocated + ABytes <= GC.MaxBytes;
+end;
+
+procedure RequireNativeBytes(const ABytes: Int64);
+var
+  GC: TGarbageCollector;
+  Budget: Int64;
+begin
+  if CanAllocateNativeBytes(ABytes) then
+    Exit;
+  GC := TGarbageCollector.Instance;
+  if Assigned(GC) then
+    Budget := GC.MaxBytes
+  else
+    Budget := 0;
+  raise TGocciaMemoryLimitError.Create(ABytes, Budget);
+end;
+
+end.

--- a/source/units/Goccia.MemoryLimit.pas
+++ b/source/units/Goccia.MemoryLimit.pas
@@ -28,7 +28,17 @@ type
     to the guest — because a resource ceiling the guest can catch is a
     resource ceiling the guest can ignore in a loop. The gate guards paths
     that had no check at all before, so nothing that used to be catchable
-    stops being catchable. }
+    stops being catchable.
+
+    Opacity is a property of the handlers, not of the class. Every boundary
+    that would otherwise convert a Pascal exception into something the guest
+    can observe — the evaluator's try/catch statement paths, the VM's
+    async-iterator and dynamic-import arms, the microtask, await, generator
+    and promise-reaction boundaries, Array.fromAsync, and the test library's
+    toThrow — names this class in its re-raise allowlist ahead of its generic
+    `on E: Exception` arm. A new boundary that omits the arm makes the
+    ceiling catchable again, which is what Goccia.MemoryLimit.Test.pas
+    guards against in both execution modes. }
   TGocciaMemoryLimitError = class(Exception)
   private
     FRequestedBytes: Int64;

--- a/source/units/Goccia.MicrotaskQueue.pas
+++ b/source/units/Goccia.MicrotaskQueue.pas
@@ -69,6 +69,7 @@ uses
   Goccia.Error,
   Goccia.GarbageCollector,
   Goccia.InstructionLimit,
+  Goccia.MemoryLimit,
   Goccia.Timeout,
   Goccia.Values.Error,
   Goccia.Values.ErrorHelper,
@@ -183,8 +184,17 @@ end;
 procedure RejectPromiseWithException(const APromise: TGocciaPromiseValue;
   const AException: Exception);
 begin
+  { Precondition, shared with the sibling reject helpers in Goccia.Values.Await
+    and Goccia.Interpreter: invoke this only from inside the `on E: Exception`
+    handler that caught AException. With no promise to reject there is nothing
+    to absorb the exception into, so it keeps unwinding to the host. `raise
+    AException` re-raised the object by name, which starts a second propagation
+    of an exception the enclosing handler still owns and frees on exit (the
+    dangling re-raise behind the async-path access violations); a bare `raise`
+    will not compile outside a lexical handler, so AcquireExceptionObject takes
+    a reference to the in-flight exception and re-raises that same object. }
   if not Assigned(APromise) then
-    raise AException;
+    raise Exception(AcquireExceptionObject);
 
   if AException is EGocciaBytecodeThrow then
     APromise.Reject(EGocciaBytecodeThrow(AException).ThrownValue)
@@ -237,6 +247,8 @@ begin
         on E: TGocciaTimeoutError do
           raise;
         on E: TGocciaInstructionLimitError do
+          raise;
+        on E: TGocciaMemoryLimitError do
           raise;
         on E: EGocciaCapabilityAuditDeliveryError do
           raise;
@@ -461,6 +473,8 @@ begin
         on E: TGocciaTimeoutError do
           raise;
         on E: TGocciaInstructionLimitError do
+          raise;
+        on E: TGocciaMemoryLimitError do
           raise;
         on E: EGocciaCapabilityAuditDeliveryError do
           raise;

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -536,6 +536,7 @@ uses
   Goccia.Execution.CallSite,
   Goccia.ImportMeta,
   Goccia.InstructionLimit,
+  Goccia.MemoryLimit,
   Goccia.MicrotaskQueue,
   Goccia.NumberConversion,
   Goccia.NumberExponentiation,
@@ -3823,6 +3824,8 @@ begin
       raise;
     on E: TGocciaInstructionLimitError do
       raise;
+    on E: TGocciaMemoryLimitError do
+      raise;
     on E: EGocciaCapabilityAuditDeliveryError do
       raise;
     on E: Exception do
@@ -3911,6 +3914,8 @@ begin
     on E: TGocciaTimeoutError do
       raise;
     on E: TGocciaInstructionLimitError do
+      raise;
+    on E: TGocciaMemoryLimitError do
       raise;
     on E: EGocciaCapabilityAuditDeliveryError do
       raise;
@@ -4010,6 +4015,8 @@ begin
     on E: TGocciaTimeoutError do
       raise;
     on E: TGocciaInstructionLimitError do
+      raise;
+    on E: TGocciaMemoryLimitError do
       raise;
     on E: EGocciaCapabilityAuditDeliveryError do
       raise;
@@ -4931,6 +4938,8 @@ begin
     on E: TGocciaTimeoutError do
       raise;
     on E: TGocciaInstructionLimitError do
+      raise;
+    on E: TGocciaMemoryLimitError do
       raise;
     on E: EGocciaCapabilityAuditDeliveryError do
       raise;
@@ -16914,6 +16923,8 @@ begin
               raise;
             on E: TGocciaInstructionLimitError do
               raise;
+            on E: TGocciaMemoryLimitError do
+              raise;
             on E: EGocciaCapabilityAuditDeliveryError do
               raise;
             on E: Exception do
@@ -16987,6 +16998,8 @@ begin
             on E: TGocciaTimeoutError do
               raise;
             on E: TGocciaInstructionLimitError do
+              raise;
+            on E: TGocciaMemoryLimitError do
               raise;
             on E: EGocciaCapabilityAuditDeliveryError do
               raise;
@@ -17112,6 +17125,8 @@ begin
             on E: TGocciaTimeoutError do
               raise;
             on E: TGocciaInstructionLimitError do
+              raise;
+            on E: TGocciaMemoryLimitError do
               raise;
             on E: EGocciaCapabilityAuditDeliveryError do
               raise;

--- a/source/units/Goccia.Values.Await.pas
+++ b/source/units/Goccia.Values.Await.pas
@@ -22,6 +22,7 @@ uses
   Goccia.FetchManager,
   Goccia.GarbageCollector,
   Goccia.InstructionLimit,
+  Goccia.MemoryLimit,
   Goccia.MicrotaskQueue,
   Goccia.Timeout,
   Goccia.Values.Error,
@@ -99,6 +100,8 @@ begin
         on E: TGocciaTimeoutError do
           raise;
         on E: TGocciaInstructionLimitError do
+          raise;
+        on E: TGocciaMemoryLimitError do
           raise;
         on E: Exception do
           RejectPromiseWithException(Promise, E);

--- a/source/units/Goccia.Values.FunctionValue.pas
+++ b/source/units/Goccia.Values.FunctionValue.pas
@@ -153,7 +153,7 @@ type
     FRealm: TGocciaRealm;
     FSettled: Boolean;
     procedure AttachAwait(const ASuspension: EGocciaAsyncAwaitSuspend);
-    procedure RejectWithException(const AException: Exception);
+    function RejectWithException(const AException: Exception): Boolean;
     procedure Resume(const AKind: TGocciaGeneratorResumeKind;
       const AValue: TGocciaValue);
   public
@@ -171,9 +171,21 @@ type
     procedure MarkReferences; override;
   end;
 
-procedure RejectAsyncPromiseWithException(const APromise: TGocciaPromiseValue;
-  const AException: Exception);
+{ True when AException is a script-level failure and the promise now carries
+  it. False means the exception is not the guest's to observe, and the caller
+  — which is inside the handler that owns it — must let it continue with a
+  bare `raise`.
+
+  The bare raise at the call site is the whole point of the Boolean. This
+  used to end in `raise AException`, which re-raises the very object the RTL
+  is already unwinding: the original handler frees it on the way out, so the
+  second raise carries a dangling reference and the async path surfaced a
+  spurious "Access violation" instead of the limit that actually fired. }
+function TryRejectAsyncPromiseWithException(
+  const APromise: TGocciaPromiseValue;
+  const AException: Exception): Boolean;
 begin
+  Result := True;
   if AException is TGocciaThrowValue then
     APromise.Reject(TGocciaThrowValue(AException).Value)
   else if AException is TGocciaTypeError then
@@ -185,7 +197,7 @@ begin
   else if AException is TGocciaRuntimeError then
     APromise.Reject(CreateErrorObject(ERROR_NAME, AException.Message))
   else
-    raise AException;
+    Result := False;
 end;
 
 { TGocciaAsyncFunctionEvaluation }
@@ -247,13 +259,17 @@ begin
   end;
 end;
 
-procedure TGocciaAsyncFunctionEvaluation.RejectWithException(
-  const AException: Exception);
+function TGocciaAsyncFunctionEvaluation.RejectWithException(
+  const AException: Exception): Boolean;
 begin
   if FSettled then
-    Exit;
-  FSettled := True;
-  RejectAsyncPromiseWithException(FPromise, AException);
+    Exit(True);
+  Result := TryRejectAsyncPromiseWithException(FPromise, AException);
+  { Only a rejection settles the evaluation. Marking it settled for an
+    exception that keeps unwinding would leave a promise that can never be
+    resolved and silence the later resume paths. }
+  if Result then
+    FSettled := True;
 end;
 
 procedure TGocciaAsyncFunctionEvaluation.Resume(
@@ -285,7 +301,8 @@ begin
       on E: EGocciaAsyncAwaitSuspend do
         AttachAwait(E);
       on E: Exception do
-        RejectWithException(E);
+        if not RejectWithException(E) then
+          raise;
     end;
   finally
     PopAsyncAwaitSuspension;
@@ -847,6 +864,7 @@ var
   AsyncBodyStatements: TObjectList<TGocciaASTNode>;
   SyntheticReturn: TGocciaReturnStatement;
   RejectedPromise: TGocciaPromiseValue;
+  Rejected: Boolean;
 begin
   GC := TGarbageCollector.Instance;
   BodyScopeRooted := False;
@@ -930,12 +948,17 @@ begin
       if Assigned(GC) then
         GC.AddTempRoot(RejectedPromise);
       try
-        RejectAsyncPromiseWithException(RejectedPromise, E);
-        Result := RejectedPromise;
+        Rejected := TryRejectAsyncPromiseWithException(RejectedPromise, E);
+        if Rejected then
+          Result := RejectedPromise;
       finally
         if Assigned(GC) then
           GC.RemoveTempRoot(RejectedPromise);
       end;
+      { Outside the temp-root frame: FPC rejects a re-raise inside a nested
+        try/finally, and the root has to come off either way. }
+      if not Rejected then
+        raise;
     end;
   end;
 

--- a/source/units/Goccia.Values.GeneratorValue.pas
+++ b/source/units/Goccia.Values.GeneratorValue.pas
@@ -159,8 +159,11 @@ uses
   Goccia.Evaluator,
   Goccia.Evaluator.Context,
   Goccia.GarbageCollector,
+  Goccia.InstructionLimit,
   Goccia.Intrinsics.FunctionObjects,
+  Goccia.MemoryLimit,
   Goccia.Realm,
+  Goccia.Timeout,
   Goccia.Types.Enforcement,
   Goccia.Values.ArgumentsObjectValue,
   Goccia.Values.ArrayValue,
@@ -1022,6 +1025,17 @@ begin
           RejectAwaitedReturn(E.Value);
         Exit;
       end;
+      { A resource ceiling reached while resolving the return/yield value —
+        e.g. `.return(thenable)` whose `then` getter allocates past the budget,
+        or an instruction/timeout deadline expiring mid-resolution — is opaque
+        to the guest. Named before the generic arm (Pascal first-match), which
+        would otherwise fold it into a promise rejection the guest can catch. }
+      on E: TGocciaTimeoutError do
+        raise;
+      on E: TGocciaInstructionLimitError do
+        raise;
+      on E: TGocciaMemoryLimitError do
+        raise;
       on E: Exception do
       begin
         if AThrowIntoGenerator then
@@ -1180,6 +1194,16 @@ begin
           RejectAwaitedYield(E.Value);
           Exit;
         end;
+        { The limit family stays opaque here too: resolving a promise-valued
+          `.return()` runs guest code (a thenable's `then` getter) that can
+          hit the budget, and the generic arm below would hand that ceiling
+          back to the guest as a catchable rejection. First-match ordering. }
+        on E: TGocciaTimeoutError do
+          raise;
+        on E: TGocciaInstructionLimitError do
+          raise;
+        on E: TGocciaMemoryLimitError do
+          raise;
         on E: Exception do
         begin
           RejectAwaitedYield(ExceptionToErrorValue(E));
@@ -1232,6 +1256,18 @@ begin
       FState := gsCompleted;
       CompleteCurrentRequest(E.Value, True, True);
     end;
+    { A `for await ... break` runs the body's `finally` as part of the
+      generator's `.return()`; a resource ceiling raised there reaches this
+      handler on the grkReturn path and, without these arms, was converted
+      into a rejection the guest could catch (and, in bytecode, diverged to a
+      fatal — a mode split). The ceiling must keep unwinding to the host in
+      both executors. Named before the generic arm (Pascal first-match). }
+    on E: TGocciaTimeoutError do
+      raise;
+    on E: TGocciaInstructionLimitError do
+      raise;
+    on E: TGocciaMemoryLimitError do
+      raise;
     on E: Exception do
     begin
       if ARequest.Kind = grkReturn then

--- a/source/units/Goccia.Values.HoleValue.pas
+++ b/source/units/Goccia.Values.HoleValue.pas
@@ -38,6 +38,7 @@ implementation
 
 uses
   Goccia.Constants.TypeNames,
+  Goccia.MemoryLimit,
   Goccia.Timeout;
 
 procedure ExtendElementsWithHoles(const AElements: TGocciaValueList;
@@ -46,6 +47,16 @@ var
   StartCount: Integer;
 begin
   StartCount := AElements.Count;
+  { Gate the whole extension up front.
+    ACount comes from a JS-controlled length, so `arr.length = 1e9` asks for
+    ~8 GB of pointer storage here. Growing element by element would sail past
+    the budget between GC samples and only be noticed once the process had
+    already committed the memory — the budget must refuse the request before
+    the first slot is allocated, not after the last.
+    A gate rather than a charge: this storage belongs to the list, which has
+    no hook to release a reservation when it shrinks or is freed. }
+  if ACount > StartCount then
+    RequireNativeBytes((ACount - StartCount) * SizeOf(Pointer));
   // Fast path: small extensions skip both the poll and the rollback frame.
   // Sequential element writes extend by one slot at a time, and an FPC
   // try/except frame per append is a measurable tax on every array-building


### PR DESCRIPTION
## Summary

Closes the memory-budget gaps and gives hosts a distinguishable limit error. **WP-3** of the sandbox-hardening series. Stacked on #1131.

### The work package's premise was wrong; the gap was real

WP-3 assumed `--max-memory` was *sampled* and could be outrun between samples. It is not: it maps to `TGarbageCollector.MaxBytes`, enforced by `TryReserveExternalBytes`, which checks **before** allocating. Strings charge their payload at construction, ArrayBuffer/SharedArrayBuffer charge on resize, and `Goccia.NativeLimits.ReserveNativeBytes` already existed as the native chokepoint. `MemoryDetection.pas` only derives the *default* ceiling — it is not in the enforcement path at all. Per the WP's own instruction, this reduced to closing gaps.

The gap was that `ReserveNativeBytes` had only **two call sites**. Array element growth had none — and `ExtendElementsWithHoles` takes a JS-controlled length:

| Budget | Outcome | Peak RSS |
|---|---|---|
| 64 MB | refused before allocating | **15.7 MB** |
| 2 GB | permitted, allocation proceeds | **1.46 GB** |

`new Array(100000000)` requests ~800 MB of pointer storage in one step. Under a 64 MB budget that previously went through: a **23× overshoot** of the stated ceiling from one line of script. Same binary, same script, budget varied — which is what shows the gate is what bounds RSS rather than unrelated engine behavior.

### `TGocciaMemoryLimitError`

New `Goccia.MemoryLimit.pas` adds a host-catchable error mirroring `TGocciaInstructionLimitError`. The budget previously surfaced **only** as a script-visible `RangeError`, which a host cannot tell apart from a `RangeError` the guest threw itself — "the sandbox hit its ceiling" and "the guest called `new Array(-1)`" arrived through the same channel. The script-visible `RangeError` is **unchanged**, so in-language error handling behaves exactly as before.

### Design note: gate, not charge

Element storage is **gated** (check, don't charge) rather than reserved. A charge would be better accounting, but the element list has no hook to release it when the array shrinks or is freed, so charging would leak reservations the engine could never give back. This bounds the peak, which is the property the budget actually promises. Where an owner *does* exist (ArrayBuffer, string payloads) the existing charge-and-release path is untouched. Documented in the unit.

### Deferred, with evidence

Object property storage remains uncharged — it needs the same lifetime hooks and is a larger change than this layer should carry. Recorded rather than silently skipped.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [x] Updated documentation
- [x] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests

`./build/GocciaTestRunner tests` **12143/12143** · `--mode=bytecode` **12143/12143** · `./format.pas --check` clean (447 files) · new `test-cli-apps.ts` section asserting **resident memory**, not just the error — a limit noticed only after the allocation bounds nothing — and asserting the same script still succeeds under a budget that accommodates it.
