### PR TITLE
fix(testing): detect terminal limit unwind with a flag, not ExceptObject

### DIFF
--- a/source/units/Goccia.Builtins.TestingLibrary.pas
+++ b/source/units/Goccia.Builtins.TestingLibrary.pas
@@ -996,26 +996,6 @@ begin
     RemoveTempRootIfNeeded(ACollection.GetElement(I));
 end;
 
-{ True while an uncatchable resource-limit exception is unwinding through the
-  current finally block. FPC's ExceptObject is non-nil only during
-  exception-driven unwind, so a normal pass or an ordinary recorded failure
-  leaves it nil. This matters for the per-test teardown: a hard memory limit
-  (refused allocation) and a describe/file-scope timeout are re-raised from the
-  test-execution handler and tear the run down uncatchably, whereas an ordinary
-  failure -- including a test-scope timeout, which the runner catches and
-  records rather than re-raising -- does not unwind here. When this returns True
-  the guest afterEach / onTestFinished hooks must be skipped (guest code may not
-  execute past a hard limit); engine bookkeeping still runs so no callback roots
-  leak as the exception propagates to the host. }
-function UncatchableLimitUnwinding: Boolean;
-var
-  InFlight: TObject;
-begin
-  InFlight := ExceptObject;
-  Result := (InFlight is TGocciaMemoryLimitError)
-    or (InFlight is TGocciaTimeoutError);
-end;
-
 { TGocciaRegisteredEntry }
 
 constructor TGocciaRegisteredEntry.Create(const AParentSuite: TGocciaTestSuite;
@@ -4026,6 +4006,7 @@ var
   RejectionReason: string;
   ExceptionDetail, ExceptionSummary: string;
   FailureRecorded: Boolean;
+  TerminalLimitUnwinding: Boolean;
   EffectiveSuiteName: string;
   HookFailed: Boolean;
   HookMessage: string;
@@ -4143,6 +4124,7 @@ begin
         RunCallbacks(BeforeCallbacks);
 
         FailureRecorded := False;
+        TerminalLimitUnwinding := False;
         TestResult := nil;
         try
           { Per-test deadline. Push unconditionally — a 0 value
@@ -4233,7 +4215,10 @@ begin
                   FailureRecorded := True;
                 end
                 else
+                begin
+                  TerminalLimitUnwinding := True;
                   raise;
+                end;
               end;
               { A refused allocation is uncatchable and must unwind to the host,
                 not be converted into a test failure and swallowed here. Pending
@@ -4245,6 +4230,7 @@ begin
                 if (TGocciaMicrotaskQueue.Instance <> nil) then
                   TGocciaMicrotaskQueue.Instance.ClearQueue;
                 DiscardFetchCompletions;
+                TerminalLimitUnwinding := True;
                 raise;
               end;
               on E: Exception do
@@ -4287,10 +4273,15 @@ begin
             guest afterEach / onTestFinished hooks must NOT run -- the limit has
             already fired and guest code may not execute past it. Keep the
             engine bookkeeping (root removal / Clear) so no callback roots leak
-            while the exception unwinds to the host. On every normal path (pass,
-            ordinary failure, recorded test-scope timeout) ExceptObject is nil,
-            so the hooks run exactly as before. }
-          if UncatchableLimitUnwinding then
+            while the exception unwinds to the host. The flag is set explicitly
+            by the two terminal re-raise arms above rather than inferred from
+            the RTL ExceptObject: on SEH targets (i386-win32) ExceptObject is
+            populated only inside except handlers, not while a finally runs
+            during unwinding, so an ExceptObject-based check silently ran the
+            hooks there. Every normal path (pass, ordinary failure, recorded
+            test-scope timeout) leaves the flag False, so the hooks run exactly
+            as before. }
+          if TerminalLimitUnwinding then
           begin
             if FOnTestFinishedCallbacks.Length > 0 then
             begin


### PR DESCRIPTION
## Summary

Fixes the regression that has kept main's CI red since #1139 merged: **`cli (i386-win32, windows-latest)`** fails on the two-direction afterEach test, because the guest `afterEach` runs after a memory-limit abort on that target.

**Root cause.** The afterEach-skip guard detected an uncatchable limit unwinding through the per-test `finally` by asking the RTL `ExceptObject` whether a limit exception was in flight. That works where FPC maintains the raise list through finally-driven unwinding (aarch64-darwin, where it was written and verified) — but under **SEH exception handling on i386-win32, `ExceptObject` is populated only inside `except` handlers and is nil while a `finally` runs during unwinding**. The guard never fired there, so `RAN:afterEach` printed after the budget refusal and the regression test failed — the test did its job; the mechanism under it was platform-dependent.

**Fix.** The guard now consults an explicit local flag set by the two terminal re-raise arms themselves (the memory-limit arm and the describe/file-scope timeout arm) — ordinary `except` handlers where the exception type is statically known. Plain data flow, no EH-model introspection, identical semantics on every target. The `ExceptObject`-based helper is deleted.

**Why the stack's own gate missed it:** the PR-level `cli` job runs on ubuntu only; only main's full cross-target matrix exercises i386-win32. Worth considering a follow-up that adds one Windows `cli` job to `pr.yml`.

## Testing

- [x] Verified no regressions and confirmed the fix in end-to-end JavaScript/TypeScript tests

`GocciaTestRunner tests` **12203/12203** · `--mode=bytecode` **12203/12203** · manual two-direction check (memory abort → body runs, afterEach skipped, exit 1; ordinary failure → afterEach runs) in **both modes** · full `scripts/test-cli-apps.ts` (the failing CI step) passes · `./format.pas --check` clean.

**Honest caveat:** i386-win32 cannot be executed locally (macOS arm64 host); the flag mechanism has no platform-variant semantics, but the definitive green is main's matrix after merge.