### PR TITLE
fix(modules): report a missing content provider as a coded JavaScript Error

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -38,6 +38,10 @@ _Avoid_: Global module, runtime module when the module is registered directly by
 An import-only module installed by a runtime extension, such as a `goccia:` data-format module.
 _Avoid_: Runtime global, host module.
 
+**Module content provider**:
+The host-installed component that retrieves a module's text or bytes once an address has been resolved. Resolution and retrieval are separate concerns: a resolver decides which address to load, a content provider decides how its content is obtained. An engine with no provider installed is not a broken engine — it refuses every retrieval with a script-catchable error carrying a stable code, which is a different condition both from an installed provider that cannot produce a particular module and from a specifier that never resolved, since resolution runs first and fails on its own terms.
+_Avoid_: Module resolver, module loader, filesystem when the retrieval mechanism is the defining property.
+
 **Runtime profile**:
 A named bundle of runtime extensions used by a CLI host or embedding host.
 _Avoid_: Mode, preset.

--- a/docs/adr/0106-sandbox-hardening-scope.md
+++ b/docs/adr/0106-sandbox-hardening-scope.md
@@ -83,7 +83,14 @@ containing them.
   callback is set, JavaScriptCore's default loader with `Could not open the
   module`, and SpiderMonkey with `Module load hook not set`. `TypeError` is the
   convention for a *configured* loader that failed (HTML, Deno), which is a
-  different condition and should stay distinguishable.
+  different condition and should stay distinguishable. The error carries `code`
+  and nothing else: unlike the sandbox filesystem errors of
+  [ADR 0092](0092-sandbox-filesystem-error-contract.md), whose `path` is a VFS
+  address the guest itself named, the only address available at this refusal is
+  the resolver's output — a host filesystem path by default — and the engine
+  that has no provider is precisely the one running untrusted source. It also
+  bounds the contract: resolution runs before retrieval, so a specifier that
+  never resolves fails earlier and carries no code at all.
 
 ## Consequences
 

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -350,7 +350,7 @@ begin
 end;
 ```
 
