### PR TITLE
fix(ci): create the heaptrc -FU dir and hard-bound the fuzz timeout

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -99,11 +99,23 @@ jobs:
           # is a NORMAL exit-0 outcome, so AFL's exec threshold must sit safely
           # above it — otherwise process overhead around a legitimate slow input
           # lands it in hangs/ and false-fails the job.
+          # -k 60: afl-fuzz does not reliably exit on the SIGTERM `timeout`
+          # sends at the deadline — run 31771115536 sat 43 further minutes on a
+          # delivered SIGTERM until the job's own 60-minute cap cancelled it,
+          # leaving `timeout` and afl-fuzz behind as orphans. The kill
+          # signal makes FUZZ_SECONDS an actual bound. Findings are written to
+          # crashes/ and hangs/ as they are discovered, so a hard kill loses no
+          # reproducers — only the final stats summary.
           AFL_SKIP_CPUFREQ=1 AFL_NO_AFFINITY=1 AFL_BENCH_UNTIL_CRASH=1 \
-          timeout "${FUZZ_SECONDS}" afl-fuzz -n -t 5000 \
+          status=0
+          timeout -k 60 "${FUZZ_SECONDS}" afl-fuzz -n -t 5000 \
             -i build/fuzz/corpus \
             -o build/fuzz/out \
-            -- ./build/GocciaFuzzHarness @@ || true
+            -- ./build/GocciaFuzzHarness @@ || status=$?
+          # 124 = deadline reached, SIGTERM honored; 137 = SIGKILL was needed,
+          # i.e. the SIGTERM hang recurred. Crash triage happens in the next
+          # step either way.
+          echo "afl-fuzz exit status: ${status}"
 
       - name: Report crashes
         run: |
@@ -152,9 +164,14 @@ jobs:
 
       - name: Build test runner with heaptrc
         # -gh links the heaptrc unit; the trailing summary goes to stderr on
-        # exit and names every unfreed block with its allocation site.
+        # exit and names every unfreed block with its allocation site. The
+        # separate -FU dir follows the per-program unit-output rule (see
+        # docs/contributing/tooling.md, "Shared -FU Directories Across
+        # Programs" — Internal error 200611011) — but fpc does not create a
+        # -FU directory, it only writes into one, so mkdir it first.
         run: |
           ./build.pas testrunner
+          mkdir -p build/compiled/targets/testrunner-heaptrc
           fpc @config.cfg -gh -gl -FUbuild/compiled/targets/testrunner-heaptrc \
             -obuild/GocciaTestRunnerHeaptrc source/app/GocciaTestRunner.dpr
 

--- a/docs/contributing/tooling.md
+++ b/docs/contributing/tooling.md
@@ -303,8 +303,16 @@ JavaScript suite under two tools that answer different questions:
 
 | Tool | Catches | Invocation |
 |------|---------|-----------|
-| **heaptrc** (`-gh`) | FPC-level leaks, double frees, unfreed blocks with allocation sites | `fpc @config.cfg -gh -gl -oBIN source/app/GocciaTestRunner.dpr` |
+| **heaptrc** (`-gh`) | FPC-level leaks, double frees, unfreed blocks with allocation sites | `mkdir -p DIR && fpc @config.cfg -gh -gl -FUDIR -oBIN source/app/GocciaTestRunner.dpr` |
 | **Valgrind memcheck** | Invalid reads/writes the allocator never sees, uninitialised values | `valgrind --tool=memcheck --error-exitcode=42 ./build/GocciaTestRunner tests` |
+
+`DIR` is a unit-output directory of your own (CI uses
+`build/compiled/targets/testrunner-heaptrc`). Give the heaptrc build its own
+per the [per-program `-FU` rule](#shared--fu-directories-across-programs--internal-error-200611011) —
+and create the directory first, because `fpc` writes into a `-FU` directory but
+will not create one; against a missing directory it fails with
+`Can't create object file: … (error code: 2)` (on external-assembler targets
+such as macOS the message is `Can't create assembler file: …` instead).
 
 Both run on Linux only. Valgrind slows the suite by roughly an order of
 magnitude, which is why neither runs per-PR. Findings upload as artifacts with


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Fixes both root causes of the "Fuzz and memory safety" workflow failure on main (run 31771115536 — the workflow's only run to date, so both bugs are latent from #1130).
- **memory-safety (both legs):** `fpc` writes into a `-FU` unit-output directory but never creates one, and nothing created `build/compiled/targets/testrunner-heaptrc`. A `mkdir -p` now precedes the raw `fpc` call, with a comment pointing at the per-program `-FU` rule (Internal error 200611011). Reproduced locally: the exact workflow command fails against a missing dir and succeeds after `mkdir` (exit 0, working `GocciaTestRunnerHeaptrc`).
- **fuzz:** `timeout` without `-k` — afl-fuzz ignores the SIGTERM at the `FUZZ_SECONDS` deadline; the job then idled 43 minutes until the 60-minute cap cancelled it, leaving orphans. `timeout -k 60` sends SIGKILL 60s after SIGTERM; the exit status is echoed (124 = deadline honored, 137 = the hang recurred) so the failure mode stays observable. Reproducers land in `crashes/`/`hangs/` as found, so a hard kill loses only the final stats banner.
- Also fixes the documented heaptrc invocation in `docs/contributing/tooling.md`, which had no `-FU` at all (would write `-gh` units into the shared `build/compiled`), and notes the macOS external-assembler error-string variant.
- Known limitation, deliberately out of scope: with the build fixed, the memory-safety job will proceed to the `Run suite under heaptrc` gate, which requires zero unfreed blocks — but the engine's exit-time teardown leaves a fixed ~21.9k-block baseline, so that gate has never been passable (ADR 0078 calls zero-leak heaptrc a future prerequisite). Whether to fix teardown, baseline the count, or make that step report-only is a separate decision; this PR makes the build reach it and produce the first real leak-inventory artifact.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests — no engine source touched; `./build.pas testrunner` exit 0, pre-fix workflow `fpc` line reproduces the ENOENT locally, post-fix line exits 0 and the heaptrc binary passes a smoke test; `./format.pas --check` clean; workflow YAML re-parses; `check-doc-links` (655 links, 0 broken) and `markdownlint-cli2` (0 issues) pass after the tooling.md edit.
- [x] Updated documentation
- [ ] Optional: native Pascal tests — not applicable: CI workflow + docs only.
- [ ] Optional: benchmarks — not applicable.
