### PR TITLE
fix(sandbox): clear pending work on memory-limit unwind, bound AFL timeout, specify pipe I/O

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -95,8 +95,12 @@ jobs:
           mkdir -p build/fuzz/out
           # -n: non-instrumented. AFL_SKIP_CPUFREQ/AFL_NO_AFFINITY are the
           # standard CI accommodations for shared runners.
+          # -t 5000: the harness's own budget is 1000ms and a harness timeout
+          # is a NORMAL exit-0 outcome, so AFL's exec threshold must sit safely
+          # above it — otherwise process overhead around a legitimate slow input
+          # lands it in hangs/ and false-fails the job.
           AFL_SKIP_CPUFREQ=1 AFL_NO_AFFINITY=1 AFL_BENCH_UNTIL_CRASH=1 \
-          timeout "${FUZZ_SECONDS}" afl-fuzz -n \
+          timeout "${FUZZ_SECONDS}" afl-fuzz -n -t 5000 \
             -i build/fuzz/corpus \
             -o build/fuzz/out \
             -- ./build/GocciaFuzzHarness @@ || true

--- a/docs/adr/0107-out-of-process-sandbox-protocol.md
+++ b/docs/adr/0107-out-of-process-sandbox-protocol.md
@@ -143,6 +143,16 @@ directions carry **length-prefixed frames**. There is no shared memory in v1.
   (`--fs-quota-bytes`) large enough to inflate the baseline is the common cause,
   but the check is on the whole frame so no field can silently push the request
   over. With the default configuration this cannot happen.
+- **Exact-length pipe I/O:** a successful pipe `read` or `write` may transfer
+  fewer bytes than requested — that is normal pipe behaviour, not an error. Both
+  sides therefore read and write the 4-byte prefix and the payload in
+  **exact-length loops**: continue issuing the operation for the remaining bytes
+  until the requested count has been transferred, EOF is reached, or a genuine
+  error occurs. `EINTR` (and `EAGAIN` when non-blocking descriptors are used) is
+  retried, never surfaced. Only after EOF or a genuine error does the failure
+  taxonomy apply (§4): a short read is never itself classified — a prefix or
+  payload cut short by EOF is an incomplete frame (`sfkChildProcessCrash` when
+  reading from the child; `sfkHostError` when the parent's own write fails).
 - **Single-frame, non-streaming:** each direction sends exactly one frame per
   run. There is no framing for incremental or streamed output in v1; streaming
   frames are an out-of-scope follow-up (§7).

--- a/docs/adr/0107-out-of-process-sandbox-protocol.md
+++ b/docs/adr/0107-out-of-process-sandbox-protocol.md
@@ -148,8 +148,15 @@ directions carry **length-prefixed frames**. There is no shared memory in v1.
   sides therefore read and write the 4-byte prefix and the payload in
   **exact-length loops**: continue issuing the operation for the remaining bytes
   until the requested count has been transferred, EOF is reached, or a genuine
-  error occurs. `EINTR` (and `EAGAIN` when non-blocking descriptors are used) is
-  retried, never surfaced. Only after EOF or a genuine error does the failure
+  error occurs. v1 uses **blocking descriptors**, so `EAGAIN` does not arise; an
+  implementation that nevertheless chooses non-blocking descriptors must wait
+  for readiness (`select`/`poll`) before reissuing the operation rather than
+  spin on `EAGAIN`. `EINTR` is retried, never surfaced — but the parent checks
+  its deadline and kill state **before** each retry, because a signal
+  interrupting a blocked read is exactly how the wall-clock deadline reaches a
+  single-threaded parent: if the deadline has expired it hard-kills the child
+  and classifies (§4) instead of resuming the read. The child has no deadline of
+  its own and retries unconditionally. Only after EOF or a genuine error does the failure
   taxonomy apply (§4): a short read is never itself classified — a prefix or
   payload cut short by EOF is an incomplete frame (`sfkChildProcessCrash` when
   reading from the child; `sfkHostError` when the parent's own write fails).

--- a/source/units/Goccia.Builtins.TestingLibrary.pas
+++ b/source/units/Goccia.Builtins.TestingLibrary.pas
@@ -3848,9 +3848,16 @@ begin
               TGocciaUndefinedLiteralValue.UndefinedValue);
         except
           { A refused allocation is uncatchable and must unwind to the host on
-            every execution path, not be converted into a describe failure. }
+            every execution path, not be converted into a describe failure.
+            Pending host work is cleared before the unwind for the same reason
+            as the per-test arm: later files run in this process. }
           on E: TGocciaMemoryLimitError do
+          begin
+            if (TGocciaMicrotaskQueue.Instance <> nil) then
+              TGocciaMicrotaskQueue.Instance.ClearQueue;
+            DiscardFetchCompletions;
             raise;
+          end;
           on E: Exception do
           begin
             if not FSuppressOutput then
@@ -4229,9 +4236,17 @@ begin
                   raise;
               end;
               { A refused allocation is uncatchable and must unwind to the host,
-                not be converted into a test failure and swallowed here. }
+                not be converted into a test failure and swallowed here. Pending
+                host work is cleared first: the host catches this error and later
+                files still run in the same process, so stale microtasks or fetch
+                completions from the aborted file must not leak into them. }
               on E: TGocciaMemoryLimitError do
+              begin
+                if (TGocciaMicrotaskQueue.Instance <> nil) then
+                  TGocciaMicrotaskQueue.Instance.ClearQueue;
+                DiscardFetchCompletions;
                 raise;
+              end;
               on E: Exception do
               begin
                 if (TGocciaMicrotaskQueue.Instance <> nil) then


### PR DESCRIPTION
## Summary

Addresses the three actionable findings from the CodeRabbit review that landed on #1139 **after** the stack had merged ([review 4918265007](https://github.com/frostney/GocciaScript/pull/1139#pullrequestreview-4918265007)). Each was validated against latest `main` before fixing; all three are genuine.

- **TestingLibrary — clear pending host work before the memory-limit unwind.** The `TGocciaMemoryLimitError` re-raise arms unwound to the host without clearing pending work, while the sibling generic arms clear it — so stale microtasks and fetch completions from an aborted file could leak into later files run by the same process. The per-test and describe-level arms (every inner re-raise unwinds through them) now clear the microtask queue and discard fetch completions before re-raising. The error stays uncatchable and no guest code runs during the clear.
- **fuzz.yml — `-t 5000` on afl-fuzz.** The harness's own budget is 1000 ms and a harness timeout is a *normal exit-0 outcome*, but AFL's default exec-threshold calibrates around 1000 ms — process overhead around a legitimately slow input could land it in `hangs/` and false-fail the job that (since #1139) fails on hangs.
- **ADR 0107 — exact-length pipe I/O rules.** The protocol specified EINTR-retry for waits but nothing for pipe reads/writes, which may legitimately transfer fewer bytes than requested. The transport section now requires exact-length loops for the 4-byte prefix and payload, EINTR/EAGAIN retry, and taxonomy classification only after EOF or a genuine error.

### Deliberate non-change

The timeout re-raise path has the same clear-before-unwind shape but is left untouched: it predates the stack and its host handling is entangled with test262 timeout classification, so it deserves its own considered change rather than a ride-along here.

## Testing

- [x] Verified no regressions and confirmed the fix in end-to-end JavaScript/TypeScript tests

`GocciaTestRunner tests` **12203/12203** · `--mode=bytecode` **12203/12203** · `test-cli.ts` (memory-limit uncatchability shapes) all pass · `./format.pas --check` clean (450) · markdownlint / doc-length / doc-links clean.