-`TGocciaEngine` also accepts an injected module loader via its constructor. When no loader is supplied, it creates a default `TGocciaModuleLoader` with the standard resolver but no filesystem content provider. `TGocciaRuntime` installs the filesystem provider when attached unless `AttachRuntime(Engine, False)` is used. Untrusted-source hosts should pass `False` and supply virtual modules, host modules, or a bounded custom content provider explicitly. Core-language-only embedders that need imports should inject their own provider.
+`TGocciaEngine` also accepts an injected module loader via its constructor. When no loader is supplied, it creates a default `TGocciaModuleLoader` with the standard resolver but no filesystem content provider. `TGocciaRuntime` installs the filesystem provider when attached unless `AttachRuntime(Engine, False)` is used. Untrusted-source hosts should pass `False` and supply virtual modules, host modules, or a bounded custom content provider explicitly. Core-language-only embedders that need imports should inject their own provider. With no provider installed, a module load that gets as far as retrieval is refused with a script-catchable `Error` carrying `code === "ERR_MODULE_LOADING_UNSUPPORTED"` rather than a Pascal exception. That covers retrieval only: resolution runs first, so a specifier the resolver rejects — with the default resolver, one whose file is absent from the host filesystem — fails before the provider is consulted, carries no `code`, and raises `TGocciaRuntimeError` across the engine boundary for a static import. Keep guarding the boundary; see [Module loading errors](errors.md#module-loading-errors).
 
 ### Virtual Modules
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -175,6 +175,65 @@ ENOENT: no such file or directory, rename '/missing.txt' -> '/destination.txt'
 `code` is the portable field to branch on. Numeric `errno` follows libuv's
 target convention, so its value can differ between operating systems.
 
+### Module loading errors
+
+An engine that was never given a module content provider refuses every module
+load it is asked to *retrieve*. The refusal is a JavaScript error rather than an
+RTL exception: `import()` rejects with it and source can catch it, and a static
+import — which no `try`/`catch` in the importing module can wrap — surfaces it as
+a JavaScript throw (`TGocciaThrowValue`) carrying the same error value.
+
+Loading a module is resolution followed by retrieval, and only retrieval reaches
+the provider. A specifier the resolver rejects fails first, and that is a
+different failure carrying no `code` — with the default resolver, which resolves
+against the host filesystem, `import "./dep.js"` where `dep.js` does not exist
+fails there. `import()` rejects with a plain `Error` reading
+`Module not found: "./dep.js" (resolved to "…")`, and a **static import raises
+`TGocciaRuntimeError` out of the engine as a host-language exception**. So an
+embedder still has to guard its engine boundary, and resolution messages do name
+host filesystem addresses, which the refusal below deliberately does not.
+
+In addition to the standard error properties, the refusal carries:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `code` | `string` | `"ERR_MODULE_LOADING_UNSUPPORTED"` |
+
+```javascript
+try {
+  await import("./dep.js");  // resolves, no provider installed
+} catch (error) {
+  error instanceof Error;  // true
+  error.name;              // "Error"
+  error.code;              // "ERR_MODULE_LOADING_UNSUPPORTED"
+  error.message;           // "Cannot load module: no module content provider is configured"
+  error.path;              // undefined — see below
+}
+```
+
+There is deliberately no `path`, and the message names no module address. The
+only address available where the refusal is raised is the *resolved* one, which
+the default resolver expands into an absolute host filesystem path, and an
+engine with no provider is exactly the configuration an embedder runs untrusted
+source in — an enumerable own property would carry that host detail into
+`JSON.stringify(error)` and object spread. Nothing is lost: while no provider is
+installed the refusal is unconditional for every module, so acting on it never
+depends on which one was asked for. Contrast
+[sandbox filesystem errors](#sandbox-filesystem-errors), whose `path` is a
+sandbox VFS address the guest itself named.
+
+The error type is a plain `Error` rather than a `TypeError`. ECMA-262
+`HostLoadImportedModule` requires a throw completion but mandates no type, and
+for this case — an engine with no loader at all — V8, JavaScriptCore, and
+SpiderMonkey all report a plain `Error`; `TypeError` is the convention for a
+*configured* loader that tried and failed. Because the constructor cannot
+separate the two, `code` is the field to branch on: a provider that is
+configured and cannot produce a module reports its own failure and never
+`ERR_MODULE_LOADING_UNSUPPORTED`. See
+[ADR 0106](adr/0106-sandbox-hardening-scope.md) for the full rationale, and
+[Embedding](embedding.md#custom-content-provider) for how to install a
+provider.
+
 ### Stack Traces
 
 The `stack` property contains a V8-style formatted string with the error header followed by `at` frames:

--- a/source/app/GocciaFuzzHarness.dpr
+++ b/source/app/GocciaFuzzHarness.dpr
@@ -107,9 +107,11 @@ type
     Two reasons, both mandatory. First, a fuzz input must never reach the host
     filesystem — without this, `import "/etc/passwd"` is a file read driven by
     attacker-shaped input, which is precisely the property this harness exists
-    to protect. Second, the engine's default provider raises a bare
-    EStreamError, an RTL type the harness cannot distinguish from a real
-    stream fault; owning the provider means owning the exception type. }
+    to protect. Second, the engine's default provider refuses with a
+    script-catchable JavaScript error, so the fuzzed input could swallow its own
+    import with a try/catch and the outcome ladder would score the run as
+    ordinary script behaviour; EFuzzModuleDenied is an RTL type the input cannot
+    intercept, so owning the provider means owning that distinction. }
   TFuzzDeniedModuleContentProvider = class(TGocciaModuleContentProvider)
   public
     function Exists(const APath: string): Boolean; override;

--- a/source/units/Goccia.Error.Messages.pas
+++ b/source/units/Goccia.Error.Messages.pas
@@ -525,6 +525,12 @@ resourcestring
   SErrorCannotDestructureNotObject = 'Cannot destructure %s as it is not an object';
   SErrorMaxCallStackExceeded = 'Maximum call stack size exceeded';
 
+  // Module loading errors
+  // Names no module address on purpose: the only address available where this
+  // is raised is the resolved one, which the default resolver expands against
+  // the host filesystem. See Goccia.Modules.Errors.
+  SErrorModuleLoadingUnsupported = 'Cannot load module: no module content provider is configured';
+
   // Uint8Array encoding errors
   SErrorRequiresUint8Array = '%s requires that |this| be a Uint8Array';
   SErrorInvalidAlphabet = 'Invalid alphabet: expected "base64" or "base64url"';

--- a/source/units/Goccia.Error.Suggestions.pas
+++ b/source/units/Goccia.Error.Suggestions.pas
@@ -111,6 +111,7 @@ resourcestring
   // Imports and exports
   SSuggestImportMetaSyntax = 'Use import.meta to access module metadata (e.g., import.meta.url)';
   SSuggestDynamicImportSyntax = 'Use import("./module-path") to dynamically load a module';
+  SSuggestConfigureModuleContentProvider = 'Install a module content provider on the engine (or attach a runtime) before importing modules';
   SSuggestStringImportAs = 'Use: import { "name" as localName } from "module"';
   SSuggestStringExportAs = 'Use: export { localName as "export-name" }';
   SSuggestDestructuringExportDeclareFirst = 'Declare first, then export: const x = ...; export { x };';

--- a/source/units/Goccia.Modules.ContentProvider.Test.pas
+++ b/source/units/Goccia.Modules.ContentProvider.Test.pas
@@ -16,8 +16,10 @@ uses
   Goccia.Arguments.Collection,
   Goccia.AST.Node,
   Goccia.Bytecode.Module,
+  Goccia.Constants.ErrorNames,
   Goccia.Constants.PropertyNames,
   Goccia.Engine,
+  Goccia.Error,
   Goccia.Executor,
   Goccia.Executor.Bytecode,
   Goccia.Executor.Interpreter,
@@ -26,6 +28,7 @@ uses
   Goccia.Lexer,
   Goccia.Modules,
   Goccia.Modules.ContentProvider,
+  Goccia.Modules.Errors,
   Goccia.Modules.Loader,
   Goccia.Modules.Resolver,
   Goccia.Parser,
@@ -86,6 +89,18 @@ type
       const AExecutor: TGocciaExecutor);
     procedure AssertReloadedModuleRetargetsCachedImport(
       const AExecutor: TGocciaExecutor);
+    procedure AssertUnavailableProviderRejectsDynamicImport(
+      const AExecutor: TGocciaExecutor);
+    procedure AssertUnavailableProviderStaticImportThrowsError(
+      const AExecutor: TGocciaExecutor);
+    procedure AssertConfiguredProviderFailureStaysDistinct(
+      const AExecutor: TGocciaExecutor);
+    procedure AssertDefaultResolverRefusesResolvedModule(
+      const AExecutor: TGocciaExecutor);
+    procedure AssertDefaultResolverStaticImportFailsBeforeProvider(
+      const AExecutor: TGocciaExecutor);
+    procedure AssertDefaultResolverDynamicImportFailsBeforeProvider(
+      const AExecutor: TGocciaExecutor);
 
     procedure TestEngineLoadsInMemoryModuleWithCustomProvider;
     procedure TestEngineRetriesModuleAfterFailedLoad;
@@ -102,6 +117,12 @@ type
     procedure TestModuleLoaderRejectsRebindingAcrossRuntimes;
     procedure TestBytecodeExecutorUsesInjectedContentProvider;
     procedure TestEngineModuleManifestDefaultsToEntryPath;
