### PR TITLE
fix(sandbox): apply engine options in the sandbox runner and classify failures

### DIFF
--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -1,5 +1,11 @@
 # Build System
 
+<!-- doc-length-limit: 900 -->
+<!-- This is the authoritative command reference (build targets, CLI options,
+     config-file behaviour) and grows with each runtime feature, so it carries
+     a higher line budget than a human-narrative doc. Keep it dense and
+     reference-shaped rather than splitting the single source of truth. -->
+
 *For contributors setting up their development environment or troubleshooting builds.*
 
 ## Executive Summary

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -471,6 +471,24 @@ const shellChild = await $`goccia --sandbox --seed /child.js --diff-metadata /ch
 
 Child seed entries are copied from the parent virtual filesystem, not the host filesystem. Child writes are discarded with the child VFS; request `diff: true` or shell `--diff` to inspect them. Use nested `diffMetadata: true` or shell `--diff-metadata` to include timestamp changes; either form implies a diff.
 
+Engine options apply to sandboxed execution exactly as they do to the other binaries — `--max-memory`, `--timeout`, `--max-instructions`, `--allowed-host`, `--fetch-deny-private-ranges`, and `--fetch-max-response-bytes` all bound the sandboxed program:
+
+```bash
+# Refuse allocations past 64 MiB and any fetch that resolves into private space.
+./build/GocciaSandboxRunner /main.js --seed-config=seed.json \
+  --max-memory=67108864 --allowed-host=api.example.com --fetch-deny-private-ranges
+```
+
+Config-file values reach the sandbox runner **only** through an explicit `--config`. It is the one binary that does not auto-discover a `goccia.json`, because the entry path names a file in the virtual filesystem: walking up from it leaves the sandbox namespace and climbs the host filesystem instead, from wherever the spelling happens to start — the host root for `/main.js`, the current directory for `main.js`. Config picked up by accident of spelling is a poor default for the binary that runs untrusted code, so the operator has to name the file.
+
+The cost is that limits an operator sets in a discovered `goccia.json` apply to every other binary and not to this one, and the omission is in the permissive direction. When a config file is discoverable and skipped for that reason, the runner says so on stderr:
+
+```
+Warning: ignoring discovered configuration /path/to/goccia.json. GocciaSandboxRunner applies configuration files only when named with --config.
+```
+
+Pass `--config=<file>` to apply it, and note that `--config` is the only way to bound a sandboxed run from a file rather than from flags.
+
 Diff output is explicit. `--diff` prints the diff after execution, `--diff-output=<host-path>` writes it to a host file, and `--diff-format=json|unified` selects the format. JSON is the default. Metadata is omitted unless `--diff-metadata` is present. In JSON it appears as a separate `metadataChanges` array whose per-path `changes` object contains only changed `atimeMs`, `mtimeMs`, `ctimeMs`, and `birthtimeMs` fields; timestamp-only changes never appear as content modifications.
 
 ## Build Output
@@ -696,7 +714,7 @@ Runs on **ubuntu-latest x64 only**; workload suites may fan out through matrices
 
 **`web-tooling-workload` / `web-tooling-report`** (needs build) — Runs the same direct-invocation workload matrix as full CI on the PR x64 build, using Goccia bytecode only, then validates and merges the shards into the normalized `web-tooling-report` JSON artifact. The downstream `web-tooling-comment` job posts or updates a `Web Tooling Benchmark` comment with per-workload build/execution status and Goccia `runs/s` where available; full stdout/stderr for failures and min/max/CV remain in the artifact.
 
-**`cli`** (needs build) — Runs CLI behavior smoke tests via Bun (`scripts/test-cli.ts`, `scripts/test-cli-lexer.ts`, `scripts/test-cli-parser.ts`, `scripts/test-cli-config.ts`, `scripts/test-cli-apps.ts`). `test-cli-apps.ts` includes `GocciaScriptLoaderBare` coverage for stdin, `-`, input files, CLI-local `print`, module source type, absence of the loader runtime profile, and `--mode=interpreted|bytecode` (both values plus invalid-value rejection), plus `GocciaSandboxRunner` coverage for seed config imports, inline text/base64 files, virtual `fs`, `$`, shared and child-sandbox `runScript` / shell `goccia`, bytecode mode, and diff output.
+**`cli`** (needs build) — Runs CLI behavior smoke tests via Bun (`scripts/test-cli.ts`, `scripts/test-cli-lexer.ts`, `scripts/test-cli-parser.ts`, `scripts/test-cli-config.ts`, `scripts/test-cli-apps.ts`). `test-cli-apps.ts` includes `GocciaScriptLoaderBare` coverage for stdin, `-`, input files, CLI-local `print`, module source type, absence of the loader runtime profile, and `--mode=interpreted|bytecode` (both values plus invalid-value rejection), plus `GocciaSandboxRunner` coverage for seed config imports, inline text/base64 files, virtual `fs`, `$`, shared and child-sandbox `runScript` / shell `goccia`, bytecode mode, diff output, the engine resource and fetch-policy options, and the `runScript` failure kinds for every guest-reachable failure and every host-set ceiling.
 
 FPC is only installed once per platform in the `build` job. In `ci.yml`, the test, AWFY, JetStream, Web Tooling, benchmark, cli, TOML, JSON5, and test262 conformance jobs reuse the pre-built binaries and artifacts from that job; in `pr.yml`, the test, AWFY, JetStream, Web Tooling, benchmark, test262, and cli jobs do the same.
 

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -489,7 +489,7 @@ Config-file values reach the sandbox runner **only** through an explicit `--conf
 
 The cost is that limits an operator sets in a discovered `goccia.json` apply to every other binary and not to this one, and the omission is in the permissive direction. When a config file is discoverable and skipped for that reason, the runner says so on stderr:
 
