### PR TITLE
perf(objects): sort array-index keys in O(n log n) during own-key ordering

### DIFF
--- a/benchmarks/objects.js
+++ b/benchmarks/objects.js
@@ -37,6 +37,19 @@ group("object access", () => {
     };
   } }).setup);
 
+  bench("Object.keys over 2000 descending-inserted index keys", ({ *setup() {
+    const obj = (() => {
+      const target = {};
+      const count = 2000;
+      for (const index of Array.from({ length: count }, (_, i) => count - 1 - i))
+        target[index] = index;
+      return target;
+    })();
+    yield () => {
+      const keys = Object.keys(obj);
+    };
+  } }).setup);
+
   bench("Object.entries", ({ *setup() {
     const obj = (() => ({ a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8 }))();
     yield () => {

--- a/source/units/Goccia.Values.ObjectValue.pas
+++ b/source/units/Goccia.Values.ObjectValue.pas
@@ -244,13 +244,117 @@ begin
   Result := AIndex < High(UInt32);
 end;
 
+// Bottom-up merge sort over the collected array-index keys.  Every own-key
+// enumeration runs this, and insertion order is arbitrary, so an insertion sort
+// degrades to O(n^2) on descending input; the already-ascending case is the
+// common one and returns from the ordered check without touching the scratch
+// buffer.  Small key counts stay on insertion sort: below the threshold it
+// beats the merge because it never allocates the scratch buffer.  The keys
+// come from distinct property names, so stability is not required here.
+procedure SortArrayIndexKeys(var AKeys: TArray<UInt64>; const ACount: Integer);
+const
+  InsertionSortThreshold = 32;
+var
+  IsOrdered: Boolean;
+  Scratch: TArray<UInt64>;
+  // Width and LowIndex are Int64 so doubling Width and computing LowIndex +
+  // 2 * Width cannot overflow Integer near High(Integer) key counts.
+  Width, LowIndex: Int64;
+  Destination, HighIndex, Index, Left, MiddleIndex, Right: Integer;
+  SortedIndex: Integer;
+  TempKey: UInt64;
+begin
+  if ACount < 2 then
+    Exit;
+
+  if ACount <= InsertionSortThreshold then
+  begin
+    for Index := 1 to ACount - 1 do
+    begin
+      TempKey := AKeys[Index];
+      SortedIndex := Index - 1;
+      while (SortedIndex >= 0) and (AKeys[SortedIndex] > TempKey) do
+      begin
+        AKeys[SortedIndex + 1] := AKeys[SortedIndex];
+        Dec(SortedIndex);
+      end;
+      AKeys[SortedIndex + 1] := TempKey;
+    end;
+    Exit;
+  end;
+
+  IsOrdered := True;
+  for Index := 1 to ACount - 1 do
+    if AKeys[Index] < AKeys[Index - 1] then
+    begin
+      IsOrdered := False;
+      Break;
+    end;
+  if IsOrdered then
+    Exit;
+
+  SetLength(Scratch, ACount);
+  Width := 1;
+  while Width < ACount do
+  begin
+    LowIndex := 0;
+    while LowIndex < ACount do
+    begin
+      // Clamp in Int64, then narrow: both bounds are <= ACount.
+      if LowIndex + Width < ACount then
+        MiddleIndex := Integer(LowIndex + Width)
+      else
+        MiddleIndex := ACount;
+      if LowIndex + 2 * Width < ACount then
+        HighIndex := Integer(LowIndex + 2 * Width)
+      else
+        HighIndex := ACount;
+
+      Left := Integer(LowIndex);
+      Right := MiddleIndex;
+      Destination := Integer(LowIndex);
+      while (Left < MiddleIndex) and (Right < HighIndex) do
+      begin
+        if AKeys[Right] < AKeys[Left] then
+        begin
+          Scratch[Destination] := AKeys[Right];
+          Inc(Right);
+        end
+        else
+        begin
+          Scratch[Destination] := AKeys[Left];
+          Inc(Left);
+        end;
+        Inc(Destination);
+      end;
+      while Left < MiddleIndex do
+      begin
+        Scratch[Destination] := AKeys[Left];
+        Inc(Left);
+        Inc(Destination);
+      end;
+      while Right < HighIndex do
+      begin
+        Scratch[Destination] := AKeys[Right];
+        Inc(Right);
+        Inc(Destination);
+      end;
+      LowIndex := LowIndex + 2 * Width;
+    end;
+
+    for Index := 0 to ACount - 1 do
+      AKeys[Index] := Scratch[Index];
+    Width := Width * 2;
+  end;
+end;
+
 function OrderOwnStringPropertyKeys(const AKeys: TArray<string>):
   TArray<string>;
 var
-  Count, I, J, K: Integer;
+  Count, I, J: Integer;
   NumericKeys: TArray<UInt64>;
   OtherKeys: TArray<string>;
-  ParsedIndex, TempIndex: UInt64;
+  ParsedIndex: UInt64;
 begin
   SetLength(NumericKeys, Length(AKeys));
   SetLength(OtherKeys, Length(AKeys));
@@ -271,17 +375,7 @@ begin
     end;
   end;
 
-  for I := 1 to Count - 1 do
-  begin
-    TempIndex := NumericKeys[I];
-    K := I - 1;
-    while (K >= 0) and (NumericKeys[K] > TempIndex) do
-    begin
-      NumericKeys[K + 1] := NumericKeys[K];
-      Dec(K);
-    end;
-    NumericKeys[K + 1] := TempIndex;
-  end;
+  SortArrayIndexKeys(NumericKeys, Count);
 
   SetLength(Result, Count + J);
   for I := 0 to Count - 1 do

--- a/tests/built-ins/Object/keys.js
+++ b/tests/built-ins/Object/keys.js
@@ -33,6 +33,76 @@ test("Object.keys omits symbol-keyed properties", () => {
   expect(Object.getOwnPropertySymbols(object)).toEqual([symbol]);
 });
 
+test("Object.keys sorts array-index keys inserted in descending order", () => {
+  const object = {};
+  for (const index of [3, 2, 1, 0]) object[index] = index;
+
+  expect(Object.keys(object)).toEqual(["0", "1", "2", "3"]);
+});
+
+test("Object.keys sorts array-index keys inserted in random order", () => {
+  const object = {};
+  for (const index of [42, 7, 19, 0, 100, 3, 58, 27, 12]) object[index] = index;
+
+  expect(Object.keys(object)).toEqual([
+    "0",
+    "3",
+    "7",
+    "12",
+    "19",
+    "27",
+    "42",
+    "58",
+    "100",
+  ]);
+});
+
+test("Object.keys sorts a hundred array-index keys inserted in permuted order", () => {
+  const count = 100;
+  // (index * 37) % count visits every index exactly once because 37 and 100
+  // are coprime, giving a deterministic unordered insertion sequence.
+  const permuted = Array.from({ length: count }, (_, index) => (index * 37) % count);
+  const object = {};
+  for (const index of permuted) object[index] = index;
+
+  expect(Object.keys(object)).toEqual(
+    Array.from({ length: count }, (_, index) => String(index)),
+  );
+});
+
+test("Object.keys puts array-index keys first and keeps string keys in insertion order", () => {
+  const object = { zebra: 1 };
+  object[5] = 5;
+  object.apple = 2;
+  object[2] = 2;
+  object["01"] = "leading zero is not an index";
+  object[4294967295] = "2^32-1 is not an index";
+  object[10] = 10;
+  object.mango = 3;
+
+  expect(Object.keys(object)).toEqual([
+    "2",
+    "5",
+    "10",
+    "zebra",
+    "apple",
+    "01",
+    "4294967295",
+    "mango",
+  ]);
+});
+
+test("Object.keys sorts many array-index keys inserted in descending order", () => {
+  const count = 5000;
+  const descending = Array.from({ length: count }, (_, index) => count - 1 - index);
+  const object = {};
+  for (const index of descending) object[index] = index;
+
+  const keys = Object.keys(object);
+  expect(keys.length).toBe(count);
+  expect(keys.every((key, index) => key === String(index))).toBe(true);
+});
+
 test("Object.keys throws for null", () => {
   expect(() => Object.keys(null)).toThrow(TypeError);
 });


### PR DESCRIPTION
## Summary

- `OrderOwnStringPropertyKeys` (source/units/Goccia.Values.ObjectValue.pas) sorted collected array-index keys with an insertion sort — O(n²) on anything but already-ascending insertion order. Measured on a production build: `Object.keys` over 20,000 integer keys inserted in **descending** order took ~156 ms vs ~16 ms for ascending. The function is on the path of every own-key enumeration (`Object.keys`/`values`/`entries`, `getOwnPropertyNames`, `Reflect.ownKeys`).
- Replaces it with a file-local bottom-up merge sort (`SortArrayIndexKeys`) with two fast paths: an O(n) already-ascending pre-check that exits before allocating the scratch buffer (the common case), and insertion sort for ≤ 32 keys so small objects never pay the scratch allocation (without the threshold, small out-of-order objects measured ~3x slower per call than the old insertion sort). Merge sort over quicksort because naive quicksort degrades to O(n²) on the already-sorted common case. `Width`/`LowIndex` are Int64 so index arithmetic can't overflow under the project's range/overflow checks.
- After: descending 20k-key `Object.keys` is at parity with ascending (16.4 ms vs 16.0 ms, production build).
- Non-goals / unchanged: `TryParseArrayIndexKey` and the string-key insertion-order handling are untouched, so ES2026 `OrdinaryOwnPropertyKeys` semantics are preserved (array-index keys ascending, then other string keys in insertion order). No shared generic sort helper exists in the repo — every existing sort is a type-specific local routine, so a local routine follows the established pattern. Arrays are unaffected: `TGocciaArrayValue.GetOwnPropertyKeys` has its own sort path.
- Known adjacent issues deliberately left out of this focused diff: `SortTimeZoneIdentifiers` (Goccia.Temporal.TimeZone) is unconditionally O(n²) over the IANA list, and `OrderOwnStringPropertyKeys` still does two `SetLength` allocations per enumeration even with zero numeric keys.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests — `./build/GocciaTestRunner tests` and `--mode=bytecode`: 12,208/12,208 passing in both modes; new ordering tests cover descending, random, a 100-key deterministic permutation (exercises the merge path above the hybrid threshold), mixed numeric+string keys including the `"01"` leading-zero and `4294967295` (2³²−1) boundary cases (cross-checked against Node), and 5,000 descending keys. `./format.pas --check` clean.
- [ ] Updated documentation — n/a, internal perf fix with no behavior change
- [x] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed) — additionally, the sort routine was validated in an isolated FPC harness (same `{$mode delphi}`, overflow/range checks) across 16,415 cases: n = 0–40 with oversized tails, descending/random/duplicate/near-2³² distributions, and 2⁶⁴-boundary values to rule out signed-compare traps; 0 failures
- [x] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change — new `Object.keys over 2000 descending-inserted index keys` bench in benchmarks/objects.js (~1.68 ms/op; old code ≈14 ms/op)