+    procedure TestUnavailableProviderRejectsDynamicImport;
+    procedure TestUnavailableProviderStaticImportThrowsError;
+    procedure TestConfiguredProviderFailureStaysDistinct;
+    procedure TestDefaultResolverRefusesResolvedModule;
+    procedure TestDefaultResolverStaticImportFailsBeforeProvider;
+    procedure TestDefaultResolverDynamicImportFailsBeforeProvider;
   protected
     procedure BeforeAll; override;
     procedure AfterAll; override;
@@ -205,6 +226,18 @@ begin
     TestBytecodeExecutorUsesInjectedContentProvider);
   Test('Engine module manifest defaults relative addresses to the entry path',
     TestEngineModuleManifestDefaultsToEntryPath);
+  Test('Unconfigured content provider rejects dynamic import with a coded Error',
+    TestUnavailableProviderRejectsDynamicImport);
+  Test('Unconfigured content provider reports static imports as JavaScript errors',
+    TestUnavailableProviderStaticImportThrowsError);
+  Test('Configured content provider failures stay distinct from an absent provider',
+    TestConfiguredProviderFailureStaysDistinct);
+  Test('Default resolver refuses a resolved module without leaking its host address',
+    TestDefaultResolverRefusesResolvedModule);
+  Test('Default resolver fails a static import before the provider is consulted',
+    TestDefaultResolverStaticImportFailsBeforeProvider);
+  Test('Default resolver rejects a dynamic import with no module loading code',
+    TestDefaultResolverDynamicImportFailsBeforeProvider);
 end;
 
 procedure TModuleContentProviderTests.BeforeAll;
@@ -1195,6 +1228,526 @@ begin
     Provider.Free;
     ExecutorB.Free;
     ExecutorA.Free;
