### PR TITLE
fix(testing): lift the parked parser-probe ceilings clear of the refusal bands

### DIFF
--- a/scripts/test-cli.ts
+++ b/scripts/test-cli.ts
@@ -1387,12 +1387,41 @@ console.log("--max-memory (builtin result builders survive mid-build collections
       // A tight window puts the crossing early in the parse, where the most
       // allocation still follows to reuse whatever the sweep freed — 100 KiB is
       // where the YAML explicit-key and JSONL accumulator defects reproduce, and
-      // a wider one lets several of them through. 2 MiB is not in the ceiling
-      // set: the wider documents cannot even be built at that ceiling, so the run
-      // refuses before it has a heap to park and proves nothing.
+      // a wider one lets several of them through. The window is that slack, not
+      // the ceiling: the ceiling only has to be wide enough that building the
+      // document cannot refuse before there is a heap to park at all.
+      //
+      // That floor is higher than it looks, and it is not monotonic. Every setup
+      // ends in one `join` that asks for the whole document as a single charged
+      // string — 617 KiB for yaml-block-and-flow, 620 KiB for toml — and absent
+      // latched external pressure, a reservation R is refused *without* a
+      // collection whenever the heap sits in (maxBytes - R, maxBytes -
+      // maxBytes/8), below the threshold at which TryReserveExternalBytes
+      // collects before giving up. Whether a given ceiling survives therefore
+      // depends on where the setup's transient garbage happens to sit at that
+      // instant, so the refusals come in bands. Measured every 50 KB from
+      // 2.5 MB across all nine documents: refusals cluster at 2.5-2.6,
+      // 2.75-3.05, 3.2-3.3, 3.45-3.55 and 3.85-3.9 MB, the top cluster toml's;
+      // from 3.95 MB to 12 MB no ceiling refuses. The old 3 MiB first ceiling
+      // sat 54 KB below a cluster on this machine and inside one on i386-win32,
+      // which is how a document that never got parsed failed as "exercised no
+      // collecting window". 6 and 8 MiB clear the top cluster by 61% and 115%.
+      //
+      // The choice is structural, not just empirical: that refusal interval is
+      // non-empty only when R > maxBytes/8, and the largest setup reservation
+      // is toml's 634,520 B — below maxBytes/8 at 6 MiB (786,432) and 8 MiB
+      // (1,048,576), so refuse-before-park is impossible at these ceilings for
+      // every document. R is pure charged string payload (length *
+      // SizeOf(Char), 2 bytes/char on every target under delphiunicode), so
+      // the condition holds on i386 unchanged; per-object InstanceSize is the
+      // only pointer-size-sensitive heap term and it only makes i386 smaller.
+      // Which of the two accepted terminal outcomes a probe lands on (refused
+      // RangeError vs the tolerated growth-gate fatal) can shift with the
+      // ceiling — yaml-anchors takes the RangeError path at 4 MiB but the
+      // growth gate here — and assertProbeRun accepts both.
       const tightPath = join(tmp, `parser-parked-${probe.name}.mjs`);
       writeFileSync(tightPath, buildSrc(parkingPreamble(100_000)));
-      for (const maxMemory of [3_145_728, 4_194_304]) {
+      for (const maxMemory of [6_291_456, 8_388_608]) {
         const proc = Bun.spawnSync([LOADER, `--max-memory=${maxMemory}`, tightPath], {
           stdout: "pipe",
           stderr: "pipe",
@@ -1408,8 +1437,8 @@ console.log("--max-memory (builtin result builders survive mid-build collections
         );
       }
 
-      // A wider window at a wider ceiling: parked enough that the parse collects
-      // repeatedly, with enough left over that it can still finish. This is the
+      // A wider window: parked enough that the parse collects repeatedly, with
+      // enough left over that it can still finish. This is the
       // only shape that can observe a swept container being written into and then
       // read back, which is how a missing root shows up as wrong data rather than
       // as a fault — so this run has to complete, and a refusal fails it.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Unblocks main CI: the `cli (i386-win32, windows-latest)` job has been red since #1146 landed, and the tag-triggered release path dies with it (release/artifacts jobs skip when `cli` fails).
- Root cause is a probe-calibration bug, not a GC regression: the parked-heap parser probes **introduced by #1146** die during their own document setup, before any parsing. Each setup's final `join` charges the whole document as one reservation (up to 634,520 B), and `TryReserveExternalBytes` refuses a reservation `R` *without collecting* whenever the heap sits in `(maxBytes − R, maxBytes − maxBytes/8)` — so refusals come in bands, and the old 3 MiB ceiling sat inside one on i386-win32. (The earlier red runs on this job died in an unrelated `afterEach` assertion fixed by #1145; this block had never executed on i386.)
- Fix: lift the tight-run ceilings from 3/4 MiB to 6/8 MiB. Structurally sufficient, not just empirically: the refusal interval is non-empty only when `R > maxBytes/8`, and both new ceilings put `maxBytes/8` above the largest setup reservation — a condition built purely from charged string payload (2 bytes/char on every target), so it holds on i386 unchanged. **Detection power is untouched**: probe sensitivity lives in the fixed 100 KiB parked slack, which is unchanged, and all nine probes still report `parked true` at both ceilings.
- Adversarially reviewed: an independent reviewer reproduced the full band map character-for-character (bands at 2.5–2.6, 2.75–3.05, 3.2–3.3, 3.45–3.55, 3.85–3.9 MB; clean 3.95→12 MB), verified the GC mechanism in `Goccia.GarbageCollector.pas`, confirmed the other fixed-ceiling parked blocks are clear, and ran a 140-point fine sweep around the new ceilings with zero refusals — both sit mid-plateau.
- Follow-up filed separately: the latent engine wart (refuse-without-collect for large reservations mid-band) deserves its own change with its own review; this PR deliberately touches no Pascal source.
- What to watch: `ci.yml` → `cli (i386-win32, windows-latest)` → "Check CLI flags across all apps". Note the steps after that block have also never run on i386 at this commit, so an unrelated downstream failure surfacing there is possible.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests — `./build.pas --clean testrunner` exit 0; `tests` and `tests --mode=bytecode` both 27,174 assertions / 0 failed; `./format.pas --check` clean; `bun run scripts/test-cli.ts` (the CI cli step) passes end-to-end; all 18 tight runs report `parked true` at 6 and 8 MiB.
- [ ] Updated documentation — not applicable: probe-internal calibration; the mechanism is documented in the probe comment.
- [x] Optional: Verified no regressions in native Pascal tests — no Pascal source touched; full engine suite green in both modes.
- [ ] Optional: benchmarks — not applicable.
