### PR TITLE
fix(gc): root parser and builtin containers across collecting safe points

### DIFF
--- a/scripts/test-cli.ts
+++ b/scripts/test-cli.ts
@@ -937,6 +937,44 @@ console.log("--max-memory (own-key enumeration survives a mid-loop collection)..
   if (json.files?.[0]?.result !== 150000) throw new Error(`Own-key enumeration should return 150000, got ${json.files?.[0]?.result}`);
 }
 
+// Parking is measured, never assumed. A fixed ballast cap fails silently in
+// both directions: at a tight ceiling the loop stops while the budget still has
+// room to spare, and at a wide one the cap runs out long before the ceiling is
+// in reach — either way the probe runs unparked and passes without ever entering
+// the window it exists to test. This grows ballast in bounded passes, collecting
+// between them so each measurement counts live bytes only, and reports the
+// outcome for the assertions to insist on.
+//
+// Shared by every parked-heap block below (parser probes, parse ceiling, parse
+// gate, stringify gate) so the calibration is defined once: they differ only in
+// the slack they park at, which is measured per block and passed in here.
+const parkingPreamble = (slackTarget: number): string[] => [
+  `const SLACK = ${slackTarget};`,
+  // Sized from the ceiling so it cannot run out, and materialised before the
+  // first measurement so it counts as baseline live set instead of quietly
+  // defeating the parking it is driving.
+  "const iters = Array.from({ length: Math.ceil(Goccia.gc.maxBytes / 4096) + 64 }, (_, j) => j);",
+  "const ballast = [];",
+  "let slack = Goccia.gc.maxBytes;",
+  "Goccia.gc();",
+  // Each pass adds only live ballast and then collects, so the post-collection
+  // slack falls monotonically and a handful of passes converges. Measuring
+  // before the collection is what let the old loop stop early: it was reading
+  // garbage the next collection would hand straight back.
+  "for (const pass of [0, 1, 2, 3, 4]) {",
+  "  for (const i of iters) {",
+  "    if (Goccia.gc.maxBytes - Goccia.gc.bytesAllocated <= SLACK) break;",
+  '    ballast.push("x".repeat(4096));',
+  "  }",
+  "  Goccia.gc();",
+  "  slack = Goccia.gc.maxBytes - Goccia.gc.bytesAllocated;",
+  "  if (slack <= SLACK) break;",
+  "}",
+  // Every caller asserts on "parked true"; the trailing numbers are diagnostics
+  // for when a calibration drifts and the assertion starts failing.
+  'console.log("parked", slack <= SLACK, "slack", slack, "ballast", ballast.length);',
+];
+
 console.log("--max-memory (builtin result builders survive mid-build collections)...");
 {
   // Same defect class as own-key enumeration: any builtin that fills a result
@@ -1146,38 +1184,6 @@ console.log("--max-memory (builtin result builders survive mid-build collections
     // nothing after it is a resource ceiling the guest can mistake for bad input,
     // so it is a failure, not a refusal.
     const EMPTY_REFUSAL = /^refused \S+ ::\s*$/m;
-
-    // Parking is measured, never assumed. A fixed ballast cap fails silently in
-    // both directions: at a tight ceiling the loop stops while the budget still
-    // has room to spare, and at a wide one the cap runs out long before the
-    // ceiling is in reach — either way the probe runs unparked and passes without
-    // ever entering the window it exists to test. This grows ballast in bounded
-    // passes, collecting between them so each measurement counts live bytes only,
-    // and reports the outcome for the assertions to insist on.
-    const parkingPreamble = (slackTarget: number): string[] => [
-      `const SLACK = ${slackTarget};`,
-      // Sized from the ceiling so it cannot run out, and materialised before the
-      // first measurement so it counts as baseline live set instead of quietly
-      // defeating the parking it is driving.
-      "const iters = Array.from({ length: Math.ceil(Goccia.gc.maxBytes / 4096) + 64 }, (_, j) => j);",
-      "const ballast = [];",
-      "let slack = Goccia.gc.maxBytes;",
-      "Goccia.gc();",
-      // Each pass adds only live ballast and then collects, so the post-collection
-      // slack falls monotonically and a handful of passes converges. Measuring
-      // before the collection is what let the old loop stop early: it was reading
-      // garbage the next collection would hand straight back.
-      "for (const pass of [0, 1, 2, 3, 4]) {",
-      "  for (const i of iters) {",
-      "    if (Goccia.gc.maxBytes - Goccia.gc.bytesAllocated <= SLACK) break;",
-      '    ballast.push("x".repeat(4096));',
-      "  }",
-      "  Goccia.gc();",
-      "  slack = Goccia.gc.maxBytes - Goccia.gc.bytesAllocated;",
-      "  if (slack <= SLACK) break;",
-      "}",
-      'console.log("parked", slack <= SLACK, "slack", slack, "ballast", ballast.length);',
-    ];
 
     // `expect` is the exact line the parse must produce when it completes.
     // "ok " on its own proves nothing: a container that was swept and had its
@@ -1561,23 +1567,9 @@ console.log("--max-memory (builtin result builders survive mid-build collections
           ...imports,
           'const S = "s".repeat(200);',
           'const doc = "[" + Array.from({ length: 1200 }, (_, i) => \'"\' + S + i + \'"\').join(",") + "]";',
-          // Same measured parking as the parser probes above, kept local so this
-          // block reads on its own.
-          "const SLACK = 300000;",
-          "const iters = Array.from({ length: Math.ceil(Goccia.gc.maxBytes / 4096) + 64 }, (_, j) => j);",
-          "const ballast = [];",
-          "let slack = Goccia.gc.maxBytes;",
-          "Goccia.gc();",
-          "for (const pass of [0, 1, 2, 3, 4]) {",
-          "  for (const i of iters) {",
-          "    if (Goccia.gc.maxBytes - Goccia.gc.bytesAllocated <= SLACK) break;",
-          '    ballast.push("x".repeat(4096));',
-          "  }",
-          "  Goccia.gc();",
-          "  slack = Goccia.gc.maxBytes - Goccia.gc.bytesAllocated;",
-          "  if (slack <= SLACK) break;",
-          "}",
-          'console.log("parked", slack <= SLACK);',
+          // Same measured parking as the parser probes above, at the slack this
+          // block was calibrated against.
+          ...parkingPreamble(300_000),
           "try {",
           `  const value = ${parse};`,
           '  console.log("completed", value === null || value === undefined ? "empty" : "value");',
@@ -1669,21 +1661,7 @@ console.log("--max-memory (builtin result builders survive mid-build collections
           // 120000 sits in the middle of the measured window: the parse survives
           // its own charges (~96 KB for 4000 properties) but the storage doubling
           // asks for 73632 or 147360 bytes in one block and is refused.
-          "const SLACK = 120000;",
-          "const iters = Array.from({ length: Math.ceil(Goccia.gc.maxBytes / 4096) + 64 }, (_, j) => j);",
-          "const ballast = [];",
-          "let slack = Goccia.gc.maxBytes;",
-          "Goccia.gc();",
-          "for (const pass of [0, 1, 2, 3, 4]) {",
-          "  for (const i of iters) {",
-          "    if (Goccia.gc.maxBytes - Goccia.gc.bytesAllocated <= SLACK) break;",
-          '    ballast.push("x".repeat(4096));',
-          "  }",
-          "  Goccia.gc();",
-          "  slack = Goccia.gc.maxBytes - Goccia.gc.bytesAllocated;",
-          "  if (slack <= SLACK) break;",
-          "}",
-          'console.log("parked", slack <= SLACK);',
+          ...parkingPreamble(120_000),
           "try {",
           `  const value = ${parse};`,
           '  console.log("guest-completed", Object.keys(value).length);',
@@ -1752,21 +1730,7 @@ console.log("--max-memory (builtin result builders survive mid-build collections
     [
       ...imports,
       setup,
-      `const SLACK = ${slackTarget};`,
-      "const iters = Array.from({ length: Math.ceil(Goccia.gc.maxBytes / 4096) + 64 }, (_, j) => j);",
-      "const ballast = [];",
-      "let slack = Goccia.gc.maxBytes;",
-      "Goccia.gc();",
-      "for (const pass of [0, 1, 2, 3, 4]) {",
-      "  for (const i of iters) {",
-      "    if (Goccia.gc.maxBytes - Goccia.gc.bytesAllocated <= SLACK) break;",
-      '    ballast.push("x".repeat(4096));',
-      "  }",
-      "  Goccia.gc();",
-      "  slack = Goccia.gc.maxBytes - Goccia.gc.bytesAllocated;",
-      "  if (slack <= SLACK) break;",
-      "}",
-      'console.log("parked", slack <= SLACK);',
+      ...parkingPreamble(slackTarget),
       "try {",
       `  const value = ${call};`,
       '  console.log("guest-completed", value.length);',

--- a/scripts/test-cli.ts
+++ b/scripts/test-cli.ts
@@ -911,9 +911,16 @@ console.log("--max-memory (own-key enumeration survives a mid-loop collection)..
       timeout: 60_000,
     });
     const out = proc.stdout.toString() + proc.stderr.toString();
-    // A budget refusal ("would exceed the memory budget") is the intended
-    // uncatchable ceiling. Any other fatal — bus error, access violation,
-    // nil object check — is the heap corruption this test guards against.
+    // The engine has two memory limiters and they surface differently, which is
+    // why the clauses below excuse one text and reject every other fatal. A
+    // charged allocation (string payload, buffer) raises a script-catchable
+    // RangeError. The growth gate (RequireNativeBytes, Goccia.MemoryLimit.pas)
+    // raises TGocciaMemoryLimitError, which is deliberately opaque to the guest:
+    // every boundary re-raises it, it escapes to the host, and the loader reports
+    // it as "Fatal error: ... would exceed the memory budget" with exit 1. That
+    // text is a refusal by design, not a crash — do not tighten these clauses
+    // into failures. Any other fatal — bus error, access violation, nil object
+    // check — is the heap corruption this test guards against.
     if (out.includes("Fatal error") && !out.includes("would exceed the memory budget"))
       throw new Error(`Own-key enumeration at --max-memory=${maxMemory} crashed: ${out}`);
     if (proc.exitCode !== 0 && !out.includes("RangeError") && !out.includes("would exceed the memory budget"))
@@ -968,6 +975,8 @@ console.log("--max-memory (builtin result builders survive mid-build collections
         timeout: 120_000,
       });
       const out = proc.stdout.toString() + proc.stderr.toString();
+      // Budget-text fatal = the uncatchable growth gate refusing; see the
+      // two-limiter note on the own-key enumeration sweep above.
       if (out.includes("Fatal error") && !out.includes("would exceed the memory budget"))
         throw new Error(`Builder sweep at --max-memory=${maxMemory} crashed: ${out}`);
       if (proc.exitCode !== 0 && !out.includes("RangeError") && !out.includes("would exceed the memory budget"))
@@ -989,6 +998,451 @@ console.log("--max-memory (builtin result builders survive mid-build collections
         throw new Error(`Builder sweep headroom run should exit 0, got ${proc.exitCode}: ${out}`);
       if (!out.includes("total 16014"))
         throw new Error(`Builder sweep headroom run should report total 16014: ${out}`);
+    }
+
+    // Second wave of the same defect class, in builders the first sweep does not
+    // reach: the JSONL chunk-result object and its error object, the JSON5
+    // reviver context/holder plus the replacer's partially built copies, and the
+    // Promise.allSettled entries — each is filled across a string allocation or
+    // a property write, and each of those is charged against the ceiling and so
+    // is a collecting safe point.
+    const wave2Src = [
+      'import * as JSONLNS from "goccia:jsonl"; const JSONL = JSONLNS.JSONL ?? JSONLNS;',
+      'import * as JSON5NS from "goccia:json5"; const JSON5 = JSON5NS.JSON5 ?? JSON5NS;',
+      'const lines = Array.from({ length: 800 }, (_, i) => \'{"k":"v\' + i + \'","n":\' + i + \'}\').join("\\n");',
+      'const chunk = JSONL.parseChunk(lines + "\\n");',
+      // An unterminated record makes parseChunk build the SyntaxError object too.
+      "const badChunk = JSONL.parseChunk('{\"k\":1}\\n{\"k\":\\n');",
+      'const json5Text = "{" + Array.from({ length: 500 }, (_, i) => "k" + i + ": \'v" + i + "\'").join(", ") + "}";',
+      "const revived = JSON5.parse(json5Text, (k, v) => v);",
+      'const nested = JSON5.parse("[" + Array.from({ length: 400 }, (_, i) => "{a: " + i + "}").join(", ") + "]", (k, v) => v);',
+      "const replaced = JSON5.stringify(nested, (k, v) => v);",
+      "const sync = chunk.values.length + badChunk.values.length +",
+      "  (badChunk.error === null ? 0 : 1) + Object.keys(revived).length +",
+      "  nested.length + replaced.length;",
+      "Promise.allSettled(Array.from({ length: 500 }, (_, i) =>",
+      '  i % 2 === 0 ? Promise.resolve("v" + i) : Promise.reject(new Error("e" + i)),',
+      ")).then((rs) => {",
+      "  console.log('total', sync + rs.length +",
+      '    rs.filter((r) => r.status === "fulfilled").length +',
+      '    rs.filter((r) => r.status === "rejected").length);',
+      "});",
+      "",
+    ].join("\n");
+    const wave2Path = join(tmp, "sweep-wave2.mjs");
+    writeFileSync(wave2Path, wave2Src);
+    for (const maxMemory of [1_048_576, 1_572_864, 2_097_152, 3_145_728, 8_388_608, 67_108_864]) {
+      const proc = Bun.spawnSync([LOADER, `--max-memory=${maxMemory}`, wave2Path], {
+        stdout: "pipe",
+        stderr: "pipe",
+        timeout: 120_000,
+      });
+      const out = proc.stdout.toString() + proc.stderr.toString();
+      // Budget-text fatal = the uncatchable growth gate refusing, as above.
+      if (out.includes("Fatal error") && !out.includes("would exceed the memory budget"))
+        throw new Error(`Wave-2 builder sweep at --max-memory=${maxMemory} crashed: ${out}`);
+      if (proc.exitCode !== 0 && !out.includes("RangeError") && !out.includes("would exceed the memory budget"))
+        throw new Error(`Wave-2 builder sweep at --max-memory=${maxMemory} failed without a clean refusal (exitCode=${proc.exitCode}): ${out}`);
+      if (proc.exitCode === 0 && !out.includes("total 5793"))
+        throw new Error(`Wave-2 builder sweep at --max-memory=${maxMemory} completed with wrong total: ${out}`);
+    }
+
+    // As above, one guaranteed-success run so an all-refusals sweep cannot pass
+    // vacuously.
+    {
+      const proc = Bun.spawnSync([LOADER, "--max-memory=134217728", wave2Path], {
+        stdout: "pipe",
+        stderr: "pipe",
+        timeout: 120_000,
+      });
+      const out = proc.stdout.toString() + proc.stderr.toString();
+      if (proc.exitCode !== 0)
+        throw new Error(`Wave-2 builder sweep headroom run should exit 0, got ${proc.exitCode}: ${out}`);
+      if (!out.includes("total 5793"))
+        throw new Error(`Wave-2 builder sweep headroom run should report total 5793: ${out}`);
+    }
+
+    // A ceiling sweep only lands in the collecting window by luck: the pressure
+    // collection runs inside the allocation that would cross the ceiling, so the
+    // heap has to already sit right below it. This shape parks it there on
+    // purpose — ballast is grown until the remaining budget is a fixed slack,
+    // after which nearly every builder allocation collects — and then keeps the
+    // reviver/replacer results alive so a swept container's slot is reused (that
+    // reuse is what turns the dangling pointer into an observable fault). With
+    // the JSON5 holder/context/copy roots removed this faults within seconds
+    // ("Object reference is Nil", "Invalid type cast"); with them it either
+    // completes or refuses cleanly.
+    const parkedSrc = [
+      'import * as JSON5NS from "goccia:json5"; const JSON5 = JSON5NS.JSON5 ?? JSON5NS;',
+      "const ballast = [];",
+      "for (const i of Array.from({ length: 20000 }, (_, j) => j)) {",
+      "  if (Goccia.gc.maxBytes - Goccia.gc.bytesAllocated <= 262144) break;",
+      '  ballast.push("x".repeat(2048));',
+      "}",
+      "const kept = [];",
+      "let n = 0;",
+      "for (const i of Array.from({ length: 600 }, (_, j) => j)) {",
+      "  const revived = JSON5.parse(\"{a: 1, b: 'two'}\", (k, v) => v);",
+      "  const text = JSON5.stringify({ a: 1, b: [2, 3] }, (k, v) => v);",
+      "  kept.push(revived, text);",
+      "  n += Object.keys(revived).length + text.length;",
+      "}",
+      "console.log('parked', n, ballast.length > 0, kept.length);",
+      "",
+    ].join("\n");
+    const parkedPath = join(tmp, "sweep-parked.mjs");
+    writeFileSync(parkedPath, parkedSrc);
+    for (const maxMemory of [2_097_152, 3_145_728, 4_194_304]) {
+      const proc = Bun.spawnSync([LOADER, `--max-memory=${maxMemory}`, parkedPath], {
+        stdout: "pipe",
+        stderr: "pipe",
+        timeout: 180_000,
+      });
+      const out = proc.stdout.toString() + proc.stderr.toString();
+      // A parked heap makes the growth gate far more likely to be the limiter
+      // that fires, and its refusal is uncatchable by design: the budget text is
+      // a legitimate outcome here, anything else fatal is not. See the
+      // two-limiter note on the own-key enumeration sweep above.
+      if (out.includes("Fatal error") && !out.includes("would exceed the memory budget"))
+        throw new Error(`Parked-heap builder run at --max-memory=${maxMemory} crashed: ${out}`);
+      if (proc.exitCode !== 0 && !out.includes("RangeError") && !out.includes("would exceed the memory budget"))
+        throw new Error(`Parked-heap builder run at --max-memory=${maxMemory} failed without a clean refusal (exitCode=${proc.exitCode}): ${out}`);
+      if (proc.exitCode === 0 && !out.includes("parked 9000 true 1200"))
+        throw new Error(`Parked-heap builder run at --max-memory=${maxMemory} completed with wrong result: ${out}`);
+    }
+
+    // The same defect class in the recursive parsers, which build their trees in
+    // plain Pascal fields and locals (JSON's visitor stack, YAML's key/value
+    // locals and anchor map, JSONL's record accumulator, TOML's node tree) that
+    // the collector cannot see. The shape below parks the heap right under the
+    // ceiling with no other garbage available, so the parse crosses the ceiling
+    // partway through and the only thing the pressure collection can free is the
+    // in-progress tree itself — after which the parse keeps writing into swept
+    // containers and the remaining values reuse their memory.
+    //
+    // The parse is wrapped in try/catch because a refused allocation surfaces as a
+    // catchable JS RangeError. A crash used to be indistinguishable from a clean
+    // refusal — both arrived as a caught SyntaxError, because the builtins
+    // converted every exception out of the parser into one — so the assertions
+    // read the whole line rather than just its shape.
+    const USE_AFTER_FREE_SIGNATURES = [
+      "Access violation",
+      "Invalid type cast",
+      "Object reference is Nil",
+      "SIGSEGV",
+      "Segmentation fault",
+      "EAccessViolation",
+      // FPC runtime errors for a nil-object call and an invalid typecast, as
+      // reported when no handler formats them.
+      "Runtime error 210",
+      "Runtime error 216",
+      "Runtime error 219",
+      "Runtime error 204",
+    ];
+
+    // A refusal whose message is empty: the shape a blanket `on E: Exception`
+    // handler produces when it relabels an engine failure, since the Pascal
+    // Message of a thrown JS value is empty by construction. `SyntaxError: ` with
+    // nothing after it is a resource ceiling the guest can mistake for bad input,
+    // so it is a failure, not a refusal.
+    const EMPTY_REFUSAL = /^refused \S+ ::\s*$/m;
+
+    // Parking is measured, never assumed. A fixed ballast cap fails silently in
+    // both directions: at a tight ceiling the loop stops while the budget still
+    // has room to spare, and at a wide one the cap runs out long before the
+    // ceiling is in reach — either way the probe runs unparked and passes without
+    // ever entering the window it exists to test. This grows ballast in bounded
+    // passes, collecting between them so each measurement counts live bytes only,
+    // and reports the outcome for the assertions to insist on.
+    const parkingPreamble = (slackTarget: number): string[] => [
+      `const SLACK = ${slackTarget};`,
+      // Sized from the ceiling so it cannot run out, and materialised before the
+      // first measurement so it counts as baseline live set instead of quietly
+      // defeating the parking it is driving.
+      "const iters = Array.from({ length: Math.ceil(Goccia.gc.maxBytes / 4096) + 64 }, (_, j) => j);",
+      "const ballast = [];",
+      "let slack = Goccia.gc.maxBytes;",
+      "Goccia.gc();",
+      // Each pass adds only live ballast and then collects, so the post-collection
+      // slack falls monotonically and a handful of passes converges. Measuring
+      // before the collection is what let the old loop stop early: it was reading
+      // garbage the next collection would hand straight back.
+      "for (const pass of [0, 1, 2, 3, 4]) {",
+      "  for (const i of iters) {",
+      "    if (Goccia.gc.maxBytes - Goccia.gc.bytesAllocated <= SLACK) break;",
+      '    ballast.push("x".repeat(4096));',
+      "  }",
+      "  Goccia.gc();",
+      "  slack = Goccia.gc.maxBytes - Goccia.gc.bytesAllocated;",
+      "  if (slack <= SLACK) break;",
+      "}",
+      'console.log("parked", slack <= SLACK, "slack", slack, "ballast", ballast.length);',
+    ];
+
+    // `expect` is the exact line the parse must produce when it completes.
+    // "ok " on its own proves nothing: a container that was swept and had its
+    // memory reused almost always yields silently wrong data rather than a crash,
+    // so every length and count is read back and compared.
+    //
+    // `windowCeiling` / `windowSlack` override the collecting-window run for
+    // probes whose parse cannot finish in the default window. Every probe must
+    // have one configuration that completes while parked, or the read-back check
+    // only ever runs unballasted and the window run proves nothing; the values
+    // are measured per probe, not guessed. Slack alone was enough for all nine
+    // here — no probe needs a different ceiling — but both knobs are exposed
+    // because which one moves a stuck probe into its window is a measurement.
+    // See the window run below.
+    const parserProbes: Array<{
+      name: string;
+      setup: string[];
+      parse: string;
+      check: string;
+      expect: string;
+      windowCeiling?: number;
+      windowSlack?: number;
+    }> = [
+      {
+        name: "json-flat",
+        setup: [
+          'const doc = "[" + Array.from({ length: 1200 }, (_, i) => \'"\' + S + i + \'"\').join(",") + "]";',
+        ],
+        parse: "JSON.parse(doc)",
+        check: "'ok', b.length, b[0].length, b[600].length, b[1199].length",
+        expect: "ok 1200 201 203 204",
+      },
+      {
+        name: "json-nested",
+        setup: [
+          'const doc = "[" + Array.from({ length: 400 }, (_, i) => \'{"a":"\' + S + i + \'","b":["\' + S + \'","\' + S + \'"]}\').join(",") + "]";',
+        ],
+        parse: "JSON.parse(doc)",
+        check: "'ok', b.length, b[0].a.length, b[399].b[1].length",
+        expect: "ok 400 201 200",
+        // Measured: at the default 600000 the parse only ever refuses; it first
+        // completes at 650000 and 800000 leaves margin over that threshold.
+        windowSlack: 800_000,
+      },
+      {
+        name: "json5",
+        setup: [
+          'import * as JSON5NS from "goccia:json5"; const JSON5 = JSON5NS.JSON5 ?? JSON5NS;',
+          'const doc = "[" + Array.from({ length: 1200 }, (_, i) => "\'" + S + i + "\'").join(",") + "]";',
+        ],
+        parse: "JSON5.parse(doc)",
+        check: "'ok', b.length, b[0].length, b[600].length, b[1199].length",
+        expect: "ok 1200 201 203 204",
+      },
+      {
+        // The JSONL accumulator: one array collecting every parsed record while
+        // each line's parse builds strings that can collect. Only the caller's
+        // hand-off window was rooted, not the loop that fills it.
+        name: "jsonl-chunk",
+        setup: [
+          'import * as JSONLNS from "goccia:jsonl"; const JSONL = JSONLNS.JSONL ?? JSONLNS;',
+          'const doc = Array.from({ length: 400 }, (_, i) => \'{"a":"\' + S + \'","b":"\' + S + i + \'"}\').join("\\n") + "\\n";',
+        ],
+        parse: "JSONL.parseChunk(doc)",
+        check: "'ok', b.values.length, b.values[0].a.length, b.values[399].b.length, b.done, b.error === null",
+        expect: "ok 400 200 203 true true",
+      },
+      {
+        // The same accumulator reached through the whole-input entry point, which
+        // returns the array directly instead of a chunk record.
+        name: "jsonl-parse",
+        setup: [
+          'import * as JSONLNS from "goccia:jsonl"; const JSONL = JSONLNS.JSONL ?? JSONLNS;',
+          'const doc = Array.from({ length: 400 }, (_, i) => \'{"a":"\' + S + \'","b":"\' + S + i + \'"}\').join("\\n") + "\\n";',
+        ],
+        parse: "JSONL.parse(doc)",
+        check: "'ok', b.length, b[0].a.length, b[399].b.length",
+        expect: "ok 400 200 203",
+      },
+      {
+        name: "yaml-block-and-flow",
+        setup: [
+          'import * as YAMLNS from "goccia:yaml"; const YAML = YAMLNS.YAML ?? YAMLNS;',
+          'const doc = Array.from({ length: 300 }, (_, i) => "k" + i + ":\\n  a: \'" + S + i + "\'\\n  b: [\'" + S + "\', \'" + S + "\']\\n  c:\\n    - \'" + S + "\'\\n    - \'" + S + "\'").join("\\n") + "\\n";',
+        ],
+        parse: "YAML.parse(doc)",
+        check: "'ok', Object.keys(b).length, b.k0.a.length, b.k299.b[1].length, b.k299.c[1].length",
+        expect: "ok 300 201 200 200",
+        // Measured: refuses through 750000, first completes at 800000.
+        windowSlack: 900_000,
+      },
+      {
+        // Explicit `? key` / `: value` entries: the key survives a full nested
+        // node parse before it is canonicalised, and the value survives the
+        // canonicalisation. Long keys make both windows wide.
+        name: "yaml-explicit-keys",
+        setup: [
+          'import * as YAMLNS from "goccia:yaml"; const YAML = YAMLNS.YAML ?? YAMLNS;',
+          'const K = "k".repeat(200);',
+          'const doc = Array.from({ length: 200 }, (_, i) => "? " + K + i + "\\n:\\n  - \'" + S + "\'\\n  - \'" + S + "\'").join("\\n") + "\\n";',
+        ],
+        parse: "YAML.parse(doc)",
+        check: "'ok', Object.keys(b).length, b[K + 0].length, b[K + 199][1].length",
+        expect: "ok 200 2 200",
+      },
+      {
+        // Anchors and aliases specifically: a value referenced only by the anchor
+        // map is invisible to the collector without a root over that map.
+        name: "yaml-anchors",
+        setup: [
+          'import * as YAMLNS from "goccia:yaml"; const YAML = YAMLNS.YAML ?? YAMLNS;',
+          'const doc = Array.from({ length: 250 }, (_, i) => "a" + i + ": &anc" + i + "\\n  x: \'" + S + i + "\'\\n  y: [\'" + S + "\', \'" + S + "\']\\nb" + i + ": *anc" + i + "\\nc" + i + ":\\n  <<: *anc" + i + "\\n  z: \'" + S + i + "\'").join("\\n") + "\\n";',
+        ],
+        parse: "YAML.parse(doc)",
+        check: "'ok', Object.keys(b).length, b.a0.x.length, b.b249.y[1].length, b.c249.z.length, b.c249.x.length",
+        expect: "ok 750 201 200 203 203",
+      },
+      {
+        name: "toml",
+        setup: [
+          'import * as TOMLNS from "goccia:toml"; const TOML = TOMLNS.TOML ?? TOMLNS;',
+          'const doc = Array.from({ length: 300 }, (_, i) => "k" + i + \' = "\' + S + i + \'"\\narr\' + i + \' = ["\' + S + \'", "\' + S + \'"]\\ninl\' + i + \' = { x = "\' + S + \'", y = "\' + S + \'" }\').join("\\n") + "\\n";',
+        ],
+        parse: "TOML.parse(doc)",
+        check: "'ok', Object.keys(b).length, b.k0.length, b.arr299[1].length, b.inl299.y.length",
+        expect: "ok 900 201 200 200",
+        // Measured: refuses through 750000, first completes at 800000.
+        windowSlack: 900_000,
+      },
+    ];
+
+    // Shared verdict for every parked-parse run. `requireParked` is off only for
+    // the headroom run, which deliberately carries no ballast. `requireExpect`
+    // is on for the calibrated window run, where a refusal is not an acceptable
+    // outcome — see there.
+    const assertProbeRun = (
+      label: string,
+      out: string,
+      exitCode: number | null,
+      expect: string,
+      requireParked: boolean,
+      requireExpect: boolean,
+    ): void => {
+      const signature = USE_AFTER_FREE_SIGNATURES.find((text) => out.includes(text));
+      if (signature) throw new Error(`${label} hit a use-after-free (${signature}): ${out}`);
+      if (out.includes("Fatal error") && !out.includes("would exceed the memory budget"))
+        throw new Error(`${label} crashed: ${out}`);
+      if (requireParked && !out.includes("parked true"))
+        throw new Error(
+          `${label} never got the heap under the ceiling, so it exercised no collecting window: ${out}`,
+        );
+      if (EMPTY_REFUSAL.test(out))
+        throw new Error(
+          `${label} refused with an empty message — an engine failure relabelled as a syntax error: ${out}`,
+        );
+      if (out.includes("refused ") && !out.includes("refused RangeError"))
+        throw new Error(
+          `${label} refused with something other than the RangeError a memory ceiling raises: ${out}`,
+        );
+      if (requireExpect) {
+        // No `|| refused` escape: this run is calibrated to finish, and a
+        // refusal means the calibration drifted rather than that the ceiling
+        // did its job. Accepting one here would silently retire the only check
+        // that reads the parsed values back under collection pressure.
+        if (exitCode !== 0 || !out.includes(expect))
+          throw new Error(
+            `${label} did not complete with "${expect}" while parked (exitCode=${exitCode}): ${out}`,
+          );
+        return;
+      }
+      if (exitCode !== 0 && !out.includes("RangeError") && !out.includes("would exceed the memory budget"))
+        throw new Error(`${label} failed without a clean refusal (exitCode=${exitCode}): ${out}`);
+      if (exitCode === 0 && !out.includes(expect) && !out.includes("refused RangeError"))
+        throw new Error(`${label} produced neither "${expect}" nor a clean refusal: ${out}`);
+    };
+
+    for (const probe of parserProbes) {
+      const buildSrc = (preamble: string[]): string =>
+        [
+          ...probe.setup.filter((line) => line.startsWith("import ")),
+          'const S = "s".repeat(200);',
+          ...probe.setup.filter((line) => !line.startsWith("import ")),
+          ...preamble,
+          "try {",
+          `  const b = ${probe.parse};`,
+          `  console.log(${probe.check});`,
+          "} catch (e) {",
+          "  console.log('refused', e.name, '::', e.message);",
+          "}",
+          "",
+        ].join("\n");
+
+      // A tight window puts the crossing early in the parse, where the most
+      // allocation still follows to reuse whatever the sweep freed — 100 KiB is
+      // where the YAML explicit-key and JSONL accumulator defects reproduce, and
+      // a wider one lets several of them through. 2 MiB is not in the ceiling
+      // set: the wider documents cannot even be built at that ceiling, so the run
+      // refuses before it has a heap to park and proves nothing.
+      const tightPath = join(tmp, `parser-parked-${probe.name}.mjs`);
+      writeFileSync(tightPath, buildSrc(parkingPreamble(100_000)));
+      for (const maxMemory of [3_145_728, 4_194_304]) {
+        const proc = Bun.spawnSync([LOADER, `--max-memory=${maxMemory}`, tightPath], {
+          stdout: "pipe",
+          stderr: "pipe",
+          timeout: 180_000,
+        });
+        assertProbeRun(
+          `Parked-heap ${probe.name} parse at --max-memory=${maxMemory}`,
+          proc.stdout.toString() + proc.stderr.toString(),
+          proc.exitCode,
+          probe.expect,
+          true,
+          false,
+        );
+      }
+
+      // A wider window at a wider ceiling: parked enough that the parse collects
+      // repeatedly, with enough left over that it can still finish. This is the
+      // only shape that can observe a swept container being written into and then
+      // read back, which is how a missing root shows up as wrong data rather than
+      // as a fault — so this run has to complete, and a refusal fails it.
+      //
+      // The window is per probe because the documents differ by an order of
+      // magnitude in what they need to finish: the default pair completes for six
+      // of the nine, while json-nested, yaml-block-and-flow and toml only refuse
+      // there and carry a measured `windowSlack` instead. Each override sits above
+      // the smallest slack at which that probe was observed to complete, and the
+      // slack the preamble converges to is deterministic for a given build, so
+      // "completes while parked" is a property of the calibration, not luck.
+      {
+        const windowCeiling = probe.windowCeiling ?? 6_291_456;
+        const windowPath = join(tmp, `parser-window-${probe.name}.mjs`);
+        writeFileSync(windowPath, buildSrc(parkingPreamble(probe.windowSlack ?? 600_000)));
+        const proc = Bun.spawnSync([LOADER, `--max-memory=${windowCeiling}`, windowPath], {
+          stdout: "pipe",
+          stderr: "pipe",
+          timeout: 180_000,
+        });
+        assertProbeRun(
+          `Collecting-window ${probe.name} parse at --max-memory=${windowCeiling}`,
+          proc.stdout.toString() + proc.stderr.toString(),
+          proc.exitCode,
+          probe.expect,
+          true,
+          true,
+        );
+      }
+
+      // One run with room to spare and no ballast at all, so a probe that only
+      // ever refuses cannot pass vacuously: the parse has to complete and every
+      // value has to read back exactly.
+      {
+        const headroomPath = join(tmp, `parser-headroom-${probe.name}.mjs`);
+        writeFileSync(headroomPath, buildSrc([]));
+        const proc = Bun.spawnSync([LOADER, "--max-memory=134217728", headroomPath], {
+          stdout: "pipe",
+          stderr: "pipe",
+          timeout: 180_000,
+        });
+        const out = proc.stdout.toString() + proc.stderr.toString();
+        if (proc.exitCode !== 0)
+          throw new Error(`Headroom ${probe.name} run should exit 0, got ${proc.exitCode}: ${out}`);
+        if (!out.includes(probe.expect))
+          throw new Error(`Headroom ${probe.name} run should report "${probe.expect}": ${out}`);
+      }
     }
   } finally {
     clean(tmp);
@@ -1056,6 +1510,395 @@ console.log("--max-memory (builtin result builders survive mid-build collections
       if (exitCode !== 1) throw new Error(`Memory limit refusal (${label}) should exit 1, got ${exitCode}: ${JSON.stringify(json)}`);
       if (json.error?.type !== "MemoryLimitError") throw new Error(`Memory limit refusal (${label}) should report MemoryLimitError, got ${json.error?.type}`);
     }
+  }
+}
+
+// The data-format parse builtins are the other half of that convention. Their
+// handlers used to catch every Pascal exception out of the parser and re-throw it
+// as a SyntaxError, which is the same swallow in a different disguise: the
+// ceiling still reached the guest, but wearing a name that says "your input is
+// malformed" and carrying no message at all (a thrown JS value's Pascal Message
+// is empty by construction, so the conversion produced `SyntaxError: ` and
+// nothing else). Each handler now names only its own parse-error class, so a
+// refusal keeps its RangeError identity and its message.
+//
+// TOML is included even though its handler was already narrow — it is the
+// reference shape the others were brought in line with, and it should stay that
+// way. Both execution modes run, because a handler that only the VM path reaches
+// is a handler that can diverge.
+{
+  const ceilingTmp = mkdtemp("goccia-parse-ceiling-");
+  try {
+    const parkedParse: Array<[string, string[], string]> = [
+      ["JSON.parse", [], "JSON.parse(doc)"],
+      [
+        "JSON5.parse",
+        ['import * as JSON5NS from "goccia:json5"; const JSON5 = JSON5NS.JSON5 ?? JSON5NS;'],
+        "JSON5.parse(doc)",
+      ],
+      [
+        "YAML.parse",
+        ['import * as YAMLNS from "goccia:yaml"; const YAML = YAMLNS.YAML ?? YAMLNS;'],
+        'YAML.parse(Array.from({ length: 400 }, (_, i) => "k" + i + ": \'" + S + i + "\'").join("\\n") + "\\n")',
+      ],
+      [
+        "JSONL.parse",
+        ['import * as JSONLNS from "goccia:jsonl"; const JSONL = JSONLNS.JSONL ?? JSONLNS;'],
+        'JSONL.parse(Array.from({ length: 400 }, (_, i) => \'{"a":"\' + S + i + \'"}\').join("\\n") + "\\n")',
+      ],
+      [
+        "TOML.parse",
+        ['import * as TOMLNS from "goccia:toml"; const TOML = TOMLNS.TOML ?? TOMLNS;'],
+        'TOML.parse(Array.from({ length: 400 }, (_, i) => "k" + i + \' = "\' + S + i + \'"\').join("\\n") + "\\n")',
+      ],
+    ];
+
+    for (const [label, imports, parse] of parkedParse) {
+      for (const modeArgs of [[], ["--mode=bytecode"]] as const) {
+        const modeLabel = modeArgs.length > 0 ? "bytecode" : "interpreted";
+        console.log(`--max-memory (parse refusal keeps its RangeError: ${label} ${modeLabel})...`);
+        const src = [
+          ...imports,
+          'const S = "s".repeat(200);',
+          'const doc = "[" + Array.from({ length: 1200 }, (_, i) => \'"\' + S + i + \'"\').join(",") + "]";',
+          // Same measured parking as the parser probes above, kept local so this
+          // block reads on its own.
+          "const SLACK = 300000;",
+          "const iters = Array.from({ length: Math.ceil(Goccia.gc.maxBytes / 4096) + 64 }, (_, j) => j);",
+          "const ballast = [];",
+          "let slack = Goccia.gc.maxBytes;",
+          "Goccia.gc();",
+          "for (const pass of [0, 1, 2, 3, 4]) {",
+          "  for (const i of iters) {",
+          "    if (Goccia.gc.maxBytes - Goccia.gc.bytesAllocated <= SLACK) break;",
+          '    ballast.push("x".repeat(4096));',
+          "  }",
+          "  Goccia.gc();",
+          "  slack = Goccia.gc.maxBytes - Goccia.gc.bytesAllocated;",
+          "  if (slack <= SLACK) break;",
+          "}",
+          'console.log("parked", slack <= SLACK);',
+          "try {",
+          `  const value = ${parse};`,
+          '  console.log("completed", value === null || value === undefined ? "empty" : "value");',
+          "} catch (e) {",
+          "  console.log('caught', e.name, '::', e.message);",
+          "}",
+          "",
+        ].join("\n");
+        const srcPath = join(ceilingTmp, `parse-ceiling-${label.replace(".", "-")}-${modeLabel}.mjs`);
+        writeFileSync(srcPath, src);
+        const proc = Bun.spawnSync([LOADER, "--max-memory=4194304", ...modeArgs, srcPath], {
+          stdout: "pipe",
+          stderr: "pipe",
+          timeout: 180_000,
+        });
+        const out = proc.stdout.toString() + proc.stderr.toString();
+        if (!out.includes("parked true"))
+          throw new Error(`Parse-ceiling ${label} (${modeLabel}) never parked the heap: ${out}`);
+        if (/^caught \S+ ::\s*$/m.test(out))
+          throw new Error(
+            `Parse-ceiling ${label} (${modeLabel}) surfaced a refusal with an empty message: ${out}`,
+          );
+        if (out.includes("caught SyntaxError"))
+          throw new Error(
+            `Parse-ceiling ${label} (${modeLabel}) relabelled a memory ceiling as a SyntaxError: ${out}`,
+          );
+        if (!out.includes("caught RangeError") && !out.includes("completed"))
+          throw new Error(
+            `Parse-ceiling ${label} (${modeLabel}) produced neither a RangeError refusal nor a completed parse: ${out}`,
+          );
+      }
+    }
+  } finally {
+    clean(ceilingTmp);
+  }
+}
+
+// The narrowing above must not have made the OTHER limiter guest-visible. A
+// charged allocation inside a parse raises the script-catchable RangeError the
+// block above pins; the growth gate (RequireNativeBytes, Goccia.MemoryLimit.pas)
+// raises TGocciaMemoryLimitError, which is opaque to the guest by design — the
+// narrowed handlers name only their own parse-error class, so the gate passes
+// straight through them, escapes to the host, and the loader reports it as
+// "Fatal error: ... would exceed the memory budget" with a nonzero exit. A guest
+// catch marker printing here would mean a parse builtin had converted the
+// ceiling into something script code can absorb and retry in a loop.
+//
+// Goccia.MemoryLimit.Test.pas guards the same convention at the executor
+// boundaries; this lives here because the gate has to be reached mid-parse,
+// which needs a measured park against a CLI-set ceiling, and because the
+// assertion is host-level (exit code plus the loader's report).
+//
+// The shape: a wide object of cheap numeric values, so the parse charges almost
+// nothing per property (~24 bytes measured) while the property map's storage
+// doubling asks for a single block far larger than the parked slack. The
+// document is built before parking, or building it — not parsing it — is what
+// would cross the ceiling.
+{
+  const gateTmp = mkdtemp("goccia-parse-gate-");
+  try {
+    const gatedParses: Array<[string, string[], string, string]> = [
+      [
+        "JSON.parse",
+        [],
+        'const doc = "{" + Array.from({ length: 4000 }, (_, i) => \'"k\' + i + \'":\' + i).join(",") + "}";',
+        "JSON.parse(doc)",
+      ],
+      [
+        "JSON5.parse",
+        ['import * as JSON5NS from "goccia:json5"; const JSON5 = JSON5NS.JSON5 ?? JSON5NS;'],
+        'const doc = "{" + Array.from({ length: 4000 }, (_, i) => "k" + i + ": " + i).join(",") + "}";',
+        "JSON5.parse(doc)",
+      ],
+      [
+        "YAML.parse",
+        ['import * as YAMLNS from "goccia:yaml"; const YAML = YAMLNS.YAML ?? YAMLNS;'],
+        'const doc = Array.from({ length: 4000 }, (_, i) => "k" + i + ": " + i).join("\\n") + "\\n";',
+        "YAML.parse(doc)",
+      ],
+    ];
+
+    for (const [label, imports, setup, parse] of gatedParses) {
+      for (const modeArgs of [[], ["--mode=bytecode"]] as const) {
+        const modeLabel = modeArgs.length > 0 ? "bytecode" : "interpreted";
+        console.log(`--max-memory (growth gate inside ${label} stays opaque to the guest: ${modeLabel})...`);
+        const src = [
+          ...imports,
+          setup,
+          // 120000 sits in the middle of the measured window: the parse survives
+          // its own charges (~96 KB for 4000 properties) but the storage doubling
+          // asks for 73632 or 147360 bytes in one block and is refused.
+          "const SLACK = 120000;",
+          "const iters = Array.from({ length: Math.ceil(Goccia.gc.maxBytes / 4096) + 64 }, (_, j) => j);",
+          "const ballast = [];",
+          "let slack = Goccia.gc.maxBytes;",
+          "Goccia.gc();",
+          "for (const pass of [0, 1, 2, 3, 4]) {",
+          "  for (const i of iters) {",
+          "    if (Goccia.gc.maxBytes - Goccia.gc.bytesAllocated <= SLACK) break;",
+          '    ballast.push("x".repeat(4096));',
+          "  }",
+          "  Goccia.gc();",
+          "  slack = Goccia.gc.maxBytes - Goccia.gc.bytesAllocated;",
+          "  if (slack <= SLACK) break;",
+          "}",
+          'console.log("parked", slack <= SLACK);',
+          "try {",
+          `  const value = ${parse};`,
+          '  console.log("guest-completed", Object.keys(value).length);',
+          "} catch (e) {",
+          // The marker the gate must never let the guest print.
+          "  console.log('guest-caught', e.name, '::', e.message);",
+          "}",
+          "",
+        ].join("\n");
+        const srcPath = join(gateTmp, `parse-gate-${label.replace(".", "-")}-${modeLabel}.mjs`);
+        writeFileSync(srcPath, src);
+        const proc = Bun.spawnSync([LOADER, "--max-memory=4194304", ...modeArgs, srcPath], {
+          stdout: "pipe",
+          stderr: "pipe",
+          timeout: 180_000,
+        });
+        const out = proc.stdout.toString() + proc.stderr.toString();
+        if (!out.includes("parked true"))
+          throw new Error(`Parse gate ${label} (${modeLabel}) never parked the heap: ${out}`);
+        if (out.includes("guest-caught"))
+          throw new Error(
+            `Parse gate ${label} (${modeLabel}) let the guest catch a growth-gate refusal: ${out}`,
+          );
+        if (out.includes("guest-completed"))
+          throw new Error(
+            `Parse gate ${label} (${modeLabel}) never reached the growth gate, so it proved nothing: ${out}`,
+          );
+        if (proc.exitCode === 0)
+          throw new Error(`Parse gate ${label} (${modeLabel}) should exit nonzero, got 0: ${out}`);
+        if (!out.includes("would exceed the memory budget"))
+          throw new Error(
+            `Parse gate ${label} (${modeLabel}) failed without the budget refusal the host reports: ${out}`,
+          );
+      }
+    }
+  } finally {
+    clean(gateTmp);
+  }
+}
+
+// The stringify half of the same convention. JSON.stringify and JSON5.stringify
+// wrap their whole body in a handler that converts a Pascal exception into a
+// script-visible TypeError ("JSON.stringify error: ..."), and that handler had
+// no re-raise allowlist: a growth-gate refusal arrived at the guest as a
+// catchable TypeError carrying the budget text, which is the ceiling-you-can-
+// ignore-in-a-loop this whole convention exists to prevent. Both handlers now
+// name the limit family (timeout, instruction limit, memory limit) ahead of the
+// generic arm, as Goccia.Builtins.GlobalFetch.pas and Goccia.Interpreter.pas do.
+//
+// Reaching the gate from a stringify needs a replacer: the plain serializer
+// writes into a native buffer and only the result string is charged, while the
+// replacer walk rebuilds every object property-by-property, so the property
+// map's storage doubling is what asks for one block larger than the parked
+// slack. The same 4000-key cheap-value object and the same measured slack as
+// the parse block above land inside the window (measured: the gate is the
+// crossing limiter for a slack of roughly 10000-150000; at 160000 and above the
+// stringify simply completes).
+{
+  const stringifyGateTmp = mkdtemp("goccia-stringify-gate-");
+  const parkedStringifySource = (
+    imports: string[],
+    setup: string,
+    call: string,
+    slackTarget: number,
+  ): string =>
+    [
+      ...imports,
+      setup,
+      `const SLACK = ${slackTarget};`,
+      "const iters = Array.from({ length: Math.ceil(Goccia.gc.maxBytes / 4096) + 64 }, (_, j) => j);",
+      "const ballast = [];",
+      "let slack = Goccia.gc.maxBytes;",
+      "Goccia.gc();",
+      "for (const pass of [0, 1, 2, 3, 4]) {",
+      "  for (const i of iters) {",
+      "    if (Goccia.gc.maxBytes - Goccia.gc.bytesAllocated <= SLACK) break;",
+      '    ballast.push("x".repeat(4096));',
+      "  }",
+      "  Goccia.gc();",
+      "  slack = Goccia.gc.maxBytes - Goccia.gc.bytesAllocated;",
+      "  if (slack <= SLACK) break;",
+      "}",
+      'console.log("parked", slack <= SLACK);',
+      "try {",
+      `  const value = ${call};`,
+      '  console.log("guest-completed", value.length);',
+      "} catch (e) {",
+      // The marker the gate must never let the guest print.
+      "  console.log('guest-caught', e.name, '::', e.message);",
+      "}",
+      "",
+    ].join("\n");
+
+  try {
+    // The object is built before parking, or building it — not stringifying it —
+    // is what would cross the ceiling.
+    const wideObject =
+      'const obj = Object.fromEntries(Array.from({ length: 4000 }, (_, i) => ["k" + i, i]));';
+    const gatedStringifies: Array<[string, string[], string, string]> = [
+      ["JSON.stringify", [], wideObject, "JSON.stringify(obj, (k, v) => v)"],
+      [
+        "JSON5.stringify",
+        ['import * as JSON5NS from "goccia:json5"; const JSON5 = JSON5NS.JSON5 ?? JSON5NS;'],
+        wideObject,
+        "JSON5.stringify(obj, (k, v) => v)",
+      ],
+    ];
+
+    for (const [label, imports, setup, call] of gatedStringifies) {
+      for (const modeArgs of [[], ["--mode=bytecode"]] as const) {
+        const modeLabel = modeArgs.length > 0 ? "bytecode" : "interpreted";
+        console.log(`--max-memory (growth gate inside ${label} stays opaque to the guest: ${modeLabel})...`);
+        const srcPath = join(stringifyGateTmp, `stringify-gate-${label.replace(".", "-")}-${modeLabel}.mjs`);
+        writeFileSync(srcPath, parkedStringifySource(imports, setup, call, 120000));
+        const proc = Bun.spawnSync([LOADER, "--max-memory=4194304", ...modeArgs, srcPath], {
+          stdout: "pipe",
+          stderr: "pipe",
+          timeout: 180_000,
+        });
+        const out = proc.stdout.toString() + proc.stderr.toString();
+        if (!out.includes("parked true"))
+          throw new Error(`Stringify gate ${label} (${modeLabel}) never parked the heap: ${out}`);
+        if (out.includes("guest-caught"))
+          throw new Error(
+            `Stringify gate ${label} (${modeLabel}) let the guest catch a growth-gate refusal: ${out}`,
+          );
+        if (out.includes("guest-completed"))
+          throw new Error(
+            `Stringify gate ${label} (${modeLabel}) never reached the growth gate, so it proved nothing: ${out}`,
+          );
+        if (proc.exitCode === 0)
+          throw new Error(`Stringify gate ${label} (${modeLabel}) should exit nonzero, got 0: ${out}`);
+        if (!out.includes("would exceed the memory budget"))
+          throw new Error(
+            `Stringify gate ${label} (${modeLabel}) failed without the budget refusal the host reports: ${out}`,
+          );
+      }
+    }
+
+    // Vacuity control for the "no guest-caught" assertion above. The other
+    // limiter — a charged string allocation — is script-visible by design and
+    // always was, so the same harness pointed at a shape that only ever crosses
+    // the charge (no replacer, one oversized string) MUST print the marker the
+    // gate cases forbid. If this stops catching, the assertions above are
+    // passing because nothing reaches any limiter, not because the ceiling is
+    // opaque.
+    console.log("--max-memory (stringify gate vacuity control: a charged refusal is still catchable)...");
+    {
+      const controlPath = join(stringifyGateTmp, "stringify-gate-control.mjs");
+      writeFileSync(
+        controlPath,
+        parkedStringifySource([], 'const big = "y".repeat(400000);', "JSON.stringify(big)", 120000),
+      );
+      const proc = Bun.spawnSync([LOADER, "--max-memory=4194304", controlPath], {
+        stdout: "pipe",
+        stderr: "pipe",
+        timeout: 180_000,
+      });
+      const out = proc.stdout.toString() + proc.stderr.toString();
+      if (!out.includes("parked true"))
+        throw new Error(`Stringify gate control never parked the heap: ${out}`);
+      if (!out.includes("guest-caught RangeError"))
+        throw new Error(
+          `Stringify gate control should let the guest catch the charged RangeError, making the gate assertions non-vacuous: ${out}`,
+        );
+      if (proc.exitCode !== 0)
+        throw new Error(`Stringify gate control should exit 0, got ${proc.exitCode}: ${out}`);
+    }
+  } finally {
+    clean(stringifyGateTmp);
+  }
+}
+
+console.log("goccia:yaml (deep flow nesting reports a named, non-empty error)...");
+{
+  // Depth refusals out of the data-format parsers do not agree on a class, and
+  // that split is pre-existing and deliberate here: JSON, JSON5 and JSONL hit
+  // their own parser-internal nesting cap and report SyntaxError, while YAML and
+  // TOML hit the shared native depth guard (EnterNativeDataDepth) and report
+  // RangeError "Maximum call stack size exceeded". Documented, not changed.
+  //
+  // For YAML this is a reclassification the except-narrowing brought about: the
+  // blanket handler used to relabel the depth guard's RangeError as a SyntaxError
+  // with an empty message, so the guest could not tell a resource ceiling from
+  // malformed input. The message being non-empty is the half that regressed.
+  const depthTmp = mkdtemp("goccia-parse-depth-");
+  try {
+    const src = [
+      'import * as YAMLNS from "goccia:yaml"; const YAML = YAMLNS.YAML ?? YAMLNS;',
+      'const deep = "[".repeat(5000) + "]".repeat(5000);',
+      "const report = (label, parse) => {",
+      "  try {",
+      "    parse();",
+      '    console.log(label, "no-throw", "::", "no-throw");',
+      "  } catch (e) {",
+      "    console.log(label, e.name, '::', e.message);",
+      "  }",
+      "};",
+      'report("yaml", () => YAML.parse(deep));',
+      'report("json", () => JSON.parse(deep));',
+      "",
+    ].join("\n");
+    const srcPath = join(depthTmp, "parse-depth.mjs");
+    writeFileSync(srcPath, src);
+    const proc = Bun.spawnSync([LOADER, srcPath], { stdout: "pipe", stderr: "pipe", timeout: 60_000 });
+    const out = proc.stdout.toString() + proc.stderr.toString();
+    if (proc.exitCode !== 0) throw new Error(`Parse depth run should exit 0, got ${proc.exitCode}: ${out}`);
+    if (!/^yaml RangeError :: .+$/m.test(out))
+      throw new Error(`YAML deep flow nesting should report a named RangeError with a message: ${out}`);
+    if (!out.includes("yaml RangeError :: Maximum call stack size exceeded"))
+      throw new Error(`YAML deep flow nesting should report the native depth guard's message: ${out}`);
+    if (!/^json SyntaxError :: .+$/m.test(out))
+      throw new Error(`JSON deep nesting should report a SyntaxError with a message: ${out}`);
+  } finally {
+    clean(depthTmp);
   }
 }
 

--- a/scripts/test-cli.ts
+++ b/scripts/test-cli.ts
@@ -961,9 +961,17 @@ const parkingPreamble = (slackTarget: number): string[] => [
   // slack falls monotonically and a handful of passes converges. Measuring
   // before the collection is what let the old loop stop early: it was reading
   // garbage the next collection would hand straight back.
-  "for (const pass of [0, 1, 2, 3, 4]) {",
+  //
+  // The push threshold sits one ballast chunk below the target because each
+  // collection hands back a little transient garbage: pushing to exactly SLACK
+  // lets the post-collection measurement bounce back just above it and stall
+  // there for every remaining pass (CI stalled 116 bytes short of a 600000
+  // target this way — the baseline live set differs per platform, so the
+  // convergence point does too). The pass cap is a generous termination bound,
+  // not a calibration: parking breaks out early on the first pass that lands.
+  "for (const pass of Array.from({ length: 32 }, (_, p) => p)) {",
   "  for (const i of iters) {",
-  "    if (Goccia.gc.maxBytes - Goccia.gc.bytesAllocated <= SLACK) break;",
+  "    if (Goccia.gc.maxBytes - Goccia.gc.bytesAllocated <= SLACK - 8192) break;",
   '    ballast.push("x".repeat(4096));',
   "  }",
   "  Goccia.gc();",

--- a/source/units/Goccia.Builtins.GlobalPromise.pas
+++ b/source/units/Goccia.Builtins.GlobalPromise.pas
@@ -665,6 +665,30 @@ begin
   if Assigned(FState) then FState.MarkReferences;
 end;
 
+// Builds one Promise.allSettled result entry: `{ status, value }` for a
+// fulfilment, `{ status, reason }` for a rejection. The status string charges
+// the memory ceiling, and crossing it collects with only that string protected —
+// so the allocation is a GC safe point, and the entry is reachable only from
+// this frame until the caller stores it. (The property writes only check the
+// budget and raise; they never collect.) Callers root the returned entry across
+// that store.
+function CreateAllSettledEntry(const AStatus, APropertyName: string;
+  const AValue: TGocciaValue): TGocciaObjectValue;
+var
+  EntryRoot: TGocciaTempRoot;
+begin
+  InitializeTempRoot(EntryRoot);
+  Result := TGocciaObjectValue.Create(TGocciaObjectValue.SharedObjectPrototype);
+  AddTempRootIfNeeded(EntryRoot, Result);
+  try
+    Result.CreateDataPropertyOrThrow('status',
+      TGocciaStringLiteralValue.Create(AStatus));
+    Result.CreateDataPropertyOrThrow(APropertyName, AValue);
+  finally
+    RemoveTempRootIfNeeded(EntryRoot);
+  end;
+end;
+
 { TPromiseAllSettledFulfillHandler }
 
 constructor TPromiseAllSettledFulfillHandler.Create(
@@ -689,18 +713,13 @@ begin
     FAlreadyCalled.Called := True;
   if FState.Settled then Exit;
 
-  // The status string charges the memory ceiling, and crossing it collects with
-  // only that string protected — so the allocation is a GC safe point, and the
-  // entry is reachable only from this frame until it lands in the results array
-  // below. (The property writes only check the budget and raise; they never
-  // collect.)
+  // Nothing but this frame references the entry until it lands in the results
+  // array, so it stays rooted across the store as well as across its own
+  // construction (see CreateAllSettledEntry).
+  Entry := CreateAllSettledEntry('fulfilled', PROP_VALUE, AArgs.GetElement(0));
   InitializeTempRoot(EntryRoot);
+  AddTempRootIfNeeded(EntryRoot, Entry);
   try
-    Entry := TGocciaObjectValue.Create(TGocciaObjectValue.SharedObjectPrototype);
-    AddTempRootIfNeeded(EntryRoot, Entry);
-    Entry.CreateDataPropertyOrThrow('status',
-      TGocciaStringLiteralValue.Create('fulfilled'));
-    Entry.CreateDataPropertyOrThrow(PROP_VALUE, AArgs.GetElement(0));
     FState.Results.Elements[FIndex] := Entry;
   finally
     RemoveTempRootIfNeeded(EntryRoot);
@@ -746,16 +765,12 @@ begin
     FAlreadyCalled.Called := True;
   if FState.Settled then Exit;
 
-  // Same shape as the fulfill handler: the status string allocation is the GC
-  // safe point, and nothing but this frame references the entry until it is
-  // stored in the results array.
+  // Same shape as the fulfill handler: nothing but this frame references the
+  // entry until it is stored in the results array.
+  Entry := CreateAllSettledEntry('rejected', 'reason', AArgs.GetElement(0));
   InitializeTempRoot(EntryRoot);
+  AddTempRootIfNeeded(EntryRoot, Entry);
   try
-    Entry := TGocciaObjectValue.Create(TGocciaObjectValue.SharedObjectPrototype);
-    AddTempRootIfNeeded(EntryRoot, Entry);
-    Entry.CreateDataPropertyOrThrow('status',
-      TGocciaStringLiteralValue.Create('rejected'));
-    Entry.CreateDataPropertyOrThrow('reason', AArgs.GetElement(0));
     FState.Results.Elements[FIndex] := Entry;
   finally
     RemoveTempRootIfNeeded(EntryRoot);
@@ -926,23 +941,6 @@ begin
     AObject.AssignSymbolProperty(ASymbol, AValue)
   else
     AObject.AssignProperty(AName, AValue);
-end;
-
-function CreateAllSettledEntry(const AStatus, APropertyName: string;
-  const AValue: TGocciaValue): TGocciaObjectValue;
-var
-  EntryRoot: TGocciaTempRoot;
-begin
-  InitializeTempRoot(EntryRoot);
-  Result := TGocciaObjectValue.Create(TGocciaObjectValue.SharedObjectPrototype);
-  AddTempRootIfNeeded(EntryRoot, Result);
-  try
-    Result.CreateDataPropertyOrThrow('status',
-      TGocciaStringLiteralValue.Create(AStatus));
-    Result.CreateDataPropertyOrThrow(APropertyName, AValue);
-  finally
-    RemoveTempRootIfNeeded(EntryRoot);
-  end;
 end;
 
 { TPromiseKeyedFulfillHandler }

--- a/source/units/Goccia.Builtins.GlobalPromise.pas
+++ b/source/units/Goccia.Builtins.GlobalPromise.pas
@@ -681,6 +681,7 @@ function TPromiseAllSettledFulfillHandler.Invoke(const AArgs: TGocciaArgumentsCo
   const AThisValue: TGocciaValue): TGocciaValue;
 var
   Entry: TGocciaObjectValue;
+  EntryRoot: TGocciaTempRoot;
 begin
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   if Assigned(FAlreadyCalled) and FAlreadyCalled.Called then Exit;
@@ -688,11 +689,22 @@ begin
     FAlreadyCalled.Called := True;
   if FState.Settled then Exit;
 
-  Entry := TGocciaObjectValue.Create(TGocciaObjectValue.SharedObjectPrototype);
-  Entry.CreateDataPropertyOrThrow('status',
-    TGocciaStringLiteralValue.Create('fulfilled'));
-  Entry.CreateDataPropertyOrThrow(PROP_VALUE, AArgs.GetElement(0));
-  FState.Results.Elements[FIndex] := Entry;
+  // The status string charges the memory ceiling, and crossing it collects with
+  // only that string protected — so the allocation is a GC safe point, and the
+  // entry is reachable only from this frame until it lands in the results array
+  // below. (The property writes only check the budget and raise; they never
+  // collect.)
+  InitializeTempRoot(EntryRoot);
+  try
+    Entry := TGocciaObjectValue.Create(TGocciaObjectValue.SharedObjectPrototype);
+    AddTempRootIfNeeded(EntryRoot, Entry);
+    Entry.CreateDataPropertyOrThrow('status',
+      TGocciaStringLiteralValue.Create('fulfilled'));
+    Entry.CreateDataPropertyOrThrow(PROP_VALUE, AArgs.GetElement(0));
+    FState.Results.Elements[FIndex] := Entry;
+  finally
+    RemoveTempRootIfNeeded(EntryRoot);
+  end;
   FState.Remaining := FState.Remaining - 1;
 
   if FState.Remaining = 0 then
@@ -726,6 +738,7 @@ function TPromiseAllSettledRejectHandler.Invoke(const AArgs: TGocciaArgumentsCol
   const AThisValue: TGocciaValue): TGocciaValue;
 var
   Entry: TGocciaObjectValue;
+  EntryRoot: TGocciaTempRoot;
 begin
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   if Assigned(FAlreadyCalled) and FAlreadyCalled.Called then Exit;
@@ -733,11 +746,20 @@ begin
     FAlreadyCalled.Called := True;
   if FState.Settled then Exit;
 
-  Entry := TGocciaObjectValue.Create(TGocciaObjectValue.SharedObjectPrototype);
-  Entry.CreateDataPropertyOrThrow('status',
-    TGocciaStringLiteralValue.Create('rejected'));
-  Entry.CreateDataPropertyOrThrow('reason', AArgs.GetElement(0));
-  FState.Results.Elements[FIndex] := Entry;
+  // Same shape as the fulfill handler: the status string allocation is the GC
+  // safe point, and nothing but this frame references the entry until it is
+  // stored in the results array.
+  InitializeTempRoot(EntryRoot);
+  try
+    Entry := TGocciaObjectValue.Create(TGocciaObjectValue.SharedObjectPrototype);
+    AddTempRootIfNeeded(EntryRoot, Entry);
+    Entry.CreateDataPropertyOrThrow('status',
+      TGocciaStringLiteralValue.Create('rejected'));
+    Entry.CreateDataPropertyOrThrow('reason', AArgs.GetElement(0));
+    FState.Results.Elements[FIndex] := Entry;
+  finally
+    RemoveTempRootIfNeeded(EntryRoot);
+  end;
   FState.Remaining := FState.Remaining - 1;
 
   if FState.Remaining = 0 then

--- a/source/units/Goccia.Builtins.JSON.pas
+++ b/source/units/Goccia.Builtins.JSON.pas
@@ -60,7 +60,10 @@ uses
   Goccia.Constants.PropertyNames,
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
+  Goccia.InstructionLimit,
+  Goccia.MemoryLimit,
   Goccia.ThreadCleanupRegistry,
+  Goccia.Timeout,
   Goccia.Utils,
   Goccia.Values.BigIntValue,
   Goccia.Values.Error,
@@ -297,10 +300,16 @@ begin
     InitializeTempRoot(HolderRoot);
     try
       // Step 2: Parse with parse-record tracking for the reviver context.
+      // Only the parser's own error means "this text is not JSON". A blanket
+      // Exception arm here also swallowed the engine's own failures: a refused
+      // allocation (TGocciaThrowValue carrying a RangeError, whose Pascal Message
+      // is empty by construction) became `SyntaxError: ` with no message, and a
+      // ceiling the guest can mistake for a syntax error is a ceiling it can
+      // retry in a loop. Everything that is not a parse error re-raises.
       try
         FParser.ParseWithRecord(JSONString, Result, ParseRecord);
       except
-        on E: Exception do
+        on E: EGocciaJSONParseError do
           ThrowSyntaxError(E.Message, SSuggestJSONFormat);
       end;
 
@@ -327,7 +336,7 @@ begin
     try
       Result := FParser.Parse(JSONString);
     except
-      on E: Exception do
+      on E: EGocciaJSONParseError do
         ThrowSyntaxError(E.Message, SSuggestJSONFormat);
     end;
   end;
@@ -369,10 +378,13 @@ begin
     ThrowSyntaxError(SErrorJSONRawJSONTrailingWhitespace, SSuggestJSONFormat);
 
   // Step 3: Parse jsonString as a JSON text. Throw SyntaxError if invalid.
+  // Narrow for the same reason as JSONParse: an engine failure is not a syntax
+  // error, and reporting it as one hides a refused allocation behind an empty
+  // message.
   try
     Parsed := FParser.Parse(JSONString);
   except
-    on E: Exception do
+    on E: EGocciaJSONParseError do
       ThrowSyntaxError(Format(SErrorJSONRawJSONInvalid, [E.Message]), SSuggestJSONFormat);
   end;
 
@@ -737,6 +749,21 @@ begin
       Result := TGocciaStringLiteralValue.Create(Stringified);
   except
     on E: TGocciaThrowValue do
+      raise;
+    // The generic arm below exists for the serializer's own native failures —
+    // anything the stringifier or a user toJSON/replacer surfaces as a plain
+    // Pascal exception — and turns them into a script-visible TypeError. The
+    // limit family is not that: WriteValue polls the deadline and the
+    // instruction counter (CheckNativeWork), and building the replacer's
+    // transformed copy grows property storage through the memory gate, so all
+    // three can land here. Converting one would hand the guest a ceiling it can
+    // catch and retry in a loop, which is exactly what the limit family is
+    // opaque to prevent (see Goccia.MemoryLimit.pas).
+    on E: TGocciaTimeoutError do
+      raise;
+    on E: TGocciaInstructionLimitError do
+      raise;
+    on E: TGocciaMemoryLimitError do
       raise;
     on E: Exception do
     begin

--- a/source/units/Goccia.Builtins.JSON5.pas
+++ b/source/units/Goccia.Builtins.JSON5.pas
@@ -73,7 +73,11 @@ uses
   Goccia.Constants.PropertyNames,
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
+  Goccia.GarbageCollector,
+  Goccia.InstructionLimit,
+  Goccia.MemoryLimit,
   Goccia.ThreadCleanupRegistry,
+  Goccia.Timeout,
   Goccia.Utils,
   Goccia.Values.Error,
   Goccia.Values.ErrorHelper,
@@ -168,55 +172,73 @@ var
   Obj: TGocciaObjectValue;
   PropKey: string;
   Value: TGocciaValue;
+  ValueRoot, ContextRoot: TGocciaTempRoot;
 begin
   Value := AHolder.GetProperty(AKey);
 
-  if Value is TGocciaObjectValue then
-  begin
-    Obj := TGocciaObjectValue(Value);
-    if Obj is TGocciaArrayValue then
+  InitializeTempRoot(ValueRoot);
+  InitializeTempRoot(ContextRoot);
+  try
+    // Every recursion below ends in a reviver call, and the reviver is arbitrary
+    // user code — a GC safe point that can also delete the holder property this
+    // value came from. Between the read above and the call at the end, this
+    // frame is the only thing holding it.
+    AddTempRootIfNeeded(ValueRoot, Value);
+
+    if Value is TGocciaObjectValue then
     begin
-      Arr := TGocciaArrayValue(Obj);
-      for I := 0 to Arr.Elements.Count - 1 do
+      Obj := TGocciaObjectValue(Value);
+      if Obj is TGocciaArrayValue then
       begin
-        NewValue := ApplyReviver(Arr, IntToStr(I), AReviver);
-        if NewValue is TGocciaUndefinedLiteralValue then
-          Arr.Elements[I] := TGocciaHoleValue.HoleValue
-        else
-          Arr.Elements[I] := NewValue;
-      end;
-    end
-    else
-    begin
-      for PropKey in Obj.GetEnumerablePropertyNames do
+        Arr := TGocciaArrayValue(Obj);
+        for I := 0 to Arr.Elements.Count - 1 do
+        begin
+          NewValue := ApplyReviver(Arr, IntToStr(I), AReviver);
+          if NewValue is TGocciaUndefinedLiteralValue then
+            Arr.Elements[I] := TGocciaHoleValue.HoleValue
+          else
+            Arr.Elements[I] := NewValue;
+        end;
+      end
+      else
       begin
-        NewValue := ApplyReviver(Obj, PropKey, AReviver);
-        if NewValue is TGocciaUndefinedLiteralValue then
-          Obj.DeleteProperty(PropKey)
-        else
-          Obj.AssignProperty(PropKey, NewValue);
+        for PropKey in Obj.GetEnumerablePropertyNames do
+        begin
+          NewValue := ApplyReviver(Obj, PropKey, AReviver);
+          if NewValue is TGocciaUndefinedLiteralValue then
+            Obj.DeleteProperty(PropKey)
+          else
+            Obj.AssignProperty(PropKey, NewValue);
+        end;
       end;
     end;
-  end;
 
-  // Build the context object for source text access.
-  Context := TGocciaObjectValue.Create;
-  if not (Value is TGocciaObjectValue) and Assigned(FReviverSourceTexts) and
-    (FReviverSourceIndex < FReviverSourceTexts.Count) then
-  begin
-    Context.AssignProperty(PROP_SOURCE,
-      TGocciaStringLiteralValue.Create(FReviverSourceTexts[FReviverSourceIndex]));
-    Inc(FReviverSourceIndex);
-  end;
+    // Build the context object for source text access.
+    Context := TGocciaObjectValue.Create;
+    // Nothing references the context until it enters the argument list below,
+    // and the source-text property write plus the argument allocations in
+    // between are all allocation points that can collect it.
+    AddTempRootIfNeeded(ContextRoot, Context);
+    if not (Value is TGocciaObjectValue) and Assigned(FReviverSourceTexts) and
+      (FReviverSourceIndex < FReviverSourceTexts.Count) then
+    begin
+      Context.AssignProperty(PROP_SOURCE,
+        TGocciaStringLiteralValue.Create(FReviverSourceTexts[FReviverSourceIndex]));
+      Inc(FReviverSourceIndex);
+    end;
 
-  Args := TGocciaArgumentsCollection.CreateWithCapacity(3);
-  try
-    Args.Add(TGocciaStringLiteralValue.Create(AKey));
-    Args.Add(Value);
-    Args.Add(Context);
-    Result := InvokeCallable(AReviver, Args, AHolder);
+    Args := TGocciaArgumentsCollection.CreateWithCapacity(3);
+    try
+      Args.Add(TGocciaStringLiteralValue.Create(AKey));
+      Args.Add(Value);
+      Args.Add(Context);
+      Result := InvokeCallable(AReviver, Args, AHolder);
+    finally
+      Args.Free;
+    end;
   finally
-    Args.Free;
+    RemoveTempRootIfNeeded(ContextRoot);
+    RemoveTempRootIfNeeded(ValueRoot);
   end;
 end;
 
@@ -224,6 +246,7 @@ function TGocciaJSON5Builtin.ApplyToJSON(const AValue: TGocciaValue;
   const AKey: string): TGocciaValue;
 var
   Args: TGocciaArgumentsCollection;
+  MethodRoot: TGocciaTempRoot;
   ToJSONMethod: TGocciaValue;
 begin
   Result := AValue;
@@ -236,12 +259,20 @@ begin
   if not Assigned(ToJSONMethod) or not ToJSONMethod.IsCallable then
     Exit;
 
-  Args := TGocciaArgumentsCollection.CreateWithCapacity(1);
+  InitializeTempRoot(MethodRoot);
   try
-    Args.Add(TGocciaStringLiteralValue.Create(AKey));
-    Result := InvokeCallable(ToJSONMethod, Args, AValue);
+    // An accessor can hand back a function that lives nowhere else, and both
+    // allocations below happen before the call that finally uses it.
+    AddTempRootIfNeeded(MethodRoot, ToJSONMethod);
+    Args := TGocciaArgumentsCollection.CreateWithCapacity(1);
+    try
+      Args.Add(TGocciaStringLiteralValue.Create(AKey));
+      Result := InvokeCallable(ToJSONMethod, Args, AValue);
+    finally
+      Args.Free;
+    end;
   finally
-    Args.Free;
+    RemoveTempRootIfNeeded(MethodRoot);
   end;
 end;
 
@@ -281,72 +312,102 @@ var
   Replaced: TGocciaValue;
   TransformedProp: TGocciaValue;
   Len: Integer;
+  ReplacedRoot, ResultRoot, PropValueRoot, TransformedPropRoot: TGocciaTempRoot;
 begin
-  Replaced := ApplyToJSON(AValue, AKey);
-  Replaced := ApplyReplacer(AHolder, AKey, Replaced, AReplacer);
-  // ES2026 §25.5.4.2 steps 4.b-4.d: unwrap boxed primitives.
-  Replaced := CoerceWrappedPrimitive(Replaced);
+  // The replacer is user code and so is every accessor this walk reads through,
+  // which makes each of them a GC safe point. Nothing in this frame is reachable
+  // from a real root while that code runs: the value the replacer returned, the
+  // partially built copy, and the property being transformed all live only in
+  // these locals. FReplacerTraversalStack is a plain TList and is not a root
+  // either, so the entry this frame pushes onto it is rooted here as well — that
+  // is what keeps the whole ancestor chain alive across a nested replacer call.
+  // The nest-safe TGocciaTempRoot form is used because the roots are re-pointed
+  // as the walk proceeds, and the finally releases whatever is left rooted.
+  InitializeTempRoot(ReplacedRoot);
+  InitializeTempRoot(ResultRoot);
+  InitializeTempRoot(PropValueRoot);
+  InitializeTempRoot(TransformedPropRoot);
+  try
+    Replaced := ApplyToJSON(AValue, AKey);
+    AddTempRootIfNeeded(ReplacedRoot, Replaced);
+    Replaced := ApplyReplacer(AHolder, AKey, Replaced, AReplacer);
+    AddTempRootIfNeeded(ReplacedRoot, Replaced);
+    // ES2026 §25.5.4.2 steps 4.b-4.d: unwrap boxed primitives.
+    Replaced := CoerceWrappedPrimitive(Replaced);
+    AddTempRootIfNeeded(ReplacedRoot, Replaced);
 
-  if Replaced is TGocciaUndefinedLiteralValue then
-  begin
-    Result := Replaced;
-    Exit;
-  end;
-
-  if Replaced.IsCallable or (Replaced is TGocciaSymbolValue) then
-  begin
-    Result := Replaced;
-    Exit;
-  end;
-
-  if Replaced is TGocciaArrayValue then
-  begin
-    if FReplacerTraversalStack.IndexOf(TGocciaArrayValue(Replaced)) <> -1 then
-      ThrowTypeError(SErrorCircularStructureToJSON5, SSuggestJSONFormat);
-
-    FReplacerTraversalStack.Add(TGocciaArrayValue(Replaced));
-    Arr := TGocciaArrayValue(Replaced);
-    NewArr := TGocciaArrayValue.Create;
-    try
-      Len := LengthOfArrayLike(Arr);
-      for I := 0 to Len - 1 do
-      begin
-        PropValue := Arr.GetProperty(IntToStr(I));
-        TransformedProp := TransformWithReplacer(Arr, IntToStr(I), PropValue,
-          AReplacer);
-        NewArr.Elements.Add(TransformedProp);
-      end;
-    finally
-      FReplacerTraversalStack.Delete(FReplacerTraversalStack.Count - 1);
+    if Replaced is TGocciaUndefinedLiteralValue then
+    begin
+      Result := Replaced;
+      Exit;
     end;
-    Result := NewArr;
-  end
-  else if (Replaced is TGocciaObjectValue) and
-    not (Replaced is TGocciaArrayValue) then
-  begin
-    if FReplacerTraversalStack.IndexOf(TGocciaObjectValue(Replaced)) <> -1 then
-      ThrowTypeError(SErrorCircularStructureToJSON5, SSuggestJSONFormat);
 
-    FReplacerTraversalStack.Add(TGocciaObjectValue(Replaced));
-    Obj := TGocciaObjectValue(Replaced);
-    NewObj := TGocciaObjectValue.Create;
-    try
-      for Key in Obj.GetEnumerablePropertyNames do
-      begin
-        PropValue := Obj.GetProperty(Key);
-        TransformedProp := TransformWithReplacer(Obj, Key, PropValue, AReplacer);
-        if not ((TransformedProp is TGocciaUndefinedLiteralValue) or
-          TransformedProp.IsCallable or
-          (TransformedProp is TGocciaSymbolValue)) then
-          NewObj.AssignProperty(Key, TransformedProp);
-      end;
-    finally
-      FReplacerTraversalStack.Delete(FReplacerTraversalStack.Count - 1);
+    if Replaced.IsCallable or (Replaced is TGocciaSymbolValue) then
+    begin
+      Result := Replaced;
+      Exit;
     end;
-    Result := NewObj;
-  end
-  else
-    Result := Replaced;
+
+    if Replaced is TGocciaArrayValue then
+    begin
+      if FReplacerTraversalStack.IndexOf(TGocciaArrayValue(Replaced)) <> -1 then
+        ThrowTypeError(SErrorCircularStructureToJSON5, SSuggestJSONFormat);
+
+      FReplacerTraversalStack.Add(TGocciaArrayValue(Replaced));
+      Arr := TGocciaArrayValue(Replaced);
+      NewArr := TGocciaArrayValue.Create;
+      AddTempRootIfNeeded(ResultRoot, NewArr);
+      try
+        Len := LengthOfArrayLike(Arr);
+        for I := 0 to Len - 1 do
+        begin
+          PropValue := Arr.GetProperty(IntToStr(I));
+          AddTempRootIfNeeded(PropValueRoot, PropValue);
+          TransformedProp := TransformWithReplacer(Arr, IntToStr(I), PropValue,
+            AReplacer);
+          AddTempRootIfNeeded(TransformedPropRoot, TransformedProp);
+          NewArr.Elements.Add(TransformedProp);
+        end;
+      finally
+        FReplacerTraversalStack.Delete(FReplacerTraversalStack.Count - 1);
+      end;
+      Result := NewArr;
+    end
+    else if (Replaced is TGocciaObjectValue) and
+      not (Replaced is TGocciaArrayValue) then
+    begin
+      if FReplacerTraversalStack.IndexOf(TGocciaObjectValue(Replaced)) <> -1 then
+        ThrowTypeError(SErrorCircularStructureToJSON5, SSuggestJSONFormat);
+
+      FReplacerTraversalStack.Add(TGocciaObjectValue(Replaced));
+      Obj := TGocciaObjectValue(Replaced);
+      NewObj := TGocciaObjectValue.Create;
+      AddTempRootIfNeeded(ResultRoot, NewObj);
+      try
+        for Key in Obj.GetEnumerablePropertyNames do
+        begin
+          PropValue := Obj.GetProperty(Key);
+          AddTempRootIfNeeded(PropValueRoot, PropValue);
+          TransformedProp := TransformWithReplacer(Obj, Key, PropValue, AReplacer);
+          AddTempRootIfNeeded(TransformedPropRoot, TransformedProp);
+          if not ((TransformedProp is TGocciaUndefinedLiteralValue) or
+            TransformedProp.IsCallable or
+            (TransformedProp is TGocciaSymbolValue)) then
+            NewObj.AssignProperty(Key, TransformedProp);
+        end;
+      finally
+        FReplacerTraversalStack.Delete(FReplacerTraversalStack.Count - 1);
+      end;
+      Result := NewObj;
+    end
+    else
+      Result := Replaced;
+  finally
+    RemoveTempRootIfNeeded(TransformedPropRoot);
+    RemoveTempRootIfNeeded(PropValueRoot);
+    RemoveTempRootIfNeeded(ResultRoot);
+    RemoveTempRootIfNeeded(ReplacedRoot);
+  end;
 end;
 
 // The upstream json5 stringifier never coerces quote explicitly, but every
@@ -441,24 +502,38 @@ var
   PreviousTraversalStack: TList<TGocciaObjectValue>;
   Root: TGocciaObjectValue;
   Transformed: TGocciaValue;
+  HolderRoot, TransformedRoot: TGocciaTempRoot;
 begin
-  Root := TGocciaObjectValue.Create;
-  Root.AssignProperty('', AValue);
-  PreviousTraversalStack := FReplacerTraversalStack;
-  FReplacerTraversalStack := TList<TGocciaObjectValue>.Create;
+  InitializeTempRoot(HolderRoot);
+  InitializeTempRoot(TransformedRoot);
   try
-    Transformed := TransformWithReplacer(Root, '', AValue, AReplacer);
+    Root := TGocciaObjectValue.Create;
+    // The wrapper exists only for this call and is the replacer's `this`, so
+    // this local is its only reference for as long as user code can run.
+    AddTempRootIfNeeded(HolderRoot, Root);
+    Root.AssignProperty('', AValue);
+    PreviousTraversalStack := FReplacerTraversalStack;
+    FReplacerTraversalStack := TList<TGocciaObjectValue>.Create;
+    try
+      Transformed := TransformWithReplacer(Root, '', AValue, AReplacer);
 
-    if RootResultShouldBeUndefined(Transformed) then
-    begin
-      Result := '';
-      Exit;
+      if RootResultShouldBeUndefined(Transformed) then
+      begin
+        Result := '';
+        Exit;
+      end;
+
+      // The transformed tree is freshly built and reachable from nothing else;
+      // serializing it allocates the result string's intermediate values.
+      AddTempRootIfNeeded(TransformedRoot, Transformed);
+      Result := FStringifier.Stringify(Transformed, AGap, APreferredQuoteChar);
+    finally
+      FReplacerTraversalStack.Free;
+      FReplacerTraversalStack := PreviousTraversalStack;
     end;
-
-    Result := FStringifier.Stringify(Transformed, AGap, APreferredQuoteChar);
   finally
-    FReplacerTraversalStack.Free;
-    FReplacerTraversalStack := PreviousTraversalStack;
+    RemoveTempRootIfNeeded(TransformedRoot);
+    RemoveTempRootIfNeeded(HolderRoot);
   end;
 end;
 
@@ -505,6 +580,7 @@ var
   Reviver: TGocciaValue;
   Root: TGocciaObjectValue;
   SourceTexts: TUnicodeStringList;
+  ParsedRoot, HolderRoot: TGocciaTempRoot;
 begin
   TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'JSON5.parse', ThrowError);
 
@@ -517,16 +593,31 @@ begin
   begin
     Reviver := AArgs.GetElement(1);
     SourceTexts := TUnicodeStringList.Create;
+    InitializeTempRoot(ParsedRoot);
+    InitializeTempRoot(HolderRoot);
     try
+      // EGocciaJSON5ParseError descends from EGocciaJSONParseError, and the
+      // reviver path goes through the inherited ParseWithSources, which raises the
+      // base class — so one arm covers both. A blanket Exception arm here also
+      // swallowed the engine's own failures: a refused allocation
+      // (TGocciaThrowValue carrying a RangeError, whose Pascal Message is empty by
+      // construction) became `SyntaxError: ` with no message, and a ceiling the
+      // guest can mistake for a syntax error is a ceiling it can retry in a loop.
       try
         FParser.ParseWithSources(
           AArgs.GetElement(0).ToStringLiteral.Value, Result, SourceTexts);
       except
-        on E: Exception do
+        on E: EGocciaJSONParseError do
           ThrowSyntaxError(E.Message, SSuggestJSONFormat);
       end;
 
+      // The parsed tree is held only by this frame until the wrapper's property
+      // write below, and creating the wrapper allocates.
+      AddTempRootIfNeeded(ParsedRoot, Result);
       Root := TGocciaObjectValue.Create;
+      // The wrapper is the reviver's `this` and exists solely for this call, so
+      // nothing else keeps it alive while the reviver runs user code.
+      AddTempRootIfNeeded(HolderRoot, Root);
       Root.AssignProperty('', Result);
 
       // Save/restore for reentrancy (reviver may call JSON5.parse).
@@ -541,6 +632,8 @@ begin
         FReviverSourceIndex := PreviousSourceIndex;
       end;
     finally
+      RemoveTempRootIfNeeded(HolderRoot);
+      RemoveTempRootIfNeeded(ParsedRoot);
       SourceTexts.Free;
     end;
   end
@@ -549,7 +642,7 @@ begin
     try
       Result := FParser.Parse(AArgs.GetElement(0).ToStringLiteral.Value);
     except
-      on E: Exception do
+      on E: EGocciaJSONParseError do
         ThrowSyntaxError(E.Message, SSuggestJSONFormat);
     end;
   end;
@@ -638,6 +731,16 @@ begin
     end;
   except
     on E: TGocciaThrowValue do
+      raise;
+    // Same allowlist as JSON.stringify, and for the same reason: the generic arm
+    // is for the serializer's own native failures, while the deadline poll, the
+    // instruction counter and the property-storage growth gate all reach here
+    // too. A ceiling the guest can catch is a ceiling it can ignore in a loop.
+    on E: TGocciaTimeoutError do
+      raise;
+    on E: TGocciaInstructionLimitError do
+      raise;
+    on E: TGocciaMemoryLimitError do
       raise;
     on E: Exception do
     begin

--- a/source/units/Goccia.Builtins.JSONL.pas
+++ b/source/units/Goccia.Builtins.JSONL.pas
@@ -46,6 +46,7 @@ uses
   Goccia.Constants.ErrorNames,
   Goccia.Constants.PropertyNames,
   Goccia.Error.Messages,
+  Goccia.GarbageCollector,
   Goccia.ThreadCleanupRegistry,
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
@@ -120,21 +121,47 @@ function TGocciaJSONLBuiltin.BuildChunkResultObject(
 var
   ErrorValue: TGocciaValue;
   ResultObject: TGocciaObjectValue;
+  ValuesRoot: TGocciaTempRoot;
+  ResultRoot: TGocciaTempRoot;
+  ErrorRoot: TGocciaTempRoot;
 begin
-  ResultObject := TGocciaObjectValue.Create;
-  if AChunkResult.ErrorMessage = '' then
-    ErrorValue := TGocciaNullLiteralValue.NullValue
-  else
-    ErrorValue := CreateErrorObject(SYNTAX_ERROR_NAME, AChunkResult.ErrorMessage,
-      1);
+  { CreateErrorObject builds its message string, and a non-empty string charges
+    the memory ceiling — which collects when crossed, protecting only that
+    string. So the parsed values array, the result object, and the error object
+    are all rooted until the assignments below store them. (The property writes
+    themselves only check the budget and raise; they never collect.)
 
-  ResultObject.AssignProperty(PROP_VALUES, AChunkResult.Values);
-  ResultObject.AssignProperty(PROP_READ,
-    TGocciaNumberLiteralValue.Create(AChunkResult.Read));
-  ResultObject.AssignProperty(PROP_DONE,
-    TGocciaBooleanLiteralValue.Create(AChunkResult.Done));
-  ResultObject.AssignProperty(PROP_ERROR, ErrorValue);
-  Result := ResultObject;
+    The values array arrives already-parsed but still unreachable: the root
+    TGocciaJSONLParser.ParseChunk holds over it for the duration of its own loop
+    is gone by the time it returns, so this hand-off window needs its own. }
+  InitializeTempRoot(ValuesRoot);
+  InitializeTempRoot(ResultRoot);
+  InitializeTempRoot(ErrorRoot);
+  AddTempRootIfNeeded(ValuesRoot, AChunkResult.Values);
+  try
+    ResultObject := TGocciaObjectValue.Create;
+    AddTempRootIfNeeded(ResultRoot, ResultObject);
+    if AChunkResult.ErrorMessage = '' then
+      ErrorValue := TGocciaNullLiteralValue.NullValue
+    else
+    begin
+      ErrorValue := CreateErrorObject(SYNTAX_ERROR_NAME,
+        AChunkResult.ErrorMessage, 1);
+      AddTempRootIfNeeded(ErrorRoot, ErrorValue);
+    end;
+
+    ResultObject.AssignProperty(PROP_VALUES, AChunkResult.Values);
+    ResultObject.AssignProperty(PROP_READ,
+      TGocciaNumberLiteralValue.Create(AChunkResult.Read));
+    ResultObject.AssignProperty(PROP_DONE,
+      TGocciaBooleanLiteralValue.Create(AChunkResult.Done));
+    ResultObject.AssignProperty(PROP_ERROR, ErrorValue);
+    Result := ResultObject;
+  finally
+    RemoveTempRootIfNeeded(ErrorRoot);
+    RemoveTempRootIfNeeded(ResultRoot);
+    RemoveTempRootIfNeeded(ValuesRoot);
+  end;
 end;
 
 function TGocciaJSONLBuiltin.JSONLParse(const AArgs: TGocciaArgumentsCollection;

--- a/source/units/Goccia.Builtins.YAML.pas
+++ b/source/units/Goccia.Builtins.YAML.pas
@@ -95,7 +95,13 @@ begin
   try
     Result := FParser.Parse(AArgs.GetElement(0).ToStringLiteral.Value);
   except
-    on E: Exception do
+    // Only the parser's own error means "this text is not YAML", and every
+    // diagnostic it raises is one of these. A blanket Exception arm also
+    // swallowed the engine's own failures: a refused allocation
+    // (TGocciaThrowValue carrying a RangeError, whose Pascal Message is empty by
+    // construction) became `SyntaxError: ` with no message, and a ceiling the
+    // guest can mistake for a syntax error is a ceiling it can retry in a loop.
+    on E: EGocciaYAMLParseError do
       ThrowSyntaxError(E.Message, SSuggestYAMLSyntax);
   end;
 end;
@@ -111,7 +117,7 @@ begin
   try
     Result := FParser.ParseDocuments(AArgs.GetElement(0).ToStringLiteral.Value);
   except
-    on E: Exception do
+    on E: EGocciaYAMLParseError do
       ThrowSyntaxError(E.Message, SSuggestYAMLSyntax);
   end;
 end;

--- a/source/units/Goccia.JSON.pas
+++ b/source/units/Goccia.JSON.pas
@@ -94,6 +94,7 @@ uses
   Goccia.Arguments.Collection,
   Goccia.Constants.PropertyNames,
   Goccia.Error.Messages,
+  Goccia.GarbageCollector,
   Goccia.JSON.Utils,
   Goccia.NativeLimits,
   Goccia.Utils,
@@ -109,8 +110,28 @@ uses
   Goccia.Values.WrapperPrimitives;
 
 type
+  TGocciaJSONVisitor = class;
+
+  // The visitor builds its tree in FStack and FResult, both plain Pascal fields
+  // the collector cannot see, and the native stack is never scanned. Every
+  // non-empty string the visitor creates charges the memory ceiling, and
+  // crossing it collects with only the new string protected — which would sweep
+  // the whole in-progress tree. This root source marks that tree instead, for as
+  // long as the visitor it belongs to is alive.
+  //
+  // The visitor cannot be a TGCRootSource itself: TAbstractJSONParser is already
+  // its ancestor.
+  TGocciaJSONVisitorRoots = class(TGCRootSource)
+  private
+    FVisitor: TGocciaJSONVisitor;
+  public
+    constructor Create(const AVisitor: TGocciaJSONVisitor);
+    procedure MarkRootReferences; override;
+  end;
+
   TGocciaJSONVisitor = class(TAbstractJSONParser)
   private
+    FRoots: TGocciaJSONVisitorRoots;
     FCollectRecords: Boolean;
     FCollectSources: Boolean;
     FKeyStack: TUnicodeStringList;
@@ -374,6 +395,36 @@ begin
   end;
 end;
 
+{ TGocciaJSONVisitorRoots }
+
+constructor TGocciaJSONVisitorRoots.Create(const AVisitor: TGocciaJSONVisitor);
+begin
+  inherited Create;
+  FVisitor := AVisitor;
+end;
+
+procedure TGocciaJSONVisitorRoots.MarkRootReferences;
+var
+  I: Integer;
+begin
+  if not Assigned(FVisitor) then
+    Exit;
+
+  // Every open container on the stack, from the document root down to the one
+  // currently being filled. Only the innermost one is attached to nothing, but
+  // none of the outer ones is reachable from a real root either until the parse
+  // finishes and the caller takes ownership.
+  if Assigned(FVisitor.FStack) then
+    for I := 0 to FVisitor.FStack.Count - 1 do
+      if Assigned(FVisitor.FStack[I]) then
+        FVisitor.FStack[I].MarkReferences;
+
+  // Set once the outermost value is emitted, and the only reference to the
+  // finished tree until the caller stores it.
+  if Assigned(FVisitor.FResult) then
+    FVisitor.FResult.MarkReferences;
+end;
+
 { TGocciaJSONVisitor }
 
 constructor TGocciaJSONVisitor.Create;
@@ -393,10 +444,16 @@ begin
   FRootRecord := nil;
   FCollectRecords := False;
   FCollectSources := False;
+  // Last, so the collector never sees a root source over a half-built visitor.
+  FRoots := TGocciaJSONVisitorRoots.Create(Self);
 end;
 
 destructor TGocciaJSONVisitor.Destroy;
 begin
+  // First, so no collection can reach FStack after it is freed. This also runs on
+  // the parse-error path, where the stack is still holding open containers.
+  FRoots.Free;
+  FRoots := nil;
   FRootRecord.Free;
   while FRecordStack.Count > 0 do
   begin

--- a/source/units/Goccia.JSONL.pas
+++ b/source/units/Goccia.JSONL.pas
@@ -61,7 +61,9 @@ uses
 
   BOM,
   TextEncoding,
-  TextSemantics;
+  TextSemantics,
+
+  Goccia.GarbageCollector;
 
 constructor TGocciaJSONLParser.Create;
 begin
@@ -210,50 +212,64 @@ var
   LineText: string;
   NextLineStart: Integer;
   ParsedValue: TGocciaValue;
+  RecordsRoot: TGocciaTempRoot;
   StartIndex: Integer;
   EndIndex: Integer;
 begin
-  Result := TGocciaArrayValue.Create;
-  if not NormalizeTextRange(AText, 0, -1, StartIndex, EndIndex) then
-    Exit;
+  { The accumulator holds every record parsed so far, and until the caller takes
+    the result nothing else refers to it — this local is invisible to the
+    collector, which never scans the native stack. Each line's parse builds
+    non-empty strings, every one of which charges the memory ceiling and collects
+    when it crosses, protecting only that new string. So the accumulator stays
+    rooted for the whole loop. The values already inside it need no root of their
+    own: marking is precise and reaches them through the array. }
+  InitializeTempRoot(RecordsRoot);
+  try
+    Result := TGocciaArrayValue.Create;
+    AddTempRootIfNeeded(RecordsRoot, Result);
+    if not NormalizeTextRange(AText, 0, -1, StartIndex, EndIndex) then
+      Exit;
 
-  LineStart := StartIndex;
-  LineNumber := 1;
-  while LineStart < EndIndex do
-  begin
-    DelimiterStart := LineStart;
-    while (DelimiterStart < EndIndex) and
-      not (AText[DelimiterStart + 1] in [#10, #13]) do
-      Inc(DelimiterStart);
+    LineStart := StartIndex;
+    LineNumber := 1;
+    while LineStart < EndIndex do
+    begin
+      DelimiterStart := LineStart;
+      while (DelimiterStart < EndIndex) and
+        not (AText[DelimiterStart + 1] in [#10, #13]) do
+        Inc(DelimiterStart);
 
-    HasDelimiter := DelimiterStart < EndIndex;
-    if HasDelimiter then
-    begin
-      LineEnd := DelimiterStart;
-      DelimiterLength := 1;
-      if (AText[DelimiterStart + 1] = #13) and
-         (DelimiterStart + 1 < EndIndex) and
-         (AText[DelimiterStart + 2] = #10) then
-        DelimiterLength := 2;
-      NextLineStart := DelimiterStart + DelimiterLength;
-    end
-    else
-    begin
-      LineEnd := EndIndex;
-      NextLineStart := EndIndex;
+      HasDelimiter := DelimiterStart < EndIndex;
+      if HasDelimiter then
+      begin
+        LineEnd := DelimiterStart;
+        DelimiterLength := 1;
+        if (AText[DelimiterStart + 1] = #13) and
+           (DelimiterStart + 1 < EndIndex) and
+           (AText[DelimiterStart + 2] = #10) then
+          DelimiterLength := 2;
+        NextLineStart := DelimiterStart + DelimiterLength;
+      end
+      else
+      begin
+        LineEnd := EndIndex;
+        NextLineStart := EndIndex;
+      end;
+
+      LineText := Copy(AText, LineStart + 1, LineEnd - LineStart);
+      if not IsBlankLine(LineText) then
+      begin
+        if not TryParseLine(LineText, ParsedValue, ErrorMessage) then
+          raise EGocciaJSONLParseError.Create(
+            FormatParseError(LineNumber, ErrorMessage));
+        Result.Elements.Add(ParsedValue);
+      end;
+
+      LineStart := NextLineStart;
+      Inc(LineNumber);
     end;
-
-    LineText := Copy(AText, LineStart + 1, LineEnd - LineStart);
-    if not IsBlankLine(LineText) then
-    begin
-      if not TryParseLine(LineText, ParsedValue, ErrorMessage) then
-        raise EGocciaJSONLParseError.Create(
-          FormatParseError(LineNumber, ErrorMessage));
-      Result.Elements.Add(ParsedValue);
-    end;
-
-    LineStart := NextLineStart;
-    Inc(LineNumber);
+  finally
+    RemoveTempRootIfNeeded(RecordsRoot);
   end;
 end;
 
@@ -271,51 +287,60 @@ var
   LineText: string;
   NextLineStart: Integer;
   ParsedValue: TGocciaValue;
+  RecordsRoot: TGocciaTempRoot;
 begin
-  Result := TGocciaArrayValue.Create;
-  if not NormalizeByteRange(ABytes, 0, -1, EffectiveStart, EffectiveEnd) then
-    Exit;
+  { Same accumulator window as the string overload: unrooted for the whole chunk
+    parse otherwise, with every line's strings as collecting safe points. }
+  InitializeTempRoot(RecordsRoot);
+  try
+    Result := TGocciaArrayValue.Create;
+    AddTempRootIfNeeded(RecordsRoot, Result);
+    if not NormalizeByteRange(ABytes, 0, -1, EffectiveStart, EffectiveEnd) then
+      Exit;
 
-  if HasUTF8BOM(ABytes, EffectiveStart, EffectiveEnd) then
-    Inc(EffectiveStart, 3);
+    if HasUTF8BOM(ABytes, EffectiveStart, EffectiveEnd) then
+      Inc(EffectiveStart, 3);
 
-  LineStart := EffectiveStart;
-  LineNumber := 1;
-  while LineStart < EffectiveEnd do
-  begin
-    DelimiterStart := LineStart;
-    while (DelimiterStart < EffectiveEnd) and
-      not (ABytes[DelimiterStart] in [10, 13]) do
-      Inc(DelimiterStart);
-
-    HasDelimiter := DelimiterStart < EffectiveEnd;
-    if HasDelimiter then
+    LineStart := EffectiveStart;
+    LineNumber := 1;
+    while LineStart < EffectiveEnd do
     begin
-      LineEnd := DelimiterStart;
-      DelimiterLength := 1;
-      if (ABytes[DelimiterStart] = 13) and
-         (DelimiterStart + 1 < EffectiveEnd) and
-         (ABytes[DelimiterStart + 1] = 10) then
-        DelimiterLength := 2;
-      NextLineStart := DelimiterStart + DelimiterLength;
-    end
-    else
-    begin
-      LineEnd := EffectiveEnd;
-      NextLineStart := EffectiveEnd;
+      DelimiterStart := LineStart;
+      while (DelimiterStart < EffectiveEnd) and
+        not (ABytes[DelimiterStart] in [10, 13]) do
+        Inc(DelimiterStart);
+
+      HasDelimiter := DelimiterStart < EffectiveEnd;
+      if HasDelimiter then
+      begin
+        LineEnd := DelimiterStart;
+        DelimiterLength := 1;
+        if (ABytes[DelimiterStart] = 13) and
+           (DelimiterStart + 1 < EffectiveEnd) and
+           (ABytes[DelimiterStart + 1] = 10) then
+          DelimiterLength := 2;
+        NextLineStart := DelimiterStart + DelimiterLength;
+      end
+      else
+      begin
+        LineEnd := EffectiveEnd;
+        NextLineStart := EffectiveEnd;
+      end;
+
+      LineText := SliceBytesToString(ABytes, LineStart, LineEnd);
+      if not IsBlankLine(LineText) then
+      begin
+        if not TryParseLine(LineText, ParsedValue, ErrorMessage) then
+          raise EGocciaJSONLParseError.Create(
+            FormatParseError(LineNumber, ErrorMessage));
+        Result.Elements.Add(ParsedValue);
+      end;
+
+      LineStart := NextLineStart;
+      Inc(LineNumber);
     end;
-
-    LineText := SliceBytesToString(ABytes, LineStart, LineEnd);
-    if not IsBlankLine(LineText) then
-    begin
-      if not TryParseLine(LineText, ParsedValue, ErrorMessage) then
-        raise EGocciaJSONLParseError.Create(
-          FormatParseError(LineNumber, ErrorMessage));
-      Result.Elements.Add(ParsedValue);
-    end;
-
-    LineStart := NextLineStart;
-    Inc(LineNumber);
+  finally
+    RemoveTempRootIfNeeded(RecordsRoot);
   end;
 end;
 
@@ -334,69 +359,80 @@ var
   LineText: string;
   NextLineStart: Integer;
   ParsedValue: TGocciaValue;
+  RecordsRoot: TGocciaTempRoot;
   ResumeOffset: Integer;
 begin
-  Result.Values := TGocciaArrayValue.Create;
-  Result.Read := ClampOffset(AStart, Length(AText));
-  Result.Done := True;
-  Result.ErrorMessage := '';
-  if not NormalizeTextRange(AText, AStart, AEnd, EffectiveStart, EffectiveEnd) then
-  begin
-    Result.Read := EffectiveStart;
-    Exit;
-  end;
-
-  LineStart := EffectiveStart;
-  LineNumber := 1;
-  ResumeOffset := EffectiveStart;
-  while LineStart < EffectiveEnd do
-  begin
-    DelimiterStart := LineStart;
-    while (DelimiterStart < EffectiveEnd) and
-      not (AText[DelimiterStart + 1] in [#10, #13]) do
-      Inc(DelimiterStart);
-
-    HasDelimiter := DelimiterStart < EffectiveEnd;
-    if HasDelimiter then
+  { Result is a plain record: its Values field is no more visible to the
+    collector than a local would be, and it accumulates across a whole chunk of
+    per-line parses, each of which can collect while building a string. The
+    caller's BuildChunkResultObject takes over from here with a root of its own. }
+  InitializeTempRoot(RecordsRoot);
+  try
+    Result.Values := TGocciaArrayValue.Create;
+    AddTempRootIfNeeded(RecordsRoot, Result.Values);
+    Result.Read := ClampOffset(AStart, Length(AText));
+    Result.Done := True;
+    Result.ErrorMessage := '';
+    if not NormalizeTextRange(AText, AStart, AEnd, EffectiveStart, EffectiveEnd) then
     begin
-      LineEnd := DelimiterStart;
-      DelimiterLength := 1;
-      if (AText[DelimiterStart + 1] = #13) and
-         (DelimiterStart + 1 < EffectiveEnd) and
-         (AText[DelimiterStart + 2] = #10) then
-        DelimiterLength := 2;
-      NextLineStart := DelimiterStart + DelimiterLength;
-    end
-    else
-    begin
-      LineEnd := EffectiveEnd;
-      NextLineStart := EffectiveEnd;
+      Result.Read := EffectiveStart;
+      Exit;
     end;
 
-    LineText := Copy(AText, LineStart + 1, LineEnd - LineStart);
-    if not IsBlankLine(LineText) then
+    LineStart := EffectiveStart;
+    LineNumber := 1;
+    ResumeOffset := EffectiveStart;
+    while LineStart < EffectiveEnd do
     begin
-      if not TryParseLine(LineText, ParsedValue, ErrorMessage) then
+      DelimiterStart := LineStart;
+      while (DelimiterStart < EffectiveEnd) and
+        not (AText[DelimiterStart + 1] in [#10, #13]) do
+        Inc(DelimiterStart);
+
+      HasDelimiter := DelimiterStart < EffectiveEnd;
+      if HasDelimiter then
       begin
-        Result.Read := ResumeOffset;
-        Result.Done := False;
-        if HasDelimiter or not IsIncompleteFinalRecord(LineText, ErrorMessage) then
-          Result.ErrorMessage := FormatParseError(LineNumber, ErrorMessage);
-        Exit;
+        LineEnd := DelimiterStart;
+        DelimiterLength := 1;
+        if (AText[DelimiterStart + 1] = #13) and
+           (DelimiterStart + 1 < EffectiveEnd) and
+           (AText[DelimiterStart + 2] = #10) then
+          DelimiterLength := 2;
+        NextLineStart := DelimiterStart + DelimiterLength;
+      end
+      else
+      begin
+        LineEnd := EffectiveEnd;
+        NextLineStart := EffectiveEnd;
       end;
-      Result.Values.Elements.Add(ParsedValue);
+
+      LineText := Copy(AText, LineStart + 1, LineEnd - LineStart);
+      if not IsBlankLine(LineText) then
+      begin
+        if not TryParseLine(LineText, ParsedValue, ErrorMessage) then
+        begin
+          Result.Read := ResumeOffset;
+          Result.Done := False;
+          if HasDelimiter or not IsIncompleteFinalRecord(LineText, ErrorMessage) then
+            Result.ErrorMessage := FormatParseError(LineNumber, ErrorMessage);
+          Exit;
+        end;
+        Result.Values.Elements.Add(ParsedValue);
+      end;
+
+      if HasDelimiter then
+        ResumeOffset := DelimiterStart
+      else
+        ResumeOffset := EffectiveEnd;
+
+      LineStart := NextLineStart;
+      Inc(LineNumber);
     end;
 
-    if HasDelimiter then
-      ResumeOffset := DelimiterStart
-    else
-      ResumeOffset := EffectiveEnd;
-
-    LineStart := NextLineStart;
-    Inc(LineNumber);
+    Result.Read := EffectiveEnd;
+  finally
+    RemoveTempRootIfNeeded(RecordsRoot);
   end;
-
-  Result.Read := EffectiveEnd;
 end;
 
 function TGocciaJSONLParser.ParseChunk(const ABytes: TBytes; const AStart,
@@ -414,72 +450,80 @@ var
   LineText: string;
   NextLineStart: Integer;
   ParsedValue: TGocciaValue;
+  RecordsRoot: TGocciaTempRoot;
   ResumeOffset: Integer;
 begin
-  Result.Values := TGocciaArrayValue.Create;
-  Result.Read := ClampOffset(AStart, Length(ABytes));
-  Result.Done := True;
-  Result.ErrorMessage := '';
-  if not NormalizeByteRange(ABytes, AStart, AEnd, EffectiveStart, EffectiveEnd) then
-  begin
-    Result.Read := EffectiveStart;
-    Exit;
-  end;
-
-  if (EffectiveStart = 0) and HasUTF8BOM(ABytes, EffectiveStart, EffectiveEnd) then
-    Inc(EffectiveStart, 3);
-
-  LineStart := EffectiveStart;
-  LineNumber := 1;
-  ResumeOffset := EffectiveStart;
-  while LineStart < EffectiveEnd do
-  begin
-    DelimiterStart := LineStart;
-    while (DelimiterStart < EffectiveEnd) and
-      not (ABytes[DelimiterStart] in [10, 13]) do
-      Inc(DelimiterStart);
-
-    HasDelimiter := DelimiterStart < EffectiveEnd;
-    if HasDelimiter then
+  { Same accumulator window as the string overload of ParseChunk. }
+  InitializeTempRoot(RecordsRoot);
+  try
+    Result.Values := TGocciaArrayValue.Create;
+    AddTempRootIfNeeded(RecordsRoot, Result.Values);
+    Result.Read := ClampOffset(AStart, Length(ABytes));
+    Result.Done := True;
+    Result.ErrorMessage := '';
+    if not NormalizeByteRange(ABytes, AStart, AEnd, EffectiveStart, EffectiveEnd) then
     begin
-      LineEnd := DelimiterStart;
-      DelimiterLength := 1;
-      if (ABytes[DelimiterStart] = 13) and
-         (DelimiterStart + 1 < EffectiveEnd) and
-         (ABytes[DelimiterStart + 1] = 10) then
-        DelimiterLength := 2;
-      NextLineStart := DelimiterStart + DelimiterLength;
-    end
-    else
-    begin
-      LineEnd := EffectiveEnd;
-      NextLineStart := EffectiveEnd;
+      Result.Read := EffectiveStart;
+      Exit;
     end;
 
-    LineText := SliceBytesToString(ABytes, LineStart, LineEnd);
-    if not IsBlankLine(LineText) then
+    if (EffectiveStart = 0) and HasUTF8BOM(ABytes, EffectiveStart, EffectiveEnd) then
+      Inc(EffectiveStart, 3);
+
+    LineStart := EffectiveStart;
+    LineNumber := 1;
+    ResumeOffset := EffectiveStart;
+    while LineStart < EffectiveEnd do
     begin
-      if not TryParseLine(LineText, ParsedValue, ErrorMessage) then
+      DelimiterStart := LineStart;
+      while (DelimiterStart < EffectiveEnd) and
+        not (ABytes[DelimiterStart] in [10, 13]) do
+        Inc(DelimiterStart);
+
+      HasDelimiter := DelimiterStart < EffectiveEnd;
+      if HasDelimiter then
       begin
-        Result.Read := ResumeOffset;
-        Result.Done := False;
-        if HasDelimiter or not IsIncompleteFinalRecord(LineText, ErrorMessage) then
-          Result.ErrorMessage := FormatParseError(LineNumber, ErrorMessage);
-        Exit;
+        LineEnd := DelimiterStart;
+        DelimiterLength := 1;
+        if (ABytes[DelimiterStart] = 13) and
+           (DelimiterStart + 1 < EffectiveEnd) and
+           (ABytes[DelimiterStart + 1] = 10) then
+          DelimiterLength := 2;
+        NextLineStart := DelimiterStart + DelimiterLength;
+      end
+      else
+      begin
+        LineEnd := EffectiveEnd;
+        NextLineStart := EffectiveEnd;
       end;
-      Result.Values.Elements.Add(ParsedValue);
+
+      LineText := SliceBytesToString(ABytes, LineStart, LineEnd);
+      if not IsBlankLine(LineText) then
+      begin
+        if not TryParseLine(LineText, ParsedValue, ErrorMessage) then
+        begin
+          Result.Read := ResumeOffset;
+          Result.Done := False;
+          if HasDelimiter or not IsIncompleteFinalRecord(LineText, ErrorMessage) then
+            Result.ErrorMessage := FormatParseError(LineNumber, ErrorMessage);
+          Exit;
+        end;
+        Result.Values.Elements.Add(ParsedValue);
+      end;
+
+      if HasDelimiter then
+        ResumeOffset := DelimiterStart
+      else
+        ResumeOffset := EffectiveEnd;
+
+      LineStart := NextLineStart;
+      Inc(LineNumber);
     end;
 
-    if HasDelimiter then
-      ResumeOffset := DelimiterStart
-    else
-      ResumeOffset := EffectiveEnd;
-
-    LineStart := NextLineStart;
-    Inc(LineNumber);
+    Result.Read := EffectiveEnd;
+  finally
+    RemoveTempRootIfNeeded(RecordsRoot);
   end;
-
-  Result.Read := EffectiveEnd;
 end;
 
 end.

--- a/source/units/Goccia.TOML.pas
+++ b/source/units/Goccia.TOML.pas
@@ -154,6 +154,7 @@ uses
 
   NumericText,
 
+  Goccia.GarbageCollector,
   Goccia.NativeLimits;
 
 function IsSpaceOrTab(const AChar: Char): Boolean;
@@ -471,27 +472,43 @@ begin
 end;
 
 function TGocciaTOMLParser.ParseDocument(const AText: string): TGocciaTOMLNode;
+var
+  RootValueRoot: TGocciaTempRoot;
 begin
-  Reset(AText);
+  // The whole document hangs off the root table's property graph, and the only
+  // thing holding that table is the TGocciaTOMLNode tree — plain Pascal objects
+  // the collector cannot see. Every string value the document contains charges
+  // the memory ceiling, and crossing it collects with only the new string
+  // protected, so one root over the root table covers the entire parse: each
+  // table and array below it is attached to a parent before any further string is
+  // built (see ParseArray and ParseInlineTable for the two that are not).
+  InitializeTempRoot(RootValueRoot);
   try
-    PrepareInput;
-    SkipBlankLinesAndComments;
-    while not IsAtEnd do
-    begin
-      if PeekChar = '[' then
-        ParseTableHeader
-      else
-        ParseKeyValuePair;
+    Reset(AText);
+    // Reset builds a fresh root table, so the root has to be taken after it.
+    AddTempRootIfNeeded(RootValueRoot, FRoot.TableValue);
+    try
+      PrepareInput;
       SkipBlankLinesAndComments;
+      while not IsAtEnd do
+      begin
+        if PeekChar = '[' then
+          ParseTableHeader
+        else
+          ParseKeyValuePair;
+        SkipBlankLinesAndComments;
+      end;
+      Result := FRoot;
+      FRoot := nil;
+    finally
+      FText := '';
+      FIndex := 1;
+      FCurrentTable := nil;
+      FRoot.Free;
+      FRoot := nil;
     end;
-    Result := FRoot;
-    FRoot := nil;
   finally
-    FText := '';
-    FIndex := 1;
-    FCurrentTable := nil;
-    FRoot.Free;
-    FRoot := nil;
+    RemoveTempRootIfNeeded(RootValueRoot);
   end;
 end;
 
@@ -1185,11 +1202,17 @@ end;
 function TGocciaTOMLParser.ParseArray: TGocciaTOMLNode;
 var
   ElementNode: TGocciaTOMLNode;
+  ArrayRoot: TGocciaTempRoot;
 begin
+  // Unlike the table nodes, this array is not attached to anything until the
+  // caller takes it, and it is filled first — across ParseValue calls that build
+  // strings, each of which charges the memory ceiling and can collect.
+  InitializeTempRoot(ArrayRoot);
   EnterNativeDataDepth('TOML parsing');
   try
     CheckNativeWork;
     Result := TGocciaTOMLNode.CreateArray(TGocciaArrayValue.Create);
+    AddTempRootIfNeeded(ArrayRoot, Result.ArrayValue);
     try
       Advance;
       SkipWhitespace(True);
@@ -1230,6 +1253,7 @@ begin
       raise;
     end;
   finally
+    RemoveTempRootIfNeeded(ArrayRoot);
     LeaveNativeDataDepth;
   end;
 end;
@@ -1238,12 +1262,17 @@ function TGocciaTOMLParser.ParseInlineTable: TGocciaTOMLNode;
 var
   InlineNode, ValueNode: TGocciaTOMLNode;
   KeyPath: TArray<string>;
+  TableRoot: TGocciaTempRoot;
 begin
+  // Same as ParseArray: detached from the document until the caller attaches it,
+  // and every entry parsed into it can collect.
+  InitializeTempRoot(TableRoot);
   EnterNativeDataDepth('TOML parsing');
   try
     CheckNativeWork;
     InlineNode := TGocciaTOMLNode.CreateTable(TGocciaObjectValue.Create, False, False,
       True, False);
+    AddTempRootIfNeeded(TableRoot, InlineNode.TableValue);
     try
       Advance;
       SkipWhitespace(True);
@@ -1289,6 +1318,7 @@ begin
       raise;
     end;
   finally
+    RemoveTempRootIfNeeded(TableRoot);
     LeaveNativeDataDepth;
   end;
 end;

--- a/source/units/Goccia.YAML.pas
+++ b/source/units/Goccia.YAML.pas
@@ -9,6 +9,7 @@ uses
 
   OrderedStringMap,
 
+  Goccia.GarbageCollector,
   Goccia.Values.ArrayValue,
   Goccia.Values.ObjectValue,
   Goccia.Values.Primitives;
@@ -24,8 +25,29 @@ type
     Text: string;
   end;
 
+  TGocciaYAMLParser = class;
+
+  // FAnchors names values the document refers to by alias, and the collector
+  // never sees it: a plain map in a plain field, reachable only from the native
+  // stack. An anchored node is registered before its parent takes it, so for that
+  // whole window the map is the only structure that knows about it — and any
+  // scalar the parser builds meanwhile charges the memory ceiling, which collects
+  // when crossed. Without this, such a node is swept and ResolveAliasValue hands
+  // back freed memory.
+  //
+  // Reset clears the map at the start of every document, so every entry marked
+  // here belongs to the document currently being parsed.
+  TGocciaYAMLAnchorRoots = class(TGCRootSource)
+  private
+    FParser: TGocciaYAMLParser;
+  public
+    constructor Create(const AParser: TGocciaYAMLParser);
+    procedure MarkRootReferences; override;
+  end;
+
   TGocciaYAMLParser = class
   private
+    FAnchorRoots: TGocciaYAMLAnchorRoots;
     FAnchors: TGocciaValueMap;
     FExplicitTagHandles: TStringStringMap;
     FTagHandles: TStringStringMap;
@@ -64,10 +86,8 @@ type
     function ParseNode(const AIndent: Integer): TGocciaValue;
     function ParseNestedNode(const AParentIndent: Integer): TGocciaValue;
     function ParseExplicitNestedNode(const AParentIndent: Integer): TGocciaValue;
-    function ParseMapping(const AIndent: Integer): TGocciaValue;
     procedure ParseMappingInto(const AIndent: Integer;
       const AObject: TGocciaObjectValue);
-    function ParseSequence(const AIndent: Integer): TGocciaValue;
     procedure ParseSequenceInto(const AIndent: Integer;
       const AArray: TGocciaArrayValue);
     function ParseMappingValueText(const AValueText: string; const ALineIndent,
@@ -76,8 +96,6 @@ type
       const ALineText: string; const ALineIndent, ALineNumber: Integer);
     procedure ParseExplicitMappingEntry(const AContainer: TGocciaObjectValue;
       const ALineText: string; const ALineIndent, ALineNumber: Integer);
-    function ParseSequenceEntryMapping(const ASequenceIndent: Integer;
-      const AEntryText: string; const ALineNumber: Integer): TGocciaValue;
     procedure ParseSequenceEntryMappingInto(const ASequenceIndent: Integer;
       const AEntryText: string; const ALineNumber: Integer;
       const AObject: TGocciaObjectValue);
@@ -93,10 +111,8 @@ type
       const AStopAtIndentedSequenceEntry: Boolean = False;
       const ARequireIndentedQuotedContinuations: Boolean = False;
       const AAllowSameIndentScalarContinuations: Boolean = False): TGocciaValue;
-    function ParseFlowSequence(const AText: string): TGocciaValue;
     procedure ParseFlowSequenceInto(const AText: string;
       const AArray: TGocciaArrayValue);
-    function ParseFlowMapping(const AText: string): TGocciaValue;
     procedure ParseFlowMappingEntry(const AObject: TGocciaObjectValue;
       const AItemText: string; const ALineNumber: Integer = 0);
     procedure ParseFlowMappingInto(const AText: string;
@@ -1624,6 +1640,25 @@ begin
   end;
 end;
 
+{ TGocciaYAMLAnchorRoots }
+
+constructor TGocciaYAMLAnchorRoots.Create(const AParser: TGocciaYAMLParser);
+begin
+  inherited Create;
+  FParser := AParser;
+end;
+
+procedure TGocciaYAMLAnchorRoots.MarkRootReferences;
+var
+  Pair: TGocciaValueMap.TKeyValuePair;
+begin
+  if not Assigned(FParser) or not Assigned(FParser.FAnchors) then
+    Exit;
+  for Pair in FParser.FAnchors do
+    if Assigned(Pair.Value) then
+      Pair.Value.MarkReferences;
+end;
+
 { TGocciaYAMLParser }
 
 constructor TGocciaYAMLParser.Create;
@@ -1633,10 +1668,15 @@ begin
   FExplicitTagHandles := TStringStringMap.Create;
   FTagHandles := TStringStringMap.Create;
   InitializeTagHandles;
+  // After FAnchors, so the collector never sees a root source over a nil map.
+  FAnchorRoots := TGocciaYAMLAnchorRoots.Create(Self);
 end;
 
 destructor TGocciaYAMLParser.Destroy;
 begin
+  // Before FAnchors, so no collection can walk the map after it is freed.
+  FAnchorRoots.Free;
+  FAnchorRoots := nil;
   FTagHandles.Free;
   FExplicitTagHandles.Free;
   FAnchors.Free;
@@ -2113,12 +2153,24 @@ end;
 function TGocciaYAMLParser.Parse(const AText: string): TGocciaValue;
 var
   Documents: TGocciaArrayValue;
+  DocumentsRoot: TGocciaTempRoot;
   HasExplicitDocumentStart: Boolean;
   SingleDocument: TGocciaValue;
 begin
   HasExplicitDocumentStart := HasExplicitDocumentStartMarker(AText);
-  Documents := ParseDocuments(AText);
+  Documents := nil;
+  // The finally block below compares Result against Documents, and a parse that
+  // raises never assigns Result — so without this the ownership decision would
+  // read an uninitialised function result.
+  Result := nil;
+  InitializeTempRoot(DocumentsRoot);
   try
+    Documents := ParseDocuments(AText);
+    // A single-document source discards the wrapper array and frees it
+    // explicitly below. That Free is only correct while the array is still
+    // alive, so it has to stay rooted until then — a sweep here would make it a
+    // second free.
+    AddTempRootIfNeeded(DocumentsRoot, Documents);
     if Documents.Elements.Count = 0 then
       Exit(TGocciaNullLiteralValue.NullValue);
     if HasExplicitDocumentStart then
@@ -2127,8 +2179,12 @@ begin
     Documents.Elements.Extract(SingleDocument);
     Result := SingleDocument;
   finally
-    if Result <> Documents then
+    // Free first, drop the root second: the invariant above is that the array is
+    // rooted for as long as it is alive, and unrooting a live array here would
+    // expose it to exactly the sweep the root exists to prevent.
+    if Assigned(Documents) and (Result <> Documents) then
       Documents.Free;
+    RemoveTempRootIfNeeded(DocumentsRoot);
   end;
 end;
 
@@ -2136,14 +2192,27 @@ function TGocciaYAMLParser.ParseDocuments(const AText: string): TGocciaArrayValu
 var
   DocumentIndex: Integer;
   DocumentText: TStringList;
+  ResultRoot: TGocciaTempRoot;
 begin
-  Result := TGocciaArrayValue.Create;
-  DocumentText := SplitYAMLDocuments(AText);
+  // Each document is parsed in full before it is appended, and every scalar in it
+  // charges the memory ceiling — so the array spends nearly the whole parse
+  // holding earlier documents while reachable from nothing but this frame.
+  InitializeTempRoot(ResultRoot);
   try
-    for DocumentIndex := 0 to DocumentText.Count - 1 do
-      Result.Elements.Add(ParseSingleDocument(DocumentText[DocumentIndex]));
+    Result := TGocciaArrayValue.Create;
+    AddTempRootIfNeeded(ResultRoot, Result);
+    DocumentText := SplitYAMLDocuments(AText);
+    try
+      for DocumentIndex := 0 to DocumentText.Count - 1 do
+        Result.Elements.Add(ParseSingleDocument(DocumentText[DocumentIndex]));
+    finally
+      DocumentText.Free;
+    end;
   finally
-    DocumentText.Free;
+    // Anchors are per-document (Reset clears them in LoadLines), so the last
+    // document's entries would otherwise stay rooted until the next parse.
+    FAnchors.Clear;
+    RemoveTempRootIfNeeded(ResultRoot);
   end;
 end;
 
@@ -2375,17 +2444,31 @@ function TGocciaYAMLParser.ParseKeyName(const AText: string;
 var
   AnchorName, KeyText, RemainingText, TagName: string;
   KeyValue: TGocciaValue;
+  KeyRoot: TGocciaTempRoot;
 begin
-  KeyText := Trim(AText);
-  ParseNodeProperties(KeyText, TagName, AnchorName, RemainingText);
-  if RemainingText = '' then
-    KeyValue := TGocciaStringLiteralValue.Create('')
-  else
-    KeyValue := ParseInlineValue(RemainingText);
+  // The key's value exists only in this frame until CanonicalizeKeyValue has read
+  // it out as text, and both steps in between allocate: ApplyTag builds a fresh
+  // tagged wrapper and its own scalars, and CanonicalizeKeyValue calls
+  // ToStringLiteral for composite and non-string keys. Either can cross the
+  // memory ceiling and collect with only the new string protected. Re-point the
+  // root after ApplyTag so the wrapper it may return is covered too.
+  InitializeTempRoot(KeyRoot);
+  try
+    KeyText := Trim(AText);
+    ParseNodeProperties(KeyText, TagName, AnchorName, RemainingText);
+    if RemainingText = '' then
+      KeyValue := TGocciaStringLiteralValue.Create('')
+    else
+      KeyValue := ParseInlineValue(RemainingText);
+    AddTempRootIfNeeded(KeyRoot, KeyValue);
 
-  KeyValue := ApplyTag(TagName, KeyValue);
-  RegisterAnchor(AnchorName, KeyValue, ALineNumber);
-  Result := CanonicalizeKeyValue(KeyValue);
+    KeyValue := ApplyTag(TagName, KeyValue);
+    AddTempRootIfNeeded(KeyRoot, KeyValue);
+    RegisterAnchor(AnchorName, KeyValue, ALineNumber);
+    Result := CanonicalizeKeyValue(KeyValue);
+  finally
+    RemoveTempRootIfNeeded(KeyRoot);
+  end;
 end;
 
 function TGocciaYAMLParser.ParseMappingValueText(const AValueText: string;
@@ -2405,19 +2488,30 @@ var
   KeyText, ValueText: string;
   SeparatorIndex: Integer;
   Value: TGocciaValue;
+  ValueRoot: TGocciaTempRoot;
 begin
-  SeparatorIndex := FindTopLevelMappingSeparator(ALineText);
-  if SeparatorIndex = 0 then
-    RaiseParseError('Expected a mapping entry.', ALineNumber);
+  // The ordinary `key: value` path parses the value before the key, so the parsed
+  // value sits in this frame alone — detached from AContainer until the store
+  // below — across ParseKeyName, which builds the key's own scalar and
+  // canonicalizes it. Both allocate charged strings, either of which can collect.
+  InitializeTempRoot(ValueRoot);
+  try
+    SeparatorIndex := FindTopLevelMappingSeparator(ALineText);
+    if SeparatorIndex = 0 then
+      RaiseParseError('Expected a mapping entry.', ALineNumber);
 
-  KeyText := Trim(Copy(ALineText, 1, SeparatorIndex - 1));
-  ValueText := Trim(Copy(ALineText, SeparatorIndex + 1, MaxInt));
-  Value := ParseMappingValueText(ValueText, ALineIndent, ALineNumber);
-  KeyText := ParseKeyName(KeyText, ALineNumber);
-  if KeyText = '<<' then
-    MergeMappingValue(AContainer, Value, ALineNumber)
-  else
-    AContainer.AssignProperty(KeyText, Value);
+    KeyText := Trim(Copy(ALineText, 1, SeparatorIndex - 1));
+    ValueText := Trim(Copy(ALineText, SeparatorIndex + 1, MaxInt));
+    Value := ParseMappingValueText(ValueText, ALineIndent, ALineNumber);
+    AddTempRootIfNeeded(ValueRoot, Value);
+    KeyText := ParseKeyName(KeyText, ALineNumber);
+    if KeyText = '<<' then
+      MergeMappingValue(AContainer, Value, ALineNumber)
+    else
+      AContainer.AssignProperty(KeyText, Value);
+  finally
+    RemoveTempRootIfNeeded(ValueRoot);
+  end;
 end;
 
 procedure TGocciaYAMLParser.ParseExplicitMappingEntry(
@@ -2427,64 +2521,75 @@ var
   KeyAnchorName, KeyRemainingText, KeyTagName: string;
   KeyLineText, ValueLineText: string;
   KeyValue, Value: TGocciaValue;
+  KeyRoot, ValueRoot: TGocciaTempRoot;
 begin
-  KeyLineText := Trim(Copy(ALineText, 2, MaxInt));
-  if KeyLineText = '' then
-  begin
-    Inc(FIndex);
-    KeyValue := ParseExplicitNestedNode(ALineIndent);
-  end
-  else
-  begin
-    ParseNodeProperties(KeyLineText, KeyTagName, KeyAnchorName, KeyRemainingText,
-      ALineNumber);
-    if KeyRemainingText = '' then
+  // An explicit `? key` / `: value` entry holds both halves in this frame at
+  // once, and each is exposed across the other's work: the key survives a full
+  // nested node parse before CanonicalizeKeyValue dereferences it, and the value
+  // survives CanonicalizeKeyValue, which allocates via ToStringLiteral for
+  // composite and non-string keys. Anchored keys are reachable from FAnchors, but
+  // unanchored ones are not, so neither half can rely on the other's roots.
+  InitializeTempRoot(KeyRoot);
+  InitializeTempRoot(ValueRoot);
+  try
+    KeyLineText := Trim(Copy(ALineText, 2, MaxInt));
+    if KeyLineText = '' then
     begin
-      KeyValue := TGocciaStringLiteralValue.Create('');
       Inc(FIndex);
+      KeyValue := ParseExplicitNestedNode(ALineIndent);
+      AddTempRootIfNeeded(KeyRoot, KeyValue);
     end
     else
-      KeyValue := ParseInlineValueWithContinuations(KeyRemainingText,
-        ALineIndent, ALineNumber, False, True);
-    KeyValue := ApplyTag(KeyTagName, KeyValue, ALineNumber);
-    RegisterAnchor(KeyAnchorName, KeyValue, ALineNumber);
-  end;
+    begin
+      ParseNodeProperties(KeyLineText, KeyTagName, KeyAnchorName, KeyRemainingText,
+        ALineNumber);
+      if KeyRemainingText = '' then
+      begin
+        KeyValue := TGocciaStringLiteralValue.Create('');
+        Inc(FIndex);
+      end
+      else
+        KeyValue := ParseInlineValueWithContinuations(KeyRemainingText,
+          ALineIndent, ALineNumber, False, True);
+      AddTempRootIfNeeded(KeyRoot, KeyValue);
+      // ApplyTag can return a fresh wrapper built from charged strings; re-point
+      // the root at whatever it hands back.
+      KeyValue := ApplyTag(KeyTagName, KeyValue, ALineNumber);
+      AddTempRootIfNeeded(KeyRoot, KeyValue);
+      RegisterAnchor(KeyAnchorName, KeyValue, ALineNumber);
+    end;
 
-  SkipIgnorableLines;
-  if not HasCurrentLine or (CurrentLine.Indent <> ALineIndent) or
-     not StartsExplicitValueEntry(CurrentLine.Text) then
-  begin
-    Value := TGocciaNullLiteralValue.NullValue;
+    SkipIgnorableLines;
+    if not HasCurrentLine or (CurrentLine.Indent <> ALineIndent) or
+       not StartsExplicitValueEntry(CurrentLine.Text) then
+    begin
+      Value := TGocciaNullLiteralValue.NullValue;
+      KeyLineText := CanonicalizeKeyValue(KeyValue);
+      if KeyLineText = '<<' then
+        MergeMappingValue(AContainer, Value, ALineNumber)
+      else
+        AContainer.AssignProperty(KeyLineText, Value);
+      Exit;
+    end;
+
+    ValueLineText := Trim(Copy(CurrentLine.Text, 2, MaxInt));
+    if ValueLineText = '' then
+    begin
+      Inc(FIndex);
+      Value := ParseExplicitNestedNode(ALineIndent);
+    end
+    else
+      Value := ParseMappingValueText(ValueLineText, ALineIndent, CurrentLine.Number);
+    AddTempRootIfNeeded(ValueRoot, Value);
     KeyLineText := CanonicalizeKeyValue(KeyValue);
     if KeyLineText = '<<' then
-      MergeMappingValue(AContainer, Value, ALineNumber)
+      MergeMappingValue(AContainer, Value, CurrentLine.Number)
     else
       AContainer.AssignProperty(KeyLineText, Value);
-    Exit;
+  finally
+    RemoveTempRootIfNeeded(ValueRoot);
+    RemoveTempRootIfNeeded(KeyRoot);
   end;
-
-  ValueLineText := Trim(Copy(CurrentLine.Text, 2, MaxInt));
-  if ValueLineText = '' then
-  begin
-    Inc(FIndex);
-    Value := ParseExplicitNestedNode(ALineIndent);
-  end
-  else
-    Value := ParseMappingValueText(ValueLineText, ALineIndent, CurrentLine.Number);
-  KeyLineText := CanonicalizeKeyValue(KeyValue);
-  if KeyLineText = '<<' then
-    MergeMappingValue(AContainer, Value, CurrentLine.Number)
-  else
-    AContainer.AssignProperty(KeyLineText, Value);
-end;
-
-function TGocciaYAMLParser.ParseMapping(const AIndent: Integer): TGocciaValue;
-var
-  Obj: TGocciaObjectValue;
-begin
-  Obj := TGocciaObjectValue.Create;
-  ParseMappingInto(AIndent, Obj);
-  Result := Obj;
 end;
 
 procedure TGocciaYAMLParser.ParseMappingInto(const AIndent: Integer;
@@ -2503,18 +2608,6 @@ begin
       ParseMappingEntry(AObject, CurrentLine.Text, CurrentLine.Indent,
         CurrentLine.Number);
   end;
-end;
-
-function TGocciaYAMLParser.ParseSequenceEntryMapping(
-  const ASequenceIndent: Integer; const AEntryText: string;
-  const ALineNumber: Integer): TGocciaValue;
-var
-  MappingIndent: Integer;
-  Obj: TGocciaObjectValue;
-begin
-  Obj := TGocciaObjectValue.Create;
-  ParseSequenceEntryMappingInto(ASequenceIndent, AEntryText, ALineNumber, Obj);
-  Result := Obj;
 end;
 
 procedure TGocciaYAMLParser.ParseSequenceEntryMappingInto(
@@ -2556,106 +2649,121 @@ var
   FlowText: string;
   Obj: TGocciaObjectValue;
   Arr: TGocciaArrayValue;
+  NodeRoot: TGocciaTempRoot;
 begin
-  if AValueText = '' then
-  begin
-    if AAdvanceBeforeNested then
-      Inc(FIndex);
-    SkipIgnorableLines;
-    if not HasCurrentLine or (CurrentLine.Indent < ALineIndent) or
-       ((CurrentLine.Indent = ALineIndent) and
-        (((not AAllowSameIndentNestedNode) and
-          not StartsSequenceEntry(CurrentLine.Text) and
-          not StartsBlockMappingEntry(CurrentLine.Text) and
-          ((CurrentLine.Text = '') or
-           ((CurrentLine.Text[1] <> '[') and (CurrentLine.Text[1] <> '{')))) or
-         (ASequenceEntryInlineMapping and StartsSequenceEntry(CurrentLine.Text)))) then
-      Result := TGocciaNullLiteralValue.NullValue
-    else if StartsSequenceEntry(CurrentLine.Text) then
+  // Every container arm below creates its node, then fills it from the source —
+  // and stays detached from its parent for the whole fill. Each scalar built in
+  // there charges the memory ceiling, and crossing it collects with only the new
+  // scalar protected, so the node needs a root of its own meanwhile. One root
+  // serves all the arms: exactly one runs per call, and the nest-safe form lets a
+  // recursive call root its own node without disturbing this one.
+  InitializeTempRoot(NodeRoot);
+  try
+    if AValueText = '' then
+    begin
+      if AAdvanceBeforeNested then
+        Inc(FIndex);
+      SkipIgnorableLines;
+      if not HasCurrentLine or (CurrentLine.Indent < ALineIndent) or
+         ((CurrentLine.Indent = ALineIndent) and
+          (((not AAllowSameIndentNestedNode) and
+            not StartsSequenceEntry(CurrentLine.Text) and
+            not StartsBlockMappingEntry(CurrentLine.Text) and
+            ((CurrentLine.Text = '') or
+             ((CurrentLine.Text[1] <> '[') and (CurrentLine.Text[1] <> '{')))) or
+           (ASequenceEntryInlineMapping and StartsSequenceEntry(CurrentLine.Text)))) then
+        Result := TGocciaNullLiteralValue.NullValue
+      else if StartsSequenceEntry(CurrentLine.Text) then
+      begin
+        Arr := TGocciaArrayValue.Create;
+        AddTempRootIfNeeded(NodeRoot, Arr);
+        RegisterAnchor(AAnchorName, Arr, ALineNumber);
+        ParseSequenceInto(CurrentLine.Indent, Arr);
+        Result := Arr;
+      end
+      else if StartsBlockMappingEntry(CurrentLine.Text) then
+      begin
+        Obj := TGocciaObjectValue.Create;
+        AddTempRootIfNeeded(NodeRoot, Obj);
+        RegisterAnchor(AAnchorName, Obj, ALineNumber);
+        ParseMappingInto(CurrentLine.Indent, Obj);
+        Result := Obj;
+      end
+      else if (CurrentLine.Text <> '') and (CurrentLine.Text[1] = '[') then
+      begin
+        Arr := TGocciaArrayValue.Create;
+        AddTempRootIfNeeded(NodeRoot, Arr);
+        RegisterAnchor(AAnchorName, Arr, ALineNumber);
+        FlowText := CollectFlowCollectionText(CurrentLine.Text, CurrentLine.Number);
+        ParseFlowSequenceInto(FlowText, Arr);
+        Result := Arr;
+      end
+      else if (CurrentLine.Text <> '') and (CurrentLine.Text[1] = '{') then
+      begin
+        Obj := TGocciaObjectValue.Create;
+        AddTempRootIfNeeded(NodeRoot, Obj);
+        RegisterAnchor(AAnchorName, Obj, ALineNumber);
+        FlowText := CollectFlowCollectionText(CurrentLine.Text, CurrentLine.Number);
+        ParseFlowMappingInto(FlowText, Obj);
+        Result := Obj;
+      end
+      else
+        Result := ParseNode(CurrentLine.Indent);
+    end
+    else if StartsSequenceEntry(AValueText) then
     begin
       Arr := TGocciaArrayValue.Create;
+      AddTempRootIfNeeded(NodeRoot, Arr);
       RegisterAnchor(AAnchorName, Arr, ALineNumber);
-      ParseSequenceInto(CurrentLine.Indent, Arr);
+      ParseInlineSequenceInto(AValueText, ALineIndent, ALineNumber, Arr);
       Result := Arr;
     end
-    else if StartsBlockMappingEntry(CurrentLine.Text) then
+    else if StartsBlockMappingEntry(AValueText) then
     begin
       Obj := TGocciaObjectValue.Create;
+      AddTempRootIfNeeded(NodeRoot, Obj);
       RegisterAnchor(AAnchorName, Obj, ALineNumber);
-      ParseMappingInto(CurrentLine.Indent, Obj);
+      if ASequenceEntryInlineMapping then
+        ParseSequenceEntryMappingInto(ALineIndent, AValueText, ALineNumber, Obj)
+      else
+        ParseMappingInto(ALineIndent, Obj);
       Result := Obj;
     end
-    else if (CurrentLine.Text <> '') and (CurrentLine.Text[1] = '[') then
+    else if IsBlockScalarHeader(AValueText) then
+      Result := ParseBlockScalar(ALineIndent, AValueText, ALineNumber)
+    else if AValueText[1] = '[' then
     begin
       Arr := TGocciaArrayValue.Create;
+      AddTempRootIfNeeded(NodeRoot, Arr);
       RegisterAnchor(AAnchorName, Arr, ALineNumber);
-      FlowText := CollectFlowCollectionText(CurrentLine.Text, CurrentLine.Number);
+      FlowText := CollectFlowCollectionText(AValueText, ALineNumber);
       ParseFlowSequenceInto(FlowText, Arr);
       Result := Arr;
     end
-    else if (CurrentLine.Text <> '') and (CurrentLine.Text[1] = '{') then
+    else if AValueText[1] = '{' then
     begin
       Obj := TGocciaObjectValue.Create;
+      AddTempRootIfNeeded(NodeRoot, Obj);
       RegisterAnchor(AAnchorName, Obj, ALineNumber);
-      FlowText := CollectFlowCollectionText(CurrentLine.Text, CurrentLine.Number);
+      FlowText := CollectFlowCollectionText(AValueText, ALineNumber);
       ParseFlowMappingInto(FlowText, Obj);
       Result := Obj;
     end
     else
-      Result := ParseNode(CurrentLine.Indent);
-  end
-  else if StartsSequenceEntry(AValueText) then
-  begin
-    Arr := TGocciaArrayValue.Create;
-    RegisterAnchor(AAnchorName, Arr, ALineNumber);
-    ParseInlineSequenceInto(AValueText, ALineIndent, ALineNumber, Arr);
-    Result := Arr;
-  end
-  else if StartsBlockMappingEntry(AValueText) then
-  begin
-    Obj := TGocciaObjectValue.Create;
-    RegisterAnchor(AAnchorName, Obj, ALineNumber);
-    if ASequenceEntryInlineMapping then
-      ParseSequenceEntryMappingInto(ALineIndent, AValueText, ALineNumber, Obj)
-    else
-      ParseMappingInto(ALineIndent, Obj);
-    Result := Obj;
-  end
-  else if IsBlockScalarHeader(AValueText) then
-    Result := ParseBlockScalar(ALineIndent, AValueText, ALineNumber)
-  else if AValueText[1] = '[' then
-  begin
-    Arr := TGocciaArrayValue.Create;
-    RegisterAnchor(AAnchorName, Arr, ALineNumber);
-    FlowText := CollectFlowCollectionText(AValueText, ALineNumber);
-    ParseFlowSequenceInto(FlowText, Arr);
-    Result := Arr;
-  end
-  else if AValueText[1] = '{' then
-  begin
-    Obj := TGocciaObjectValue.Create;
-    RegisterAnchor(AAnchorName, Obj, ALineNumber);
-    FlowText := CollectFlowCollectionText(AValueText, ALineNumber);
-    ParseFlowMappingInto(FlowText, Obj);
-    Result := Obj;
-  end
-  else
-    Result := ParseInlineValueWithContinuations(AValueText, ALineIndent,
-      ALineNumber, AStopAtIndentedSequenceEntry,
-      ARequireIndentedQuotedContinuation,
-      AAllowSameIndentScalarContinuation);
+      Result := ParseInlineValueWithContinuations(AValueText, ALineIndent,
+        ALineNumber, AStopAtIndentedSequenceEntry,
+        ARequireIndentedQuotedContinuation,
+        AAllowSameIndentScalarContinuation);
 
-  Result := ApplyTag(ATagName, Result, ALineNumber);
-  RegisterAnchor(AAnchorName, Result, ALineNumber);
-end;
-
-function TGocciaYAMLParser.ParseSequence(const AIndent: Integer): TGocciaValue;
-var
-  Arr: TGocciaArrayValue;
-begin
-  Arr := TGocciaArrayValue.Create;
-  ParseSequenceInto(AIndent, Arr);
-  Result := Arr;
+    // ApplyTag can wrap the node in a fresh tagged value, built from strings that
+    // are themselves charged; re-point the root at whatever is being returned so
+    // the wrapper survives until the anchor registration below records it.
+    Result := ApplyTag(ATagName, Result, ALineNumber);
+    AddTempRootIfNeeded(NodeRoot, Result);
+    RegisterAnchor(AAnchorName, Result, ALineNumber);
+  finally
+    RemoveTempRootIfNeeded(NodeRoot);
+  end;
 end;
 
 procedure TGocciaYAMLParser.ParseSequenceInto(const AIndent: Integer;
@@ -2679,24 +2787,6 @@ begin
       AnchorName, True, True, True, False, True, False);
     AArray.Elements.Add(Value);
   end;
-end;
-
-function TGocciaYAMLParser.ParseFlowSequence(const AText: string): TGocciaValue;
-var
-  Arr: TGocciaArrayValue;
-begin
-  Arr := TGocciaArrayValue.Create;
-  ParseFlowSequenceInto(AText, Arr);
-  Result := Arr;
-end;
-
-function TGocciaYAMLParser.ParseFlowMapping(const AText: string): TGocciaValue;
-var
-  Obj: TGocciaObjectValue;
-begin
-  Obj := TGocciaObjectValue.Create;
-  ParseFlowMappingInto(AText, Obj);
-  Result := Obj;
 end;
 
 procedure TGocciaYAMLParser.ParseInlineSequenceInto(const AFirstEntryText: string;
@@ -2753,6 +2843,7 @@ var
   ItemIndex: Integer;
   Items: TStringList;
   Obj: TGocciaObjectValue;
+  EntryRoot: TGocciaTempRoot;
 begin
   if (Length(AText) < 2) or (AText[1] <> '[') or
      (AText[Length(AText)] <> ']') then
@@ -2762,18 +2853,24 @@ begin
   if InnerText = '' then
     Exit;
 
+  // A flow-mapping entry is filled by ParseFlowMappingEntry before it joins the
+  // sequence, and the scalars built in there charge the memory ceiling, so this
+  // frame is its only reference across a collection.
+  InitializeTempRoot(EntryRoot);
   Items := SplitTopLevelItems(InnerText);
   try
     for ItemIndex := 0 to Items.Count - 1 do
       if FindTopLevelFlowMappingSeparator(Items[ItemIndex]) > 0 then
       begin
         Obj := TGocciaObjectValue.Create;
+        AddTempRootIfNeeded(EntryRoot, Obj);
         ParseFlowMappingEntry(Obj, Items[ItemIndex]);
         AArray.Elements.Add(Obj);
       end
       else
         AArray.Elements.Add(ParseInlineValue(Items[ItemIndex]));
   finally
+    RemoveTempRootIfNeeded(EntryRoot);
     Items.Free;
   end;
 end;
@@ -2839,7 +2936,12 @@ var
   Obj: TGocciaObjectValue;
   RemainingText: string;
   TrimmedText: string;
+  NodeRoot: TGocciaTempRoot;
 begin
+  // Both flow-collection arms below fill their node before returning it, across
+  // scalar allocations that are charged against the memory ceiling and so can
+  // collect. One root serves both: only one arm runs per call.
+  InitializeTempRoot(NodeRoot);
   EnterNativeDataDepth('YAML parsing');
   try
     CheckNativeWork;
@@ -2865,6 +2967,7 @@ begin
   else if TrimmedText[1] = '[' then
   begin
     Arr := TGocciaArrayValue.Create;
+    AddTempRootIfNeeded(NodeRoot, Arr);
     RegisterAnchor(AnchorName, Arr);
     ParseFlowSequenceInto(TrimmedText, Arr);
     Result := Arr;
@@ -2872,6 +2975,7 @@ begin
   else if TrimmedText[1] = '{' then
   begin
     Obj := TGocciaObjectValue.Create;
+    AddTempRootIfNeeded(NodeRoot, Obj);
     RegisterAnchor(AnchorName, Obj);
     ParseFlowMappingInto(TrimmedText, Obj);
     Result := Obj;
@@ -2897,8 +3001,10 @@ begin
     Result := TGocciaStringLiteralValue.Create(TrimmedText);
 
   Result := ApplyTag(TagName, Result);
+    AddTempRootIfNeeded(NodeRoot, Result);
     RegisterAnchor(AnchorName, Result);
   finally
+    RemoveTempRootIfNeeded(NodeRoot);
     LeaveNativeDataDepth;
   end;
 end;


### PR DESCRIPTION
## Summary

- Second wave of the use-after-free class fixed in #1140: builtins and the recursive parsers filled freshly created GC-managed containers across *collecting safe points* (non-empty string creation charges the memory ceiling via `TryReserveExternalBytes`, which can run `CollectForMemoryPressure`; the collector marks only explicit roots, never the native stack). An interprocedural audit plus two adversarial review rounds found and fixed sites in six units:
  - **JSONL** — chunk result builder and all four parse-entry accumulator arrays.
  - **JSON5 builtin** — reviver/replacer/`toJSON`/parse-holder surfaces (mirrors the already-hardened JSON builtin).
  - **`Promise.allSettled`** — both settle handlers' entry objects.
  - **JSON parser** — a `TGCRootSource` marking the visitor's open-container stack and finished tree; covers the JSON5 parser path, which shares the visitor.
  - **YAML parser** — document array, all eight `ParseNodeValue` container arms, flow/inline entries, the mapping-entry key/value windows, a `TGCRootSource` over the anchors map, and a double-free on the multi-document path.
  - **TOML parser** — parse-duration root over the root table plus the two detached sites (`ParseArray`, `ParseInlineTable`).
- **Resource-ceiling opacity** (per the `Goccia.MemoryLimit` contract): the JSON/JSON5/YAML parse handlers are narrowed to their parsers' own error classes, and the JSON/JSON5 stringify handlers gain re-raise allowlist arms for the timeout/instruction-limit/memory-limit family. User-visible changes: charged-allocation refusals in parse now keep their `RangeError` identity and message (previously an empty-message `SyntaxError`, or a fatal nil-deref at tight ceilings); growth-gate refusals in parse/stringify are no longer guest-catchable (previously convertible to `SyntaxError`/`TypeError`, which let a guest ignore the ceiling in a loop); deeply nested YAML now reports `RangeError` like TOML instead of an empty `SyntaxError`.
- Removes five uncalled (and unrooted) private YAML parser methods.
- Non-goals: the pre-existing depth-error classification split (JSON/JSON5/JSONL report `SyntaxError` from the parser-internal nesting cap; YAML/TOML report `RangeError` from the native depth guard) is documented in the tests, not changed.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [ ] Updated documentation
- [x] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

Details: eight distinct use-after-free crash shapes (access violations, nil dereferences, an invalid type cast, a double free) were reproduced on the pre-fix tree with parked-heap probes and are clean refusals after. `scripts/test-cli.ts` gains those probes as regression tests — measured multi-pass heap parking that fails loudly when not parked, exact-value assertions on runs that complete under pressure, guest-opacity checks with in-suite vacuity controls, and re-raise-allowlist coverage for all five data formats in both execution modes; every new check was negative-control validated (fails on the pre-fix binary). Full gate: `./build.pas testrunner loader`, `GocciaTestRunner tests` (12203/12203) in both modes, `./format.pas --check`, and `bun run scripts/test-cli.ts` all exit 0. The full Pascal unit-test set (including `Goccia.MemoryLimit.Test`) passes.