-```
+```text
 Warning: ignoring discovered configuration /path/to/goccia.json. GocciaSandboxRunner applies configuration files only when named with --config.
 ```
 

--- a/docs/built-ins.md
+++ b/docs/built-ins.md
@@ -752,13 +752,31 @@ The `"goccia"` module exposes sandbox runner orchestration helpers.
 | Export | Description |
 |--------|-------------|
 | `$` | Bun-like shell tagged template / command factory. Commands run against the sandbox filesystem and return a lazy command object with `.run()`, `.text()`, `.json()`, `.quiet()`, and `.nothrow()` |
-| `runScript(path, options?)` | Execute another sandbox entry path with the same execution mode. Shared VFS is the default; `{ sandbox: true }` creates a child VFS. Returns `{ ok, exitCode, stdout, stderr, result, error, diff }` |
+| `runScript(path, options?)` | Execute another sandbox entry path with the same execution mode. Shared VFS is the default; `{ sandbox: true }` creates a child VFS. Returns `{ ok, exitCode, stdout, stderr, result, error, diff, failureKind }` |
 
 `$` accepts tagged templates or command strings. Tagged-template substitutions are shell-quoted before command parsing.
 
 ```javascript
 const name = "hello world";
 console.log(await $`echo ${name}`.text());
+```
+
+`failureKind` says **why** a run ended, so an orchestrating script does not have to match on `error` text to tell a buggy child from one that hit a ceiling:
+
+| `failureKind` | Meaning |
+|---------------|---------|
+| `"none"` | The run completed. `ok` is `true` and `error` is `null` |
+| `"script-error"` | The child failed: it threw, failed to parse or link, or named a path the sandbox filesystem does not have — its own entry path, or a seed source |
+| `"resource-limit"` | A host-set ceiling refused the run: `--max-memory`, `--max-instructions`, the sandbox filesystem quota, or the `runScript` nesting depth |
+| `"timeout"` | The `--timeout` deadline elapsed |
+| `"host-error"` | The runner itself could not carry the run out. Nothing the child does produces this |
+| `"child-process-crash"` | Reserved for out-of-process execution; never produced in-process |
+
+```javascript
+const child = runScript("/child.js");
+if (child.failureKind === "resource-limit") {
+  // Raise the ceiling or split the work; retrying unchanged will not help.
+}
 ```
 
 By default, nested execution shares the current virtual filesystem:

--- a/scripts/test-cli-apps.ts
+++ b/scripts/test-cli-apps.ts
@@ -6721,6 +6721,10 @@ await section("SandboxRunner: virtual modules share the CLI surface and cannot s
     if (isolated.exitCode !== 0 ||
         normalizeLineEndings(isolated.stdout.toString()).trim() !== "isolated")
       throw new Error(`Sandbox consulted host config for a virtual path: ${isolated.stdout.toString()}${isolated.stderr.toString()}`);
+    // Skipping the discovered config is deliberate, and silence about it is
+    // not: this is the one binary whose ignored config fails open.
+    if (!isolated.stderr.toString().includes("ignoring discovered configuration"))
+      throw new Error(`Sandbox skipped a discoverable config without saying so: ${isolated.stderr.toString()}`);
 
     const manifest = join(tmp, "modules.mjs");
     const manifestSource = join(tmp, "module-map.mjs");
@@ -7400,6 +7404,269 @@ await section("Memory budget: single large allocation is refused before it happe
     const permittedOut = permitted.stdout.toString() + permitted.stderr.toString();
     if (permitted.exitCode !== 0 || !permittedOut.includes("len 100000000"))
       throw new Error(`Allocation within budget was refused:\n${permittedOut}`);
+  } finally {
+    clean(tmp);
+  }
+});
+
+// ── Sandbox runner engine options (WP-5) ───────────────────────────────
+//
+// The sandbox runner builds its own engine, because it needs its own module
+// resolver. It used to build it without applying the engine options, so the
+// binary whose entire purpose is running untrusted code silently ignored its
+// own resource and network policy flags. These assert the flags reach the
+// engine, and — for the budget — that the refusal is a refusal rather than a
+// broken gate that rejects everything.
+
+await section("SandboxRunner: --max-memory bounds the sandboxed program...", async () => {
+  const tmp = makeTmp();
+  try {
+    const seed = join(tmp, "seed.json");
+    writeFileSync(seed, JSON.stringify({
+      files: [
+        {
+          path: "/alloc.js",
+          // 32 MB of pointer storage in one step: enough to sit either side
+          // of the two budgets below, small enough that the permitted arm
+          // allocates it in milliseconds rather than seconds.
+          text: "const a = new Array(4000000); console.log('len ' + a.length);\n",
+        },
+      ],
+    }));
+
+    const refused = Bun.spawnSync(
+      [SANDBOXRUNNER, "/alloc.js", `--seed-config=${seed}`, "--max-memory=8388608"],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+    const refusedOut = refused.stdout.toString() + refused.stderr.toString();
+    if (refused.exitCode === 0)
+      throw new Error(`Sandbox allocation past the budget was permitted:\n${refusedOut}`);
+    if (!/memory limit exceeded/i.test(refusedOut))
+      throw new Error(`Expected a sandbox memory-budget error, got:\n${refusedOut}`);
+
+    // The same script under a budget that accommodates it must still run,
+    // otherwise the option is not applied so much as the runner is broken.
+    const permitted = Bun.spawnSync(
+      [SANDBOXRUNNER, "/alloc.js", `--seed-config=${seed}`, "--max-memory=67108864"],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+    const permittedOut = permitted.stdout.toString() + permitted.stderr.toString();
+    if (permitted.exitCode !== 0 || !permittedOut.includes("len 4000000"))
+      throw new Error(`Sandbox allocation within budget was refused:\n${permittedOut}`);
+  } finally {
+    clean(tmp);
+  }
+});
+
+await section("SandboxRunner: --fetch-deny-private-ranges reaches the sandboxed fetch...", async () => {
+  const tmp = makeTmp();
+  try {
+    const seed = join(tmp, "seed.json");
+    writeFileSync(seed, JSON.stringify({
+      files: [
+        {
+          path: "/fetch.js",
+          // Port 1 on loopback needs no server: with the policy on the request
+          // is refused before any connect, with it off it fails at connect.
+          text: [
+            "try {",
+            "  await fetch('http://127.0.0.1:1/');",
+            "  console.log('no-error');",
+            "} catch (error) {",
+            "  console.log('err:' + error.message);",
+            "}",
+          ].join("\n"),
+        },
+      ],
+    }));
+    const args = [
+      SANDBOXRUNNER,
+      "/fetch.js",
+      `--seed-config=${seed}`,
+      "--source-type=module",
+      "--allowed-host=127.0.0.1",
+    ];
+
+    const denied = Bun.spawnSync([...args, "--fetch-deny-private-ranges"], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const deniedOut = denied.stdout.toString() + denied.stderr.toString();
+    if (!deniedOut.includes("resolves to private address 127.0.0.1"))
+      throw new Error(`Sandbox fetch should be refused by address policy, got:\n${deniedOut}`);
+
+    // Asserted positively: the default arm has to prove the request reached
+    // the connect, because an absent substring is also what a script that
+    // never ran produces.
+    const allowed = Bun.spawnSync(args, { stdout: "pipe", stderr: "pipe" });
+    const allowedOut = allowed.stdout.toString() + allowed.stderr.toString();
+    if (allowed.exitCode !== 0 ||
+        !allowedOut.includes("err:Failed to connect to 127.0.0.1:1"))
+      throw new Error(`Sandbox fetch should reach the connect by default, got (exit ${allowed.exitCode}):\n${allowedOut}`);
+  } finally {
+    clean(tmp);
+  }
+});
+
+// ── Sandbox run failure taxonomy (WP-5) ────────────────────────────────
+//
+// `runScript` reports why a nested run ended alongside the message that says
+// it in prose, so a host orchestrating children can tell a bug from a
+// ceiling without matching on text. The property worth pinning is not that
+// the field exists: it is that the guest cannot talk its way into
+// "host-error". Everything the child steers — its own throw, a path it
+// named, a ceiling it ran into — must classify as its own fault or as the
+// limit it hit, or the distinction the field exists to draw is gone.
+//
+// Both execution modes, because the classification sits in the runner's
+// exception ladder and the executors raise through it differently.
+
+const sandboxSeedConfig = (files: Record<string, string>): string =>
+  JSON.stringify({
+    files: Object.entries(files).map(([path, text]) => ({ path, text })),
+  });
+
+const runSandboxKinds = (
+  seed: string,
+  mode: "interpreted" | "bytecode",
+  extraArgs: string[] = [],
+): { stdout: string; exitCode: number | null; combined: string } => {
+  const proc = Bun.spawnSync(
+    [
+      SANDBOXRUNNER,
+      "/main.js",
+      `--seed-config=${seed}`,
+      "--source-type=module",
+      `--mode=${mode}`,
+      ...extraArgs,
+    ],
+    { stdout: "pipe", stderr: "pipe" },
+  );
+  return {
+    stdout: normalizeLineEndings(proc.stdout.toString()).trim(),
+    exitCode: proc.exitCode,
+    combined: proc.stdout.toString() + proc.stderr.toString(),
+  };
+};
+
+await section("SandboxRunner: guest-reachable failures never classify as host faults...", async () => {
+  const tmp = makeTmp();
+  try {
+    const seed = join(tmp, "failure-kinds.json");
+    writeFileSync(seed, sandboxSeedConfig({
+      "/main.js": [
+        'import { runScript } from "goccia";',
+        'const ok = runScript("/ok.js");',
+        'console.log("success:" + ok.failureKind + ":" + ok.ok);',
+        'const thrown = runScript("/throw.js");',
+        'console.log("throw:" + thrown.failureKind + ":" + thrown.ok);',
+        // An entry path the guest picked, which the VFS does not have.
+        'const missing = runScript("/absent.js");',
+        'console.log("missing:" + missing.failureKind);',
+        // A child seed source the guest picked, which the VFS does not have.
+        'const badSeed = runScript("/ok.js", { sandbox: true, seed: ["/ok.js", "/absent.txt"] });',
+        'console.log("seed:" + badSeed.failureKind);',
+        // The nesting ceiling, observed from the frame one level above it.
+        'console.log("nesting:" + runScript("/deep.js").stdout.trim());',
+      ].join("\n"),
+      "/ok.js": 'console.log("child ran");\n',
+      "/throw.js": 'throw new Error("boom");\n',
+      "/deep.js": [
+        'import { runScript } from "goccia";',
+        'const child = runScript("/deep.js");',
+        "if (child.ok) console.log(child.stdout.trim());",
+        'else console.log(child.failureKind);',
+      ].join("\n"),
+    }));
+
+    const expected = [
+      "success:none:true",
+      "throw:script-error:false",
+      "missing:script-error",
+      "seed:script-error",
+      "nesting:resource-limit",
+    ].join("\n");
+    for (const mode of ["interpreted", "bytecode"] as const) {
+      const run = runSandboxKinds(seed, mode);
+      if (run.exitCode !== 0)
+        throw new Error(`SandboxRunner ${mode} failure-kind run should exit 0, got ${run.exitCode}:\n${run.combined}`);
+      if (run.stdout !== expected)
+        throw new Error(`SandboxRunner ${mode} failure kinds should be ${JSON.stringify(expected)}, got:\n${run.stdout}`);
+    }
+  } finally {
+    clean(tmp);
+  }
+});
+
+await section("SandboxRunner: every host-set ceiling reports itself as one...", async () => {
+  const tmp = makeTmp();
+  try {
+    const memorySeed = join(tmp, "memory-kind.json");
+    writeFileSync(memorySeed, sandboxSeedConfig({
+      "/main.js": [
+        'import { runScript } from "goccia";',
+        'const child = runScript("/hog.js");',
+        'console.log("memory:" + child.failureKind + ":" + child.ok);',
+      ].join("\n"),
+      "/hog.js": "const a = new Array(4000000); console.log(a.length);\n",
+    }));
+
+    const timeoutSeed = join(tmp, "timeout-kind.json");
+    writeFileSync(timeoutSeed, sandboxSeedConfig({
+      "/main.js": [
+        'import { runScript } from "goccia";',
+        'const child = runScript("/spin.js");',
+        'console.log("timeout:" + child.failureKind + ":" + child.ok);',
+      ].join("\n"),
+      "/spin.js": "while (true) {}\n",
+    }));
+
+    // The child sandbox inherits what the parent VFS has left, so a parent
+    // that has spent its node quota cannot seed one at all. That refusal
+    // raises out of the nested call rather than returning a result, so it is
+    // classified by the frame that called it — here, /filler.js.
+    const quotaSeed = join(tmp, "quota-kind.json");
+    writeFileSync(quotaSeed, sandboxSeedConfig({
+      "/main.js": [
+        'import { runScript } from "goccia";',
+        'const filler = runScript("/filler.js");',
+        'console.log("quota:" + filler.failureKind + ":" + filler.ok);',
+        'console.log("filler:" + filler.stdout.trim());',
+      ].join("\n"),
+      "/filler.js": [
+        'import fs from "fs";',
+        'import { runScript } from "goccia";',
+        'let code = "";',
+        'for (const name of Array.from({ length: 200 }, (_, i) => "/f" + i + ".txt")) {',
+        '  try { fs.writeFileSync(name, "x"); } catch (error) { code = error.code; }',
+        "}",
+        'console.log("filled:" + code);',
+        'runScript("/ok.js", { sandbox: true, seed: ["/ok.js"] });',
+        'console.log("unreachable");',
+      ].join("\n"),
+      "/ok.js": 'console.log("child ran");\n',
+    }));
+
+    for (const mode of ["interpreted", "bytecode"] as const) {
+      const memory = runSandboxKinds(memorySeed, mode, ["--max-memory=8388608"]);
+      if (memory.stdout !== "memory:resource-limit:false")
+        throw new Error(`SandboxRunner ${mode} memory ceiling should classify as a resource limit, got:\n${memory.combined}`);
+
+      // The parent shares the deadline it hands the child, so it may be out
+      // of time itself once the child is refused. Its output is captured
+      // either way; the exit code is not the assertion.
+      const timeout = runSandboxKinds(timeoutSeed, mode, [
+        "--compat-while-loops",
+        "--timeout=300",
+      ]);
+      if (!containsLine(timeout.stdout, "timeout:timeout:false"))
+        throw new Error(`SandboxRunner ${mode} deadline should classify as a timeout, got:\n${timeout.combined}`);
+
+      const quota = runSandboxKinds(quotaSeed, mode, ["--fs-node-limit=32"]);
+      const expectedQuota = ["quota:resource-limit:false", "filler:filled:ENOSPC"].join("\n");
+      if (quota.stdout !== expectedQuota)
+        throw new Error(`SandboxRunner ${mode} filesystem quota should classify as a resource limit, got:\n${quota.combined}`);
+    }
   } finally {
     clean(tmp);
   }

--- a/source/app/Goccia.CLI.Application.pas
+++ b/source/app/Goccia.CLI.Application.pas
@@ -139,6 +139,16 @@ function ResolveSourceTypeOption(
 procedure ApplyCompatibilityAndWarningFlags(const AEngine: TGocciaEngine;
   const AEngineOptions: TGocciaEngineOptions;
   const AFileConfig: TConfigEntryArray);
+{ The single place engine-affecting options reach an engine.  CreateEngine
+  calls it for every binary that builds its engine through the base class;
+  binaries that must construct the engine themselves — GocciaSandboxRunner
+  needs its own module resolver — call it directly rather than restating
+  the option set, which is how the sandbox runner previously lost
+  --max-memory and the fetch policy.  Pass an empty AFileConfig when there
+  is no host file to discover a per-file config for. }
+procedure ApplyFileConfigToEngine(const AEngine: TGocciaEngine;
+  const AEngineOptions: TGocciaEngineOptions;
+  const AFileConfig: TConfigEntryArray; const AFileName: string);
 
 implementation
 

--- a/source/app/GocciaSandboxRunner.dpr
+++ b/source/app/GocciaSandboxRunner.dpr
@@ -15,7 +15,6 @@ uses
   Goccia.Application,
   Goccia.Base64,
   Goccia.Builtins.Console,
-  Goccia.Builtins.GlobalShadowRealm,
   Goccia.CapabilityAudit,
   Goccia.CLI.Application,
   Goccia.CLI.Options,
@@ -46,7 +45,15 @@ uses
   Goccia.Values.Error,
   Goccia.Values.ObjectValue,
   Goccia.Values.Primitives,
+  Goccia.VM.Exception,
   SandboxVirtualFileSystem;
+
+const
+  { Each nesting level holds an engine, a realm, and a virtual
+    filesystem alive on the native stack, so the depth a guest may ask
+    for is a resource ceiling like the memory budget, not a taste
+    judgement about how deep orchestration should go. }
+  MAX_RUN_SCRIPT_DEPTH = 32;
 
 type
   TSandboxRunnerApp = class(TGocciaCLIApplication)
@@ -233,10 +240,28 @@ begin
   Result := '<sandbox-entry-path> [options]';
 end;
 
+{ Config reaches this runner only through an explicit --config.  The entry
+  path names a file in the virtual filesystem, so discovery walking up from
+  it describes host directories that have nothing to do with the run, and
+  which host directories those are depends on how the operator spelled the
+  path: an absolute sandbox path starts the walk at the host root, a bare
+  name starts it at the current directory.  Config that lands by accident of
+  spelling is worse than no config for the one binary that runs untrusted
+  code, so the runner requires the operator to say which file to apply.
+
+  The cost is that an operator who sets limits in a discovered goccia.json
+  gets no limits here while every other binary honours them, and the failure
+  is silent and in the permissive direction.  So say so, on stderr, whenever
+  a config was found and skipped — this predicate is the only place that
+  knows both that a config exists and that it will not be applied. }
 function TSandboxRunnerApp.ShouldApplyRootConfig(const APaths: TStringList;
   const AConfigPath: string; const AExplicitConfig: Boolean): Boolean;
 begin
   Result := AExplicitConfig;
+  if not Result then
+    WriteLn(ErrOutput, Format('Warning: ignoring discovered configuration ' +
+      '%s. %s applies configuration files only when named with --config.',
+      [AConfigPath, Name]));
 end;
 
 procedure TSandboxRunnerApp.Validate;
@@ -615,27 +640,27 @@ var
 begin
   EmptyConfig := EmptyConfigEntries;
   ConfigureCapabilityAudit(AEngine);
-  AEngine.SourceType := ResolveSourceTypeOption(EngineOptions.SourceType,
-    EmptyConfig, AFileName);
-  ApplyCompatibilityAndWarningFlags(AEngine, EngineOptions, EmptyConfig);
-  AEngine.StrictTypes := ResolveFlagOption(EngineOptions.StrictTypes,
-    EmptyConfig);
-  AEngine.FunctionConstructor.Enabled := ResolveFlagOption(
-    EngineOptions.UnsafeFunctionConstructor, EmptyConfig);
   if Assigned(AParentHostEnvironment) then
     AEngine.HostEnvironment.ConfigureAsChildOf(AParentHostEnvironment)
   else if ResolveFlagOption(EngineOptions.Deterministic, EmptyConfig) then
     AEngine.HostEnvironment.UseDeterministicProfile;
-  if ResolveFlagOption(EngineOptions.UnsafeShadowRealm, EmptyConfig) then
-    EnableShadowRealm(AEngine);
 
   Runtime := AttachRuntime(AEngine);
   ApplyLoaderRuntimeProfile(Runtime);
   Runtime.Install(TGocciaSandboxRuntimeExtension.Create(AContext));
   if ResolveFlagOption(EngineOptions.UnsafeFFI, EmptyConfig) then
     Runtime.Install(TGocciaFFIRuntimeExtension.Create);
-  if EngineOptions.AllowedHosts.Present then
-    AEngine.SetAllowedFetchHosts(EngineOptions.AllowedHosts.Values);
+
+  { Same option application every other binary gets from CreateEngine, in the
+    same position relative to runtime attachment — SetAllowedFetchHosts fans
+    out to engine extensions, so it has to run after the runtime is installed.
+    The per-file config is empty because AFileName is a sandbox path, not a
+    host path: a per-file walk upwards from it would leave the sandbox
+    namespace entirely and climb the host filesystem from its root, so it
+    could only ever find a config that has nothing to do with this run.
+    Root config still applies, because it is merged into the option values
+    before execution starts. }
+  ApplyFileConfigToEngine(AEngine, EngineOptions, EmptyConfig, AFileName);
 
   ConsoleExtension := TGocciaConsoleRuntimeExtension(
     Runtime.FindRuntimeExtension(TGocciaConsoleRuntimeExtension));
@@ -769,10 +794,18 @@ begin
   FillChar(Result, SizeOf(Result), 0);
   Result.Ok := False;
   Result.ExitCode := 1;
+  { Only a fall-through default: every path below assigns a kind, so
+    this stands for "the runner returned without classifying", which is
+    a runner defect by definition. }
+  Result.FailureKind := sfkHostError;
 
   if not AContext.Fs.IsFile(AEntryPath) then
   begin
+    { The entry path is an argument, and for a nested run the guest
+      chose it — sfkHostError here would let the guest name the runner
+      as the party at fault by passing a path that does not exist. }
     Result.ErrorMessage := 'sandbox entry file not found: ' + AEntryPath;
+    Result.FailureKind := sfkScriptError;
     Exit;
   end;
 
@@ -823,6 +856,7 @@ begin
         end;
         Result.Ok := True;
         Result.ExitCode := 0;
+        Result.FailureKind := sfkNone;
       finally
         PopTimeoutScope;
         PopInstructionLimitScope;
@@ -830,22 +864,71 @@ begin
     except
       on E: EGocciaCapabilityAuditDeliveryError do
         raise;
-      { Named before the generic Exception branch so a budget refusal is
-        reported as the limit it is, rather than folded into "some native
-        error happened". A structured failure taxonomy on
-        TGocciaSandboxRunResult belongs to the out-of-process work, which has
-        to define crash / timeout-kill / limit / script-error as one set;
-        adding a field here would pre-empt that design, so this layer only
-        makes the case distinguishable in the message. }
+      { Each branch classifies as well as formats.  The order is what does
+        the classifying: every kind the guest can steer is named ahead of
+        the generic Exception branch, so a ceiling is reported as the
+        ceiling it is and a guest throw as the guest's, rather than either
+        being folded into "some native error happened". }
       on E: TGocciaMemoryLimitError do
+      begin
         Result.ErrorMessage := 'memory limit exceeded: ' + E.Message;
+        Result.FailureKind := sfkResourceLimit;
+      end;
+      on E: TGocciaInstructionLimitError do
+      begin
+        Result.ErrorMessage := E.Message;
+        Result.FailureKind := sfkResourceLimit;
+      end;
+      { Reached from a nested isolated runScript, which checks the
+        inherited quota before it builds the child context and raises
+        out through the calling guest rather than returning a result;
+        this frame is where that lands. }
+      on E: ESandboxFsQuotaExceeded do
+      begin
+        Result.ErrorMessage := E.Message;
+        Result.FailureKind := sfkResourceLimit;
+      end;
+      on E: EGocciaSandboxNestingLimitExceeded do
+      begin
+        Result.ErrorMessage := E.Message;
+        Result.FailureKind := sfkResourceLimit;
+      end;
+      on E: TGocciaTimeoutError do
+      begin
+        Result.ErrorMessage := E.Message;
+        Result.FailureKind := sfkTimeout;
+      end;
       on E: TGocciaError do
+      begin
         Result.ErrorMessage := E.GetDetailedMessage(False);
+        Result.FailureKind := sfkScriptError;
+      end;
       on E: TGocciaThrowValue do
+      begin
         Result.ErrorMessage := FormatThrowDetail(E.Value, AEntryPath, Source,
           False, E.Suggestion);
+        Result.FailureKind := sfkScriptError;
+      end;
+      { The same guest throw, as the bytecode VM delivers it.  Without this
+        branch a bytecode run reported an uncaught throw as a host fault and
+        printed the bare message where the interpreter printed the frame —
+        the guest picking both the classification and the format. }
+      on E: EGocciaBytecodeThrow do
+      begin
+        Result.ErrorMessage := FormatThrowDetail(E.ThrownValue, AEntryPath,
+          Source, False);
+        Result.FailureKind := sfkScriptError;
+      end;
+      { Whatever is left is a native error the engine does not model.
+        Every failure the guest can steer is named above, so reaching
+        here means the runner malfunctioned; if a guest-reachable
+        condition ever lands here it belongs in a branch of its own
+        rather than in this one. }
       on E: Exception do
+      begin
         Result.ErrorMessage := E.Message;
+        Result.FailureKind := sfkHostError;
+      end;
     end;
 
     Result.Output := OutputLines.Text;
@@ -871,8 +954,9 @@ var
   RemainingBytes: Int64;
   RemainingNodes: Integer;
 begin
-  if FRunScriptDepth >= 32 then
-    raise Exception.Create('sandbox runScript nesting limit exceeded');
+  if FRunScriptDepth >= MAX_RUN_SCRIPT_DEPTH then
+    raise EGocciaSandboxNestingLimitExceeded.Create(
+      'sandbox runScript nesting limit exceeded');
   Inc(FRunScriptDepth);
   try
   if not AOptions.Isolated then
@@ -881,6 +965,10 @@ begin
   FillChar(Result, SizeOf(Result), 0);
   Result.Ok := False;
   Result.ExitCode := 1;
+  { Fall-through default, as in ExecuteSandboxPathInContext: the child
+    run replaces the whole record and every except branch assigns a
+    kind, so this only survives if the runner returned unclassified. }
+  Result.FailureKind := sfkHostError;
   RemainingBytes := AContext.Fs.QuotaBytes - AContext.Fs.UsedBytes;
   RemainingNodes := AContext.Fs.NodeQuota - AContext.Fs.NodeCount;
   if RemainingBytes <= 0 then
@@ -906,12 +994,38 @@ begin
     except
       on E: EGocciaCapabilityAuditDeliveryError do
         raise;
+      { Seeding and diffing the child context, not the child program —
+        but the guest supplies the seed list, so most of what fails here
+        is still its own doing: the inherited quotas are a ceiling like
+        any other, and a seed path that is missing, is not a directory,
+        or is otherwise unusable is the guest naming a path the parent
+        filesystem does not have. }
+      on E: ESandboxFsQuotaExceeded do
+      begin
+        Result.Ok := False;
+        Result.ExitCode := 1;
+        Result.ErrorMessage := E.Message;
+        Result.ErrorOutput := E.Message + sLineBreak;
+        Result.FailureKind := sfkResourceLimit;
+      end;
+      on E: ESandboxFsError do
+      begin
+        Result.Ok := False;
+        Result.ExitCode := 1;
+        Result.ErrorMessage := E.Message;
+        Result.ErrorOutput := E.Message + sLineBreak;
+        Result.FailureKind := sfkScriptError;
+      end;
+      { What is left is seeding or diffing failing for a reason the
+        guest did not name — a native error in the runner's own copy or
+        diff machinery. }
       on E: Exception do
       begin
         Result.Ok := False;
         Result.ExitCode := 1;
         Result.ErrorMessage := E.Message;
         Result.ErrorOutput := E.Message + sLineBreak;
+        Result.FailureKind := sfkHostError;
       end;
     end;
   finally

--- a/source/units/Goccia.RuntimeExtensions.Sandbox.pas
+++ b/source/units/Goccia.RuntimeExtensions.Sandbox.pas
@@ -1488,6 +1488,13 @@ begin
     Obj.SetProperty('diff', TGocciaStringLiteralValue.Create(RunResult.Diff))
   else
     Obj.SetProperty('diff', TGocciaNullLiteralValue.NullValue);
+  { Why the run ended, next to the message that says it in prose.  A
+    caller orchestrating nested runs has to tell "the child is buggy"
+    from "the child hit a ceiling I set" to decide whether retrying or
+    raising the ceiling is the answer, and `error` alone forces that
+    decision to be made by matching on message text. }
+  Obj.SetProperty('failureKind', TGocciaStringLiteralValue.Create(
+    SandboxFailureKindName(RunResult.FailureKind)));
   Result := Obj;
 end;
 

--- a/source/units/Goccia.Sandbox.Context.pas
+++ b/source/units/Goccia.Sandbox.Context.pas
@@ -46,12 +46,56 @@ type
     DiffFormat: string;
   end;
 
+  { Why a sandbox run ended, as a value the host can branch on.
+
+    ErrorMessage stays the human-readable text it always was; this is
+    additive and never replaces it.  The distinction that matters is
+    "the guest program failed" versus "the guest hit a ceiling the host
+    set" — those arrive through the same string today and a host cannot
+    tell a runaway from a bug without parsing prose.
+
+    The dividing line is who is at fault, so nothing the guest can
+    trigger may classify as sfkHostError: a guest that can name its own
+    failure kind has erased the distinction the type exists to draw.
+    Anything the guest chose — a path it passed, a seed it asked for, a
+    ceiling it ran into — is its own error or the ceiling it hit.
+
+    sfkChildProcessCrash is reserved and never produced in-process: a
+    crashed child is only observable once execution moves out of process
+    (see ADR 0106), and naming it here keeps that outcome from being
+    folded into sfkHostError when it lands. }
+  TGocciaSandboxFailureKind = (
+    { The run completed; Ok is True and no error was reported. }
+    sfkNone,
+    { The guest program failed: it threw, failed to parse or link, or
+      named a path that the sandbox filesystem does not have — its own
+      entry path, or a path it asked to seed a child from. }
+    sfkScriptError,
+    { A host-set resource ceiling refused the run: memory budget,
+      instruction limit, sandbox filesystem quota, or nesting depth. }
+    sfkResourceLimit,
+    { The execution deadline elapsed. }
+    sfkTimeout,
+    { The runner itself could not carry the run out — a native error
+      with no engine meaning and no guest-reachable cause. }
+    sfkHostError,
+    { Reserved: an out-of-process child died without reporting. }
+    sfkChildProcessCrash
+  );
+
+  { Raised when the guest asks to nest runScript deeper than the runner
+    permits.  Typed rather than a bare Exception so the ceiling
+    classifies as the resource limit it is, instead of falling through
+    to the host-error branch or being recognised by message text. }
+  EGocciaSandboxNestingLimitExceeded = class(Exception);
+
   TGocciaSandboxRunResult = record
     Ok: Boolean;
     ExitCode: Integer;
     Output: string;
     ErrorOutput: string;
     ErrorMessage: string;
+    FailureKind: TGocciaSandboxFailureKind;
     Diff: string;
     DiffRequested: Boolean;
     ResultValue: TGocciaValue;
@@ -105,12 +149,33 @@ type
   end;
 
 function DefaultSandboxRunOptions: TGocciaSandboxRunOptions;
+{ The wire name of a failure kind.  Hosts see these strings — runScript
+  exposes them as its `failureKind` property — so they are a stable
+  contract: rename a value here and every host branching on it breaks. }
+function SandboxFailureKindName(
+  const AKind: TGocciaSandboxFailureKind): string;
 
 implementation
+
+const
+  SANDBOX_FAILURE_KIND_NAMES: array[TGocciaSandboxFailureKind] of string = (
+    'none',
+    'script-error',
+    'resource-limit',
+    'timeout',
+    'host-error',
+    'child-process-crash'
+  );
 
 function BytesLength(const ABytes: TBytes): Int64;
 begin
   Result := Length(ABytes);
+end;
+
+function SandboxFailureKindName(
+  const AKind: TGocciaSandboxFailureKind): string;
+begin
+  Result := SANDBOX_FAILURE_KIND_NAMES[AKind];
 end;
 
 function DefaultSandboxRunOptions: TGocciaSandboxRunOptions;


### PR DESCRIPTION
## Summary

Makes `GocciaSandboxRunner` actually honour its own engine options, and gives its result a machine-readable failure taxonomy. Layer 5; stacked on #1134.

The runner built its engine directly, bypassing `ApplyFileConfigToEngine`, so `--max-memory` and (once layers 2–3 landed) `--fetch-deny-private-ranges` / `--fetch-max-response-bytes` silently did nothing in the one binary whose entire purpose is running untrusted code. It now routes option application through the shared helper — deliberately **not** through `CreateEngine`, because that discovers per-file config from the entry path, which in a sandbox is a guest-controlled VFS path that would climb the host filesystem. Config discovery is disabled for that reason; root `--config` still applies, and a discovered-but-skipped `goccia.json` now warns rather than passing in silence.

`TGocciaSandboxRunResult` gains a failure taxonomy — `none` / `script-error` / `resource-limit` / `timeout` / `host-error`, plus `child-process-crash` reserved for the out-of-process work (#1138) — surfaced as a lowercase string on the `runScript` result and asserted from JavaScript in both modes. A guest can no longer name the runner as the faulty party.

### Review-driven

An adversarial review found the taxonomy was write-only dead code; wiring it to a consumer immediately exposed a second defect (bytecode guest-throw diverging from the interpreter). Both fixed. The empty-config comment's threat model was corrected — resolution runs once from the operator path, not per guest import.

## Testing

- [x] JS suite 12143/12143 both modes · Pascal binaries · `test-cli-apps.ts` · `format --check`
- [x] New sections prove `--max-memory` refuses/permits and `--fetch-deny-private-ranges` refuses before connect, in the sandbox runner specifically.
