### PR TITLE
fix(website): make the installers work against the real release-archive layout

### DIFF
--- a/website/public/install.ps1
+++ b/website/public/install.ps1
@@ -51,13 +51,35 @@ try {
   # --- install -------------------------------------------------------
   New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
 
+  # The archive expands into a single top-level directory named after the
+  # release (gocciascript-<version>-windows-<arch>) with the executables
+  # sitting at its root. Resolve it by glob rather than by exact name, and
+  # keep the legacy build\ and flat layouts as fallbacks.
+  $Candidates = @(Join-Path $TempDir "gocciascript-$Version-windows-$Arch")
+  $Candidates += @(
+    Get-ChildItem -Path $TempDir -Directory -Filter "gocciascript-*" |
+      ForEach-Object { $_.FullName }
+  )
+  $Candidates += (Join-Path $TempDir "build"), $TempDir
+
+  $SrcDir = $Candidates |
+    Where-Object { Test-Path -LiteralPath (Join-Path $_ "GocciaScriptLoader.exe") } |
+    Select-Object -First 1
+  if (-not $SrcDir) {
+    throw "install.ps1: could not find GocciaScriptLoader.exe in $Asset"
+  }
+
+  # Every release archive carries all three; a missing one means a broken
+  # download or a layout change, so fail rather than report a partial
+  # install as success.
   foreach ($exe in @("GocciaScriptLoader", "GocciaTestRunner", "GocciaREPL")) {
-    $src = Join-Path $TempDir "build\$exe.exe"
-    if (Test-Path $src) {
-      Move-Item -Force $src (Join-Path $InstallDir "$exe.exe")
-    } else {
-      Write-Warning "install.ps1: $src not found in archive — skipping"
+    $src = Join-Path $SrcDir "$exe.exe"
+    if (-not (Test-Path -LiteralPath $src)) {
+      throw "install.ps1: $src not found in archive"
     }
+  }
+  foreach ($exe in @("GocciaScriptLoader", "GocciaTestRunner", "GocciaREPL")) {
+    Move-Item -Force (Join-Path $SrcDir "$exe.exe") (Join-Path $InstallDir "$exe.exe")
   }
 
   # --- ensure InstallDir is on user PATH -----------------------------

--- a/website/public/install.sh
+++ b/website/public/install.sh
@@ -71,17 +71,35 @@ if [ ! -w "$INSTALL_DIR" ]; then
   fi
 fi
 
-mkdir -p build  # paranoia: archive should already create this
-for bin in GocciaScriptLoader GocciaTestRunner GocciaREPL; do
-  src="build/${bin}"
-  if [ ! -f "$src" ]; then
-    printf 'install.sh: %s not found in archive — skipping\n' "$src" >&2
-    continue
+# The archive expands into a single top-level directory named after the
+# release (gocciascript-<version>-<os>-<arch>) with the executables sitting
+# at its root. Resolve it by glob rather than by exact name, and keep the
+# legacy build/ and flat layouts as fallbacks.
+SRC_DIR=""
+for candidate in "gocciascript-${VERSION}-${OS}-${ARCH}" gocciascript-*/ build .; do
+  candidate="${candidate%/}"
+  if [ -f "${candidate}/GocciaScriptLoader" ]; then
+    SRC_DIR="$candidate"
+    break
   fi
+done
+[ -n "$SRC_DIR" ] || err "could not find GocciaScriptLoader in $ASSET"
+
+# Every release archive carries all three; a missing one means a broken
+# download or a layout change, so fail rather than report a partial
+# install as success.
+for bin in GocciaScriptLoader GocciaTestRunner GocciaREPL; do
+  [ -f "${SRC_DIR}/${bin}" ] || err "${SRC_DIR}/${bin} not found in archive"
+done
+for bin in GocciaScriptLoader GocciaTestRunner GocciaREPL; do
+  src="${SRC_DIR}/${bin}"
   chmod +x "$src"
   $SUDO mv "$src" "${INSTALL_DIR}/${bin}"
 done
 
+INSTALL_DIR="${INSTALL_DIR%/}"
 printf '\nGocciaScript %s installed to %s\n' "$VERSION" "$INSTALL_DIR"
-"${INSTALL_DIR}/GocciaScriptLoader" --version 2>/dev/null \
-  || printf 'Add %s to your PATH if it is not already there.\n' "$INSTALL_DIR"
+case ":${PATH}:" in
+  *":${INSTALL_DIR}:"*) ;;
+  *) printf 'Add %s to your PATH if it is not already there.\n' "$INSTALL_DIR" ;;
+esac


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- The published `curl | sh` / `irm | iex` installers have been a **no-op since the website's introduction**: they assumed archive binaries under `build/`, but every release ever published extracts to a flat `gocciascript-<version>-<os>-<arch>/` directory (verified empirically against 0.12.0 assets and the packaging step of every tagged `ci.yml` back to 0.3.0). All three moves skipped with a warning, and the script still exited 0 and printed the success banner.
- Both installers now resolve the package directory by validated candidate list (exact versioned name → `gocciascript-*/` glob → legacy `build` → flat root) and **hard-error** when `GocciaScriptLoader` is nowhere; a missing sibling binary is likewise a hard error rather than warn-and-succeed, since every archive carries all three.
- Second bug: the final health check ran `GocciaScriptLoader --version` — a flag the CLI does not have — so even a correct install printed an error line and a spurious PATH hint. Replaced with a PATH-membership check (trailing slashes normalized).
- `install.ps1` mirrors the sh logic (`@()`-normalized candidate array, `Test-Path -LiteralPath`, `throw` on miss); no `pwsh` on this host, so it is rigorously desk-checked rather than executed.
- Related: [#1147](https://github.com/frostney/GocciaScript/pull/1147) fixes the same wrong `build/` layout in the manual-install commands rendered by `install.tsx`; until both land, one surface of the install page will disagree with the other.
- Follow-up worth filing: nothing in lefthook or CI lints or exercises `website/public/install.sh`/`install.ps1` — which is how a never-valid path shipped and survived to 0.12.0.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests — `install.sh` exercised end-to-end on macOS against live GitHub assets: fresh prefix, already-on-PATH prefix, prefix with spaces, trailing-slash prefix, `GOCCIA_VERSION=nightly`, bad tag (curl 404 → abort), and a loader-only archive (exit 1, nothing installed, temp dir cleaned by the EXIT trap); installed loader passes a script smoke test; `shellcheck --shell=sh` and `sh -n` clean; website `bun test` (204 pass) and Biome clean.
- [ ] Updated documentation — not applicable: behavior now matches what the docs already claim.
- [ ] Optional: native Pascal tests — not applicable: installer scripts only.
- [ ] Optional: benchmarks — not applicable.