+  end;
+end;
+
+{ The catch block records primitives only, so the assertions below never depend
+  on the error object outliving the microtask drain. `code` and `path` are
+  stringified so an absent one is observable as "undefined" rather than reading
+  as a missing property, and `serialized` captures exactly what an enumerable
+  own property would expose to the source that caught the error. }
+function DynamicImportProbeSource(const AModulePath: string): string;
+begin
+  Result :=
+    'const outcome = { stage: "pending" };' + sLineBreak +
+    '(async () => {' + sLineBreak +
+    '  try {' + sLineBreak +
+    '    await import("' + AModulePath + '");' + sLineBreak +
+    '    outcome.stage = "resolved";' + sLineBreak +
+    '  } catch (error) {' + sLineBreak +
+    '    outcome.stage = "caught";' + sLineBreak +
+    '    outcome.name = error.name;' + sLineBreak +
+    '    outcome.code = String(error.code);' + sLineBreak +
+    '    outcome.message = error.message;' + sLineBreak +
+    '    outcome.path = String(error.path);' + sLineBreak +
+    '    outcome.hasOwnPath =' + sLineBreak +
+    '      Object.prototype.hasOwnProperty.call(error, "path");' + sLineBreak +
+    '    outcome.serialized = JSON.stringify(error);' + sLineBreak +
+    '    outcome.isError = error instanceof Error;' + sLineBreak +
+    '    outcome.isTypeError = error instanceof TypeError;' + sLineBreak +
+    '  }' + sLineBreak +
+    '})();' + sLineBreak +
+    'outcome;';
+end;
+
+function TryExtractThrownValue(const AException: Exception;
+  out AValue: TGocciaValue): Boolean;
+begin
+  AValue := nil;
+  if AException is TGocciaThrowValue then
+    AValue := TGocciaThrowValue(AException).Value
+  else if AException is EGocciaBytecodeThrow then
+    AValue := EGocciaBytecodeThrow(AException).ThrownValue;
+  Result := Assigned(AValue);
+end;
+
+procedure TModuleContentProviderTests.AssertUnavailableProviderRejectsDynamicImport(
+  const AExecutor: TGocciaExecutor);
+const
+  ENTRY_PATH = 'memory:/app.mjs';
+  MODULE_PATH = 'memory:/dep.js';
+  OUTCOME_STAGE = 'stage';
+  OUTCOME_HAS_OWN_PATH = 'hasOwnPath';
+  OUTCOME_IS_ERROR = 'isError';
+  OUTCOME_IS_TYPE_ERROR = 'isTypeError';
+  UNDEFINED_TEXT = 'undefined';
+var
+  Engine: TGocciaEngine;
+  ModuleLoader: TGocciaModuleLoader;
+  Outcome: TGocciaObjectValue;
+  Resolver: TInMemoryModuleResolver;
+  ScriptResult: TGocciaScriptResult;
+  Source: TStringList;
+begin
+  Resolver := TInMemoryModuleResolver.Create;
+  Source := TStringList.Create;
+  try
+    Source.Text := DynamicImportProbeSource(MODULE_PATH);
+
+    ModuleLoader := TGocciaModuleLoader.Create(ENTRY_PATH, Resolver, nil);
+    try
+      Engine := TGocciaEngine.Create(ENTRY_PATH, Source, ModuleLoader,
+        AExecutor);
+      try
+        ScriptResult := Engine.Execute;
+
+        Expect<Boolean>(ScriptResult.Result is TGocciaObjectValue).ToBe(True);
+        Outcome := TGocciaObjectValue(ScriptResult.Result);
+        Expect<string>(Outcome.GetProperty(OUTCOME_STAGE).ToStringLiteral.Value)
+          .ToBe('caught');
+        Expect<string>(Outcome.GetProperty(PROP_NAME).ToStringLiteral.Value)
+          .ToBe(ERROR_NAME);
+        { Spelled out rather than compared against the constant: hosts branch on
+          this exact text, so editing the constant's value must fail a test. }
+        Expect<string>(Outcome.GetProperty(PROP_CODE).ToStringLiteral.Value)
+          .ToBe('ERR_MODULE_LOADING_UNSUPPORTED');
+        Expect<string>(Outcome.GetProperty(PROP_MESSAGE).ToStringLiteral.Value)
+          .ToBe('Cannot load module: no module content provider is configured');
+        { The refusal names no module address, so nothing derived from the
+          resolver — a host filesystem path in the default configuration —
+          reaches the source that caught it. }
+        Expect<string>(Outcome.GetProperty(PROP_PATH).ToStringLiteral.Value)
+          .ToBe(UNDEFINED_TEXT);
+        Expect<Boolean>(
+          Outcome.GetProperty(OUTCOME_HAS_OWN_PATH).ToBooleanLiteral.Value)
+          .ToBe(False);
+        Expect<Boolean>(Pos(MODULE_PATH,
+          Outcome.GetProperty(PROP_MESSAGE).ToStringLiteral.Value) > 0)
+          .ToBe(False);
+        Expect<Boolean>(
+          Outcome.GetProperty(OUTCOME_IS_ERROR).ToBooleanLiteral.Value)
+          .ToBe(True);
+        Expect<Boolean>(
+          Outcome.GetProperty(OUTCOME_IS_TYPE_ERROR).ToBooleanLiteral.Value)
+          .ToBe(False);
+      finally
+        Engine.Free;
+      end;
+    finally
+      ModuleLoader.Free;
+    end;
+  finally
+    Source.Free;
+    Resolver.Free;
+  end;
+end;
+
+procedure TModuleContentProviderTests.AssertUnavailableProviderStaticImportThrowsError(
+  const AExecutor: TGocciaExecutor);
+const
+  ENTRY_PATH = 'memory:/app.mjs';
+  MODULE_PATH = 'memory:/dep.js';
+var
+  Engine: TGocciaEngine;
+  ErrorObject: TGocciaObjectValue;
+  FailureDescription: string;
+  ModuleLoader: TGocciaModuleLoader;
+  Resolver: TInMemoryModuleResolver;
+  Source: TStringList;
+  ThrownValue: TGocciaValue;
+begin
+  Resolver := TInMemoryModuleResolver.Create;
+  Source := TStringList.Create;
+  try
+    Source.Text := 'import { value } from "' + MODULE_PATH + '";' +
+      sLineBreak + 'value;';
+
+    ModuleLoader := TGocciaModuleLoader.Create(ENTRY_PATH, Resolver, nil);
+    try
+      Engine := TGocciaEngine.Create(ENTRY_PATH, Source, ModuleLoader,
+        AExecutor);
+      try
+        ThrownValue := nil;
+        FailureDescription := '';
+        try
+          Engine.Execute;
+          FailureDescription := 'no exception was raised';
+        except
+          on E: Exception do
+            if not TryExtractThrownValue(E, ThrownValue) then
+              FailureDescription := E.ClassName + ': ' + E.Message;
+        end;
+
+        { An RTL exception here would mean the refusal crossed the embedder's
+          engine boundary as a Pascal error instead of a JavaScript one. }
+        if FailureDescription <> '' then
+          Fail('Expected a JavaScript throw, got ' + FailureDescription);
+
+        Expect<Boolean>(ThrownValue is TGocciaObjectValue).ToBe(True);
+        ErrorObject := TGocciaObjectValue(ThrownValue);
+        Expect<string>(ErrorObject.GetProperty(PROP_NAME).ToStringLiteral.Value)
+          .ToBe(ERROR_NAME);
+        Expect<string>(ErrorObject.GetProperty(PROP_CODE).ToStringLiteral.Value)
+          .ToBe(MODULE_ERROR_CODE_LOADING_UNSUPPORTED);
+        Expect<Boolean>(ErrorObject.HasOwnProperty(PROP_PATH)).ToBe(False);
+        Expect<Boolean>(Pos(MODULE_PATH,
+          ErrorObject.GetProperty(PROP_MESSAGE).ToStringLiteral.Value) > 0)
+          .ToBe(False);
+      finally
+        Engine.Free;
+      end;
+    finally
+      ModuleLoader.Free;
+    end;
+  finally
+    Source.Free;
+    Resolver.Free;
+  end;
+end;
+
+procedure TModuleContentProviderTests.AssertConfiguredProviderFailureStaysDistinct(
+  const AExecutor: TGocciaExecutor);
+const
+  ENTRY_PATH = 'memory:/app.mjs';
+  MISSING_MODULE_PATH = 'memory:/absent.js';
+  PRESENT_MODULE_PATH = 'memory:/present.js';
+  OUTCOME_STAGE = 'stage';
+  UNDEFINED_TEXT = 'undefined';
+var
+  Engine: TGocciaEngine;
+  ModuleLoader: TGocciaModuleLoader;
+  Outcome: TGocciaObjectValue;
+  Provider: TMemoryModuleContentProvider;
+  Resolver: TInMemoryModuleResolver;
+  ScriptResult: TGocciaScriptResult;
+  Source: TStringList;
+begin
+  Provider := TMemoryModuleContentProvider.Create;
+  Resolver := TInMemoryModuleResolver.Create;
+  Source := TStringList.Create;
+  try
+    Provider.AddModule(PRESENT_MODULE_PATH, 'export const value = 1;');
+    Source.Text := DynamicImportProbeSource(MISSING_MODULE_PATH);
+
+    ModuleLoader := TGocciaModuleLoader.Create(ENTRY_PATH, Resolver, Provider);
+    try
+      Engine := TGocciaEngine.Create(ENTRY_PATH, Source, ModuleLoader,
+        AExecutor);
+      try
+        ScriptResult := Engine.Execute;
+
+        Expect<Boolean>(ScriptResult.Result is TGocciaObjectValue).ToBe(True);
+        Outcome := TGocciaObjectValue(ScriptResult.Result);
+        Expect<string>(Outcome.GetProperty(OUTCOME_STAGE).ToStringLiteral.Value)
+          .ToBe('caught');
+        { A provider that was configured and could not produce the module is a
+          different condition, so it must not borrow the absent-provider code. }
+        Expect<string>(Outcome.GetProperty(PROP_CODE).ToStringLiteral.Value)
+          .ToBe(UNDEFINED_TEXT);
+      finally
+        Engine.Free;
+      end;
+    finally
+      ModuleLoader.Free;
+    end;
+  finally
+    Source.Free;
+    Resolver.Free;
+    Provider.Free;
+  end;
+end;
+
+{ The tests above drive TInMemoryModuleResolver, whose Resolve returns the
+  specifier verbatim. The three below use the DEFAULT resolver the loader
+  creates when none is injected — the configuration an embedder actually gets
+  from AttachRuntime(Engine, False) — which expands specifiers against the real
+  host filesystem before any provider is consulted. }
+procedure TModuleContentProviderTests.AssertDefaultResolverRefusesResolvedModule(
+  const AExecutor: TGocciaExecutor);
+const
+  OUTCOME_STAGE = 'stage';
+  OUTCOME_HAS_OWN_PATH = 'hasOwnPath';
+  OUTCOME_SERIALIZED = 'serialized';
+  UNDEFINED_TEXT = 'undefined';
+var
+  Engine: TGocciaEngine;
+  EntryPath, ModulePath, TempDirectory: string;
+  ModuleLoader: TGocciaModuleLoader;
+  Outcome: TGocciaObjectValue;
+  ScriptResult: TGocciaScriptResult;
+  Source: TStringList;
+begin
+  TempDirectory := CreateTempDirectory;
+  EntryPath := IncludeTrailingPathDelimiter(TempDirectory) + 'app.mjs';
+  ModulePath := IncludeTrailingPathDelimiter(TempDirectory) + 'dep.js';
+  { The file exists so the specifier resolves; this is the only branch that
+    reaches the provider, and therefore the only one that carries the code. }
+  WriteTextFile(ModulePath, 'export const value = 1;');
+
+  Source := TStringList.Create;
+  try
+    Source.Text := DynamicImportProbeSource('./dep.js');
+
+    ModuleLoader := TGocciaModuleLoader.Create(EntryPath, nil, nil);
+    try
+      Engine := TGocciaEngine.Create(EntryPath, Source, ModuleLoader,
+        AExecutor);
+      try
+        ScriptResult := Engine.Execute;
+
+        Expect<Boolean>(ScriptResult.Result is TGocciaObjectValue).ToBe(True);
+        Outcome := TGocciaObjectValue(ScriptResult.Result);
+        Expect<string>(Outcome.GetProperty(OUTCOME_STAGE).ToStringLiteral.Value)
+          .ToBe('caught');
+        Expect<string>(Outcome.GetProperty(PROP_CODE).ToStringLiteral.Value)
+          .ToBe('ERR_MODULE_LOADING_UNSUPPORTED');
+        { The resolved address is an absolute host path here, so the refusal
+          must expose it neither as a property nor through the message nor in
+          what JSON.stringify hands back to the source that caught it. }
+        Expect<string>(Outcome.GetProperty(PROP_PATH).ToStringLiteral.Value)
+          .ToBe(UNDEFINED_TEXT);
+        Expect<Boolean>(
+          Outcome.GetProperty(OUTCOME_HAS_OWN_PATH).ToBooleanLiteral.Value)
+          .ToBe(False);
+        Expect<Boolean>(Pos(TempDirectory,
+          Outcome.GetProperty(PROP_MESSAGE).ToStringLiteral.Value) > 0)
+          .ToBe(False);
+        Expect<Boolean>(Pos(TempDirectory,
+          Outcome.GetProperty(OUTCOME_SERIALIZED).ToStringLiteral.Value) > 0)
+          .ToBe(False);
+      finally
+        Engine.Free;
+      end;
+    finally
+      ModuleLoader.Free;
+    end;
+  finally
+    Source.Free;
+  end;
+end;
+
+procedure TModuleContentProviderTests.AssertDefaultResolverStaticImportFailsBeforeProvider(
+  const AExecutor: TGocciaExecutor);
+var
+  Engine: TGocciaEngine;
+  EntryPath, FailureDescription, RaisedMessage, TempDirectory: string;
+  IsHostRuntimeError, IsJavaScriptThrow: Boolean;
+  ModuleLoader: TGocciaModuleLoader;
+  Source: TStringList;
+  ThrownValue: TGocciaValue;
+begin
+  TempDirectory := CreateTempDirectory;
+  EntryPath := IncludeTrailingPathDelimiter(TempDirectory) + 'app.mjs';
+
+  Source := TStringList.Create;
+  try
+    Source.Text := 'import { value } from "./absent.js";' + sLineBreak +
+      'value;';
+
+    ModuleLoader := TGocciaModuleLoader.Create(EntryPath, nil, nil);
+    try
+      Engine := TGocciaEngine.Create(EntryPath, Source, ModuleLoader,
+        AExecutor);
+      try
+        FailureDescription := '';
+        IsHostRuntimeError := False;
+        IsJavaScriptThrow := False;
+        RaisedMessage := '';
+        try
+          Engine.Execute;
+          FailureDescription := 'no exception was raised';
+        except
+          on E: Exception do
+          begin
+            RaisedMessage := E.Message;
+            IsHostRuntimeError := E is TGocciaRuntimeError;
+            IsJavaScriptThrow := TryExtractThrownValue(E, ThrownValue);
+          end;
+        end;
+
+        if FailureDescription <> '' then
+          Fail('Expected the resolver to reject the specifier, but ' +
+            FailureDescription);
+
+        { Resolution runs before retrieval, so this never reaches the absent
+          provider and never carries its code. An embedder therefore still has
+          to guard its engine boundary: the failure crosses it as the host
+          exception documented in docs/errors.md, not as a catchable JavaScript
+          error. }
+        Expect<Boolean>(IsJavaScriptThrow).ToBe(False);
+        Expect<Boolean>(IsHostRuntimeError).ToBe(True);
+        Expect<Boolean>(Pos('Module not found', RaisedMessage) > 0).ToBe(True);
+      finally
+        Engine.Free;
+      end;
+    finally
+      ModuleLoader.Free;
+    end;
+  finally
+    Source.Free;
+  end;
+end;
+
+procedure TModuleContentProviderTests.AssertDefaultResolverDynamicImportFailsBeforeProvider(
+  const AExecutor: TGocciaExecutor);
+const
+  OUTCOME_STAGE = 'stage';
+  UNDEFINED_TEXT = 'undefined';
+var
+  Engine: TGocciaEngine;
+  EntryPath, TempDirectory: string;
+  ModuleLoader: TGocciaModuleLoader;
+  Outcome: TGocciaObjectValue;
+  ScriptResult: TGocciaScriptResult;
+  Source: TStringList;
+begin
+  TempDirectory := CreateTempDirectory;
+  EntryPath := IncludeTrailingPathDelimiter(TempDirectory) + 'app.mjs';
+
+  Source := TStringList.Create;
+  try
+    Source.Text := DynamicImportProbeSource('./absent.js');
+
+    ModuleLoader := TGocciaModuleLoader.Create(EntryPath, nil, nil);
+    try
+      Engine := TGocciaEngine.Create(EntryPath, Source, ModuleLoader,
+        AExecutor);
+      try
+        ScriptResult := Engine.Execute;
+
+        Expect<Boolean>(ScriptResult.Result is TGocciaObjectValue).ToBe(True);
+        Outcome := TGocciaObjectValue(ScriptResult.Result);
+        Expect<string>(Outcome.GetProperty(OUTCOME_STAGE).ToStringLiteral.Value)
+          .ToBe('caught');
+        { A resolution failure is a different condition from an absent
+          provider, so a host branching on the code must not see it here. }
+        Expect<string>(Outcome.GetProperty(PROP_CODE).ToStringLiteral.Value)
+          .ToBe(UNDEFINED_TEXT);
+        Expect<Boolean>(Pos('Module not found',
+          Outcome.GetProperty(PROP_MESSAGE).ToStringLiteral.Value) > 0)
+          .ToBe(True);
+      finally
+        Engine.Free;
+      end;
+    finally
+      ModuleLoader.Free;
+    end;
+  finally
+    Source.Free;
+  end;
+end;
+
+procedure TModuleContentProviderTests.TestUnavailableProviderRejectsDynamicImport;
+var
+  Executor: TGocciaExecutor;
+begin
+  Executor := TGocciaInterpreterExecutor.Create;
+  try
+    AssertUnavailableProviderRejectsDynamicImport(Executor);
+  finally
+    Executor.Free;
+  end;
+
+  Executor := TGocciaBytecodeExecutor.Create;
+  try
+    AssertUnavailableProviderRejectsDynamicImport(Executor);
+  finally
+    Executor.Free;
+  end;
+end;
+
+procedure TModuleContentProviderTests.TestUnavailableProviderStaticImportThrowsError;
+var
+  Executor: TGocciaExecutor;
+begin
+  Executor := TGocciaInterpreterExecutor.Create;
+  try
+    AssertUnavailableProviderStaticImportThrowsError(Executor);
+  finally
+    Executor.Free;
+  end;
+
+  Executor := TGocciaBytecodeExecutor.Create;
+  try
+    AssertUnavailableProviderStaticImportThrowsError(Executor);
+  finally
+    Executor.Free;
+  end;
+end;
+
+procedure TModuleContentProviderTests.TestConfiguredProviderFailureStaysDistinct;
+var
+  Executor: TGocciaExecutor;
+begin
+  Executor := TGocciaInterpreterExecutor.Create;
+  try
+    AssertConfiguredProviderFailureStaysDistinct(Executor);
+  finally
+    Executor.Free;
+  end;
+
+  Executor := TGocciaBytecodeExecutor.Create;
+  try
+    AssertConfiguredProviderFailureStaysDistinct(Executor);
+  finally
+    Executor.Free;
+  end;
+end;
+
+procedure TModuleContentProviderTests.TestDefaultResolverRefusesResolvedModule;
+var
+  Executor: TGocciaExecutor;
+begin
+  Executor := TGocciaInterpreterExecutor.Create;
+  try
+    AssertDefaultResolverRefusesResolvedModule(Executor);
+  finally
+    Executor.Free;
+  end;
+
+  Executor := TGocciaBytecodeExecutor.Create;
+  try
+    AssertDefaultResolverRefusesResolvedModule(Executor);
+  finally
+    Executor.Free;
+  end;
+end;
+
+procedure TModuleContentProviderTests.TestDefaultResolverStaticImportFailsBeforeProvider;
+var
+  Executor: TGocciaExecutor;
+begin
+  Executor := TGocciaInterpreterExecutor.Create;
+  try
+    AssertDefaultResolverStaticImportFailsBeforeProvider(Executor);
+  finally
+    Executor.Free;
+  end;
+
+  Executor := TGocciaBytecodeExecutor.Create;
+  try
+    AssertDefaultResolverStaticImportFailsBeforeProvider(Executor);
+  finally
+    Executor.Free;
+  end;
+end;
+
+procedure TModuleContentProviderTests.TestDefaultResolverDynamicImportFailsBeforeProvider;
+var
+  Executor: TGocciaExecutor;
+begin
+  Executor := TGocciaInterpreterExecutor.Create;
+  try
+    AssertDefaultResolverDynamicImportFailsBeforeProvider(Executor);
+  finally
+    Executor.Free;
+  end;
+
+  Executor := TGocciaBytecodeExecutor.Create;
+  try
+    AssertDefaultResolverDynamicImportFailsBeforeProvider(Executor);
+  finally
+    Executor.Free;
   end;
 end;
 

--- a/source/units/Goccia.Modules.ContentProvider.pas
+++ b/source/units/Goccia.Modules.ContentProvider.pas
@@ -64,6 +64,7 @@ uses
   TextEncoding,
   TextSemantics,
 
+  Goccia.Modules.Errors,
   Goccia.TextFiles;
 
 function TryGetFileLastModified(const APath: string;
@@ -133,8 +134,16 @@ end;
 function TGocciaUnavailableModuleContentProvider.LoadContent(
   const APath: string): TGocciaModuleContent;
 begin
-  raise EStreamError.Create(
-    'No module content provider configured for: ' + APath);
+  { An embedder that runs untrusted source without installing a provider must
+    not get an RTL exception through its engine boundary, so the refusal is
+    reported to source as a plain Error carrying a stable code. LoadContentBytes
+    inherits this: the base implementation calls LoadContent first.
+
+    APath is deliberately dropped: it is the resolved address, which the default
+    resolver expands against the host filesystem, and this refusal is reported
+    to potentially untrusted source. See Goccia.Modules.Errors. }
+  Result := nil;
+  ThrowModuleLoadingUnsupported;
 end;
 
 function TGocciaUnavailableModuleContentProvider.TryGetLastModified(

--- a/source/units/Goccia.Modules.Errors.Test.pas
+++ b/source/units/Goccia.Modules.Errors.Test.pas
@@ -1,0 +1,126 @@
+program Goccia.Modules.Errors.Test;
+
+{$I Goccia.inc}
+
+uses
+  SysUtils,
+
+  TestingPascalLibrary,
+
+  Goccia.Constants.PropertyNames,
+  Goccia.Error.Suggestions,
+  Goccia.Modules.Errors,
+  Goccia.TestSetup,
+  Goccia.Values.Error,
+  Goccia.Values.ObjectValue;
+
+type
+  TModuleErrorTests = class(TTestSuite)
+  private
+    procedure TestCarriesTheStableCode;
+    procedure TestOmitsTheResolvedModuleAddress;
+    procedure TestThrowsAsAScriptVisibleValue;
+  public
+    procedure SetupTests; override;
+  end;
+
+const
+  { Spelled out rather than taken from Goccia.Modules.Errors: hosts branch on
+    this exact text, so a test that compared against the constant would stay
+    green while the value changed underneath every one of them. }
+  EXPECTED_CODE = 'ERR_MODULE_LOADING_UNSUPPORTED';
+  EXPECTED_MESSAGE =
+    'Cannot load module: no module content provider is configured';
+
+procedure TModuleErrorTests.SetupTests;
+begin
+  Test('Carries the stable module loading code',
+    TestCarriesTheStableCode);
+  Test('Omits the resolved module address',
+    TestOmitsTheResolvedModuleAddress);
+  Test('Throws as a script-visible value with a host suggestion',
+    TestThrowsAsAScriptVisibleValue);
+end;
+
+procedure TModuleErrorTests.TestCarriesTheStableCode;
+var
+  ErrorObject: TGocciaObjectValue;
+begin
+  ErrorObject := CreateModuleLoadingUnsupportedError;
+  try
+    Expect<Boolean>(ErrorObject.HasErrorData).ToBe(True);
+    { A plain Error, not a TypeError: TypeError is the convention for a
+      configured loader that tried and failed. }
+    Expect<string>(ErrorObject.GetProperty(PROP_NAME).ToStringLiteral.Value)
+      .ToBe('Error');
+    Expect<string>(ErrorObject.GetProperty(PROP_CODE).ToStringLiteral.Value)
+      .ToBe(EXPECTED_CODE);
+    Expect<string>(ErrorObject.GetProperty(PROP_MESSAGE).ToStringLiteral.Value)
+      .ToBe(EXPECTED_MESSAGE);
+  finally
+    ErrorObject.Free;
+  end;
+end;
+
+procedure TModuleErrorTests.TestOmitsTheResolvedModuleAddress;
+var
+  ErrorObject: TGocciaObjectValue;
+begin
+  ErrorObject := CreateModuleLoadingUnsupportedError;
+  try
+    { The refusal is reported to potentially untrusted source, and the only
+      address available where it is raised is the resolved one — an absolute
+      host filesystem path under the default resolver. An enumerable own `path`
+      would carry it into JSON.stringify(error) and object spread, so there is
+      none, and the message names no address either. }
+    Expect<Boolean>(ErrorObject.HasOwnProperty(PROP_PATH)).ToBe(False);
+    Expect<Boolean>(Pos('/',
+      ErrorObject.GetProperty(PROP_MESSAGE).ToStringLiteral.Value) > 0)
+      .ToBe(False);
+  finally
+    ErrorObject.Free;
+  end;
+end;
+
+procedure TModuleErrorTests.TestThrowsAsAScriptVisibleValue;
+var
+  ErrorObject: TGocciaObjectValue;
+  Raised: Boolean;
+  Suggestion: string;
+begin
+  ErrorObject := nil;
+  Raised := False;
+  Suggestion := '';
+  try
+    ThrowModuleLoadingUnsupported;
+  except
+    { Not an RTL exception class: an embedder running untrusted source with no
+      provider must be able to let source catch this instead of unwinding
+      through its engine boundary. }
+    on E: TGocciaThrowValue do
+    begin
+      Raised := True;
+      Suggestion := E.Suggestion;
+      if E.Value is TGocciaObjectValue then
+        ErrorObject := TGocciaObjectValue(E.Value);
+    end;
+  end;
+
+  Expect<Boolean>(Raised).ToBe(True);
+  Expect<Boolean>(Assigned(ErrorObject)).ToBe(True);
+  Expect<string>(Suggestion).ToBe(SSuggestConfigureModuleContentProvider);
+  if Assigned(ErrorObject) then
+  try
+    Expect<string>(ErrorObject.GetProperty(PROP_CODE).ToStringLiteral.Value)
+      .ToBe(EXPECTED_CODE);
+  finally
+    ErrorObject.Free;
+  end;
+end;
+
+begin
+  TestRunnerProgram.AddSuite(
+    TModuleErrorTests.Create('ModuleErrors'));
+  RunGocciaTests;
+  ExitCode := TestResultToExitCode;
+end.

--- a/source/units/Goccia.Modules.Errors.pas
+++ b/source/units/Goccia.Modules.Errors.pas
@@ -1,0 +1,72 @@
+unit Goccia.Modules.Errors;
+
+{$I Goccia.inc}
+
+interface
+
+uses
+  Goccia.Values.ObjectValue;
+
+const
+  { Stable `code` for a module load attempted on an engine that was never given
+    a module content provider.
+
+    ECMA-262 sec-HostLoadImportedModule (ES2026 §16.2.1.10) requires a throw
+    completion but mandates no error type, and for this exact case the major
+    engines agree on a plain Error: V8 rejects with "Not supported" when no host
+    import callback is set, JavaScriptCore's default loader with "Could not open
+    the module", and SpiderMonkey with "Module load hook not set". TypeError is
+    the convention for a *configured* loader that tried and failed (HTML, Deno),
+    which is a different condition — so the constructor cannot separate the two
+    and the code is what a host branches on. A future provider-backed "module
+    not found" must therefore carry its own code, never this one. }
+  MODULE_ERROR_CODE_LOADING_UNSUPPORTED = 'ERR_MODULE_LOADING_UNSUPPORTED';
+
+{ Builds the plain Error reported when a module load is attempted with no
+  content provider configured, carrying the stable `code` above.
+
+  It deliberately carries no `path`, and names no module address in its message.
+  The only address available at the refusal site is the *resolved* one: refusal
+  happens inside the content provider, which is only ever handed the address the
+  resolver produced, and the default TGocciaModuleResolver expands every
+  specifier against the real host filesystem. An engine with no provider is
+  exactly the configuration an embedder runs untrusted source in, so a
+  structured, enumerable `path` — visible to that source through
+  JSON.stringify(error) and object spread — would hand it a host layout detail
+  it did not supply. The specifier as written is not reachable from here without
+  widening the provider interface, and the address adds nothing diagnostically:
+  with no provider installed the refusal is unconditional for every module, so
+  the fix never depends on which one was requested. Contrast ADR 0092, where
+  `path` carries a sandbox VFS address the guest itself named. }
+function CreateModuleLoadingUnsupportedError: TGocciaObjectValue;
+
+{ Raises that Error as a script-visible throw, so `import()` rejects with it and
+  a static import surfaces it as a JavaScript error rather than letting an RTL
+  exception cross the embedder's engine boundary. }
+procedure ThrowModuleLoadingUnsupported;
+
+implementation
+
+uses
+  Goccia.Constants.ErrorNames,
+  Goccia.Constants.PropertyNames,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
+  Goccia.Values.Error,
+  Goccia.Values.ErrorHelper,
+  Goccia.Values.Primitives;
+
+function CreateModuleLoadingUnsupportedError: TGocciaObjectValue;
+begin
+  Result := CreateErrorObject(ERROR_NAME, SErrorModuleLoadingUnsupported);
+  Result.AssignProperty(PROP_CODE, TGocciaStringLiteralValue.Create(
+    MODULE_ERROR_CODE_LOADING_UNSUPPORTED));
+end;
+
+procedure ThrowModuleLoadingUnsupported;
+begin
+  raise TGocciaThrowValue.Create(CreateModuleLoadingUnsupportedError,
+    SSuggestConfigureModuleContentProvider);
+end;
+
+end.


### PR DESCRIPTION
## Summary

Reports a missing module content provider as a script-catchable coded `Error` instead of a raw RTL `EStreamError` crossing the engine boundary. Layer 6; stacked on #1135.

With no provider configured, an `import` escaped as `EStreamError` — a Pascal exception an embedder saw at its boundary rather than a catchable error. It now throws a plain JavaScript `Error` with `code: ERR_MODULE_LOADING_UNSUPPORTED`, matching the no-loader convention V8, JavaScriptCore, and SpiderMonkey all use. `TypeError` is the convention for a *configured* loader that failed — a different condition kept distinct via the `code`. ECMA-262 §16.2.1.10 mandates no type, so convention governs; evidence in ADR 0106.

### Review-driven

The error carries **only** the code — the resolved host path is dropped from both the `path` property and the message, because the no-provider case is precisely the sandboxed-embedder one and the refusal is unconditional while no provider is installed. The docs were corrected to stop overclaiming: resolution runs before retrieval, so a specifier the resolver rejects still fails without the code, and embedders keep their boundary guard. A stale `GocciaFuzzHarness` comment (from #1130) describing the old behaviour is fixed here.

## Testing

- [x] JS suite 12143/12143 both modes · new `Goccia.Modules.Errors.Test` · `test-cli-apps.ts` · docs gates
- [x] Tests assert the literal code string and that `path` is absent from the error, its own properties, and its serialization, in both modes.
