### PR TITLE
fix(interpreter): perform compound assignment's GetValue exactly once

### DIFF
--- a/source/units/Goccia.AST.Expressions.pas
+++ b/source/units/Goccia.AST.Expressions.pas
@@ -2012,9 +2012,9 @@ begin
     key literal, the read-back current value and the RHS sit in native locals
     across `Value.Evaluate`, a getter call, or a property-map growth — each a
     collecting safe point that marks explicit roots only. Only the values still
-    read after such a point are rooted: on the non-super paths the current value
-    is consumed by the short-circuit predicates before anything can collect, and
-    PerformPropertyCompoundAssignment re-reads the property itself. }
+    read after such a point are rooted: the short-circuit predicates consume the
+    current value before anything can collect, while the arithmetic branches
+    carry it across the RHS and hand it to the store. }
   Roots.Initialize;
   try
     if ObjectExpr is TGocciaSuperExpression then
@@ -2070,7 +2070,12 @@ begin
 
     Obj := ObjectExpr.Evaluate(AContext);
     Roots.Add(Obj);
-    CurrentValue := NormalizeAssignmentValue(Obj.GetProperty(PropertyName));
+    // ES2026 §13.15.2 step 3: GetValue(lref) runs exactly once here, before the
+    // RHS, and feeds both the short-circuit predicates and the arithmetic.
+    if not ReadPropertyCompoundAssignmentValue(Obj, PropertyName,
+      AContext.OnError, Line, Column, CurrentValue) then
+      Exit(TGocciaUndefinedLiteralValue.UndefinedValue);
+
     // ES2026 §13.15.2 step 3: ??=
     if Operator = gttNullishCoalescingAssign then
     begin
@@ -2110,10 +2115,14 @@ begin
       Exit;
     end;
 
+    { The current value is now the only copy of what step 3 read — a getter's
+      result is reachable from nothing else, and the RHS can overwrite the
+      property — so it has to survive `Value.Evaluate` and the arithmetic. }
+    Roots.Add(CurrentValue);
     RhsValue := Value.Evaluate(AContext);
     Roots.Add(RhsValue);
-    Result := PerformPropertyCompoundAssignment(Obj, PropertyName, RhsValue,
-      Operator, AContext.OnError, Line, Column, AContext.NonStrictMode);
+    Result := PerformPropertyCompoundAssignment(Obj, PropertyName, CurrentValue,
+      RhsValue, Operator, AContext.OnError, Line, Column, AContext.NonStrictMode);
   finally
     Roots.Clear;
   end;
@@ -2226,11 +2235,12 @@ begin
     begin
       { A symbol key survives the read, the RHS and the store; a string key is
         consumed by the PropName extraction below with nothing collecting in
-        between. Neither branch roots the current value: it is read by the
-        short-circuit predicates before anything can collect, and
-        PerformSymbolPropertyCompoundAssignment / PerformPropertyCompoundAssignment
-        re-read the property themselves. }
+        between. The current value is only rooted on the arithmetic branches:
+        the short-circuit predicates read it before anything can collect, while
+        the arithmetic carries it across the RHS and hands it to the store. }
       Roots.Add(PropertyKeyValue);
+      // ES2026 §13.15.2 step 3: GetValue(lref) runs exactly once here, before
+      // the RHS, and feeds both the short-circuit predicates and the arithmetic.
       CurrentValue := NormalizeAssignmentValue(ReadSymbolProperty(Obj,
         TGocciaSymbolValue(PropertyKeyValue)));
 
@@ -2246,16 +2256,20 @@ begin
         Exit;
       end;
 
+      Roots.Add(CurrentValue);
       RhsValue := Value.Evaluate(AContext);
       Roots.Add(RhsValue);
       Result := PerformSymbolPropertyCompoundAssignment(Obj,
-        TGocciaSymbolValue(PropertyKeyValue), RhsValue, Operator,
+        TGocciaSymbolValue(PropertyKeyValue), CurrentValue, RhsValue, Operator,
         AContext.OnError, Line, Column, AContext.NonStrictMode);
       Exit;
     end;
 
     PropName := TGocciaStringLiteralValue(PropertyKeyValue).Value;
-    CurrentValue := NormalizeAssignmentValue(Obj.GetProperty(PropName));
+    if not ReadPropertyCompoundAssignmentValue(Obj, PropName, AContext.OnError,
+      Line, Column, CurrentValue) then
+      Exit(TGocciaUndefinedLiteralValue.UndefinedValue);
+
     if IsShortCircuitOperator then
     begin
       if ShortCircuits then
@@ -2268,10 +2282,12 @@ begin
       Exit;
     end;
 
+    Roots.Add(CurrentValue);
     RhsValue := Value.Evaluate(AContext);
     Roots.Add(RhsValue);
-    Result := PerformPropertyCompoundAssignment(Obj, PropName, RhsValue,
-      Operator, AContext.OnError, Line, Column, AContext.NonStrictMode);
+    Result := PerformPropertyCompoundAssignment(Obj, PropName, CurrentValue,
+      RhsValue, Operator, AContext.OnError, Line, Column,
+      AContext.NonStrictMode);
   finally
     Roots.Clear;
   end;

--- a/source/units/Goccia.Evaluator.Assignment.pas
+++ b/source/units/Goccia.Evaluator.Assignment.pas
@@ -15,8 +15,14 @@ procedure AssignProperty(const AObj: TGocciaValue; const APropertyName: string; 
 procedure AssignSymbolProperty(const AObj: TGocciaValue; const ASymbol: TGocciaSymbolValue; const AValue: TGocciaValue; const AOnError: TGocciaThrowErrorCallback; const ALine, AColumn: Integer; const ANonStrictMode: Boolean = False);
 
 // Compound assignment operations
-function PerformPropertyCompoundAssignment(const AObj: TGocciaValue; const APropertyName: string; const AValue: TGocciaValue; const AOperator: TGocciaTokenType; const AOnError: TGocciaThrowErrorCallback; const ALine, AColumn: Integer; const ANonStrictMode: Boolean = False): TGocciaValue;
-function PerformSymbolPropertyCompoundAssignment(const AObj: TGocciaValue; const ASymbol: TGocciaSymbolValue; const AValue: TGocciaValue; const AOperator: TGocciaTokenType; const AOnError: TGocciaThrowErrorCallback; const ALine, AColumn: Integer; const ANonStrictMode: Boolean = False): TGocciaValue;
+// ES2026 §13.15.2 step 3 performs GetValue(lref) once, before the right-hand
+// side is evaluated, so the read is the caller's — it owns the evaluation order
+// and the short-circuit operators consume the same read. The value it obtained
+// is passed back in as ACurrentValue; reading the property again here would call
+// an accessor's getter twice per compound assignment.
+function ReadPropertyCompoundAssignmentValue(const AObj: TGocciaValue; const APropertyName: string; const AOnError: TGocciaThrowErrorCallback; const ALine, AColumn: Integer; out ACurrentValue: TGocciaValue): Boolean;
+function PerformPropertyCompoundAssignment(const AObj: TGocciaValue; const APropertyName: string; const ACurrentValue, AValue: TGocciaValue; const AOperator: TGocciaTokenType; const AOnError: TGocciaThrowErrorCallback; const ALine, AColumn: Integer; const ANonStrictMode: Boolean = False): TGocciaValue;
+function PerformSymbolPropertyCompoundAssignment(const AObj: TGocciaValue; const ASymbol: TGocciaSymbolValue; const ACurrentValue, AValue: TGocciaValue; const AOperator: TGocciaTokenType; const AOnError: TGocciaThrowErrorCallback; const ALine, AColumn: Integer; const ANonStrictMode: Boolean = False): TGocciaValue;
 
 // Increment/Decrement operations
 function PerformIncrement(const AOldValue: TGocciaValue; const AIsIncrement: Boolean): TGocciaValue;
@@ -206,80 +212,64 @@ begin
       SSuggestCheckNullBeforeAccess);
 end;
 
-function PerformPropertyCompoundAssignment(const AObj: TGocciaValue; const APropertyName: string; const AValue: TGocciaValue; const AOperator: TGocciaTokenType; const AOnError: TGocciaThrowErrorCallback; const ALine, AColumn: Integer; const ANonStrictMode: Boolean = False): TGocciaValue;
+// ES2026 §13.15.2 step 3 → §6.2.5.5 GetValue step 3: a primitive base is read
+// through its wrapper object, so the fallbacks below mirror the boxing that
+// GetValue performs. Returns False when the base cannot be read at all — the
+// caller then has no current value to compute with.
+function ReadPropertyCompoundAssignmentValue(const AObj: TGocciaValue; const APropertyName: string; const AOnError: TGocciaThrowErrorCallback; const ALine, AColumn: Integer; out ACurrentValue: TGocciaValue): Boolean;
 var
-  CurrentValue, NewValue: TGocciaValue;
   BoxedValue: TGocciaObjectValue;
 begin
-  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
-  EnsureAssignableReceiver(AObj, APropertyName);
-  CurrentValue := AObj.GetProperty(APropertyName);
-  if CurrentValue = nil then
+  { This is the read step, so a nullish base fails as a read — the store's
+    set-flavored message would misattribute the failure (and diverge from the
+    VM, which reports the read). }
+  if AObj is TGocciaNullLiteralValue then
+    ThrowTypeError(Format(SErrorCannotReadPropertiesOfNull, [APropertyName]),
+      SSuggestCheckNullBeforeAccess)
+  else if AObj is TGocciaUndefinedLiteralValue then
+    ThrowTypeError(Format(SErrorCannotReadPropertiesOfUndefined,
+      [APropertyName]), SSuggestCheckNullBeforeAccess);
+  ACurrentValue := AObj.GetProperty(APropertyName);
+  if ACurrentValue = nil then
   begin
     BoxedValue := BoxAssignablePrimitive(AObj);
     if Assigned(BoxedValue) then
-    begin
-      CurrentValue := BoxedValue.GetPropertyWithContext(APropertyName, AObj);
-      if CurrentValue = nil then
-        CurrentValue := TGocciaUndefinedLiteralValue.UndefinedValue;
-    end
+      ACurrentValue := BoxedValue.GetPropertyWithContext(APropertyName, AObj)
     else if (AObj is TGocciaSymbolValue) and
             (TGocciaSymbolValue.SharedPrototype is TGocciaObjectValue) then
-    begin
-      CurrentValue := TGocciaObjectValue(TGocciaSymbolValue.SharedPrototype)
-        .GetPropertyWithContext(APropertyName, AObj);
-      if CurrentValue = nil then
-        CurrentValue := TGocciaUndefinedLiteralValue.UndefinedValue;
-    end
+      ACurrentValue := TGocciaObjectValue(TGocciaSymbolValue.SharedPrototype)
+        .GetPropertyWithContext(APropertyName, AObj)
     else
     begin
       if Assigned(AOnError) then
         AOnError('Cannot access property on non-object', ALine, AColumn);
-      Exit;
+      ACurrentValue := TGocciaUndefinedLiteralValue.UndefinedValue;
+      Exit(False);
     end;
   end;
 
-  NewValue := Goccia.Arithmetic.CompoundOperations(
-    CurrentValue, AValue, AOperator);
-  AssignProperty(AObj, APropertyName, NewValue, AOnError, ALine, AColumn,
-    ANonStrictMode);
-  Result := NewValue;
+  if ACurrentValue = nil then
+    ACurrentValue := TGocciaUndefinedLiteralValue.UndefinedValue;
+  Result := True;
 end;
 
-function PerformSymbolPropertyCompoundAssignment(const AObj: TGocciaValue; const ASymbol: TGocciaSymbolValue; const AValue: TGocciaValue; const AOperator: TGocciaTokenType; const AOnError: TGocciaThrowErrorCallback; const ALine, AColumn: Integer; const ANonStrictMode: Boolean = False): TGocciaValue;
-var
-  CurrentValue, NewValue: TGocciaValue;
-  BoxedValue: TGocciaObjectValue;
+// ES2026 §13.15.2 steps 5-7: ApplyStringOrNumericBinaryOperator on the value
+// step 3 already read, then PutValue.
+function PerformPropertyCompoundAssignment(const AObj: TGocciaValue; const APropertyName: string; const ACurrentValue, AValue: TGocciaValue; const AOperator: TGocciaTokenType; const AOnError: TGocciaThrowErrorCallback; const ALine, AColumn: Integer; const ANonStrictMode: Boolean = False): TGocciaValue;
 begin
-  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
-  EnsureAssignableReceiver(AObj, ASymbol.ToDisplayString.Value);
-  if AObj is TGocciaClassValue then
-    CurrentValue := TGocciaClassValue(AObj).GetSymbolProperty(ASymbol)
-  else if AObj is TGocciaObjectValue then
-    CurrentValue := TGocciaObjectValue(AObj).GetSymbolProperty(ASymbol)
-  else if (AObj is TGocciaSymbolValue) and
-          (TGocciaSymbolValue.SharedPrototype is TGocciaObjectValue) then
-    CurrentValue := TGocciaObjectValue(TGocciaSymbolValue.SharedPrototype)
-      .GetSymbolPropertyWithReceiver(ASymbol, AObj)
-  else
-  begin
-    CurrentValue := nil;
-    BoxedValue := BoxAssignablePrimitive(AObj);
-    if Assigned(BoxedValue) then
-      CurrentValue := BoxedValue.GetSymbolPropertyWithReceiver(ASymbol, AObj)
-    else if Assigned(AOnError) then
-    begin
-      AOnError('Cannot access property on non-object', ALine, AColumn);
-      Exit;
-    end;
-  end;
-  if CurrentValue = nil then
-    CurrentValue := TGocciaUndefinedLiteralValue.UndefinedValue;
-  NewValue := Goccia.Arithmetic.CompoundOperations(
-    CurrentValue, AValue, AOperator);
-  AssignSymbolProperty(AObj, ASymbol, NewValue, AOnError, ALine, AColumn,
+  Result := Goccia.Arithmetic.CompoundOperations(
+    ACurrentValue, AValue, AOperator);
+  AssignProperty(AObj, APropertyName, Result, AOnError, ALine, AColumn,
     ANonStrictMode);
-  Result := NewValue;
+end;
+
+// ES2026 §13.15.2 steps 5-7 for a symbol-keyed target.
+function PerformSymbolPropertyCompoundAssignment(const AObj: TGocciaValue; const ASymbol: TGocciaSymbolValue; const ACurrentValue, AValue: TGocciaValue; const AOperator: TGocciaTokenType; const AOnError: TGocciaThrowErrorCallback; const ALine, AColumn: Integer; const ANonStrictMode: Boolean = False): TGocciaValue;
+begin
+  Result := Goccia.Arithmetic.CompoundOperations(
+    ACurrentValue, AValue, AOperator);
+  AssignSymbolProperty(AObj, ASymbol, Result, AOnError, ALine, AColumn,
+    ANonStrictMode);
 end;
 
 function PerformIncrement(const AOldValue: TGocciaValue; const AIsIncrement: Boolean): TGocciaValue;

--- a/tests/language/expressions/compound-assignment-accessor-reads.js
+++ b/tests/language/expressions/compound-assignment-accessor-reads.js
@@ -1,0 +1,245 @@
+/*---
+description: Compound assignment reads its target exactly once, before the right-hand side
+features: [compound-assignment-operators, Symbol, accessor-properties]
+---*/
+
+// ES2026 §13.15.2 evaluates `target op= value` by taking GetValue(target) once
+// (step 3) and only then evaluating the right-hand side, so an accessor target
+// runs its getter once per compound assignment and its setter once per store.
+
+const makeAccessor = (initial) => {
+  const state = {
+    reads: 0,
+    writes: 0,
+    stored: initial,
+  };
+
+  state.target = {
+    get value() {
+      state.reads += 1;
+      return state.stored;
+    },
+    set value(next) {
+      state.writes += 1;
+      state.stored = next;
+    },
+  };
+
+  return state;
+};
+
+describe("compound assignment on accessor properties", () => {
+  test("a named target runs the getter and the setter once", () => {
+    const state = makeAccessor(1);
+
+    state.target.value += 1;
+
+    expect(state.reads).toBe(1);
+    expect(state.writes).toBe(1);
+    expect(state.stored).toBe(2);
+  });
+
+  test("a named target reports the stored value as the expression result", () => {
+    const state = makeAccessor(10);
+
+    expect((state.target.value -= 4)).toBe(6);
+    expect(state.reads).toBe(1);
+    expect(state.writes).toBe(1);
+  });
+
+  test("a computed target runs the getter and the setter once", () => {
+    const state = makeAccessor("a");
+    const key = "value";
+
+    state.target[key] += "b";
+
+    expect(state.reads).toBe(1);
+    expect(state.writes).toBe(1);
+    expect(state.stored).toBe("ab");
+  });
+
+  test("an inherited accessor is read once through the receiver", () => {
+    const state = makeAccessor(3);
+    const child = Object.create(state.target);
+
+    child.value *= 5;
+
+    expect(state.reads).toBe(1);
+    expect(state.writes).toBe(1);
+    expect(state.stored).toBe(15);
+  });
+
+  test("each compound assignment reads its own target once", () => {
+    const left = makeAccessor(2);
+    const right = makeAccessor(7);
+
+    left.target.value += right.target.value;
+
+    expect(left.reads).toBe(1);
+    expect(left.writes).toBe(1);
+    expect(right.reads).toBe(1);
+    expect(right.writes).toBe(0);
+    expect(left.stored).toBe(9);
+  });
+});
+
+describe("compound assignment on symbol-keyed accessor properties", () => {
+  const key = Symbol("value");
+
+  const makeSymbolAccessor = (initial) => {
+    const state = {
+      reads: 0,
+      writes: 0,
+      stored: initial,
+    };
+
+    state.target = {};
+    Object.defineProperty(state.target, key, {
+      get() {
+        state.reads += 1;
+        return state.stored;
+      },
+      set(next) {
+        state.writes += 1;
+        state.stored = next;
+      },
+      configurable: true,
+    });
+
+    return state;
+  };
+
+  test("a symbol-keyed target runs the getter and the setter once", () => {
+    const state = makeSymbolAccessor(4);
+
+    state.target[key] += 6;
+
+    expect(state.reads).toBe(1);
+    expect(state.writes).toBe(1);
+    expect(state.stored).toBe(10);
+  });
+
+  test("a short-circuiting symbol-keyed target is read once and never stored", () => {
+    const state = makeSymbolAccessor(4);
+
+    state.target[key] ??= 99;
+
+    expect(state.reads).toBe(1);
+    expect(state.writes).toBe(0);
+    expect(state.stored).toBe(4);
+  });
+});
+
+describe("short-circuiting compound assignment on accessor properties", () => {
+  test("??= reads once and stores only when the target is nullish", () => {
+    const nullish = makeAccessor(undefined);
+    nullish.target.value ??= "filled";
+    expect(nullish.reads).toBe(1);
+    expect(nullish.writes).toBe(1);
+    expect(nullish.stored).toBe("filled");
+
+    const present = makeAccessor("kept");
+    present.target.value ??= "filled";
+    expect(present.reads).toBe(1);
+    expect(present.writes).toBe(0);
+    expect(present.stored).toBe("kept");
+  });
+
+  test("||= reads once and stores only when the target is falsy", () => {
+    const falsy = makeAccessor(0);
+    falsy.target.value ||= 5;
+    expect(falsy.reads).toBe(1);
+    expect(falsy.writes).toBe(1);
+    expect(falsy.stored).toBe(5);
+
+    const truthy = makeAccessor(1);
+    truthy.target.value ||= 5;
+    expect(truthy.reads).toBe(1);
+    expect(truthy.writes).toBe(0);
+    expect(truthy.stored).toBe(1);
+  });
+
+  test("&&= reads once and stores only when the target is truthy", () => {
+    const truthy = makeAccessor(1);
+    truthy.target.value &&= 5;
+    expect(truthy.reads).toBe(1);
+    expect(truthy.writes).toBe(1);
+    expect(truthy.stored).toBe(5);
+
+    const falsy = makeAccessor(0);
+    falsy.target.value &&= 5;
+    expect(falsy.reads).toBe(1);
+    expect(falsy.writes).toBe(0);
+    expect(falsy.stored).toBe(0);
+  });
+
+  test("a computed short-circuiting target is read once", () => {
+    const state = makeAccessor(null);
+    const key = "value";
+
+    state.target[key] ??= "filled";
+
+    expect(state.reads).toBe(1);
+    expect(state.writes).toBe(1);
+    expect(state.stored).toBe("filled");
+  });
+});
+
+describe("compound assignment on data properties", () => {
+  test("named, computed and element targets keep their values", () => {
+    const object = { count: 1, label: "a" };
+
+    object.count += 2;
+    object["label"] += "b";
+
+    expect(object.count).toBe(3);
+    expect(object.label).toBe("ab");
+
+    const values = [1, 2, 3];
+    values[1] *= 10;
+    expect(values[1]).toBe(20);
+  });
+
+  test("a missing target compounds against undefined", () => {
+    const object = {};
+
+    object.missing += 1;
+    object["alsoMissing"] ??= "default";
+
+    expect(object.missing).toBeNaN();
+    expect(object.alsoMissing).toBe("default");
+  });
+
+  test("a symbol-keyed data target keeps its value", () => {
+    const key = Symbol("count");
+    const object = { [key]: 5 };
+
+    object[key] -= 2;
+
+    expect(object[key]).toBe(3);
+  });
+
+  test("a primitive base is read through its wrapper", () => {
+    // §6.2.5.5 GetValue step 3 boxes the primitive, so the short-circuit read
+    // sees the real property value; the store then throws because a primitive
+    // base accepts no property write.
+    const text = "abc";
+
+    expect(() => {
+      text.length &&= 0;
+    }).toThrow(TypeError);
+    expect(text.length).toBe(3);
+  });
+
+  test("a nullish base throws before the right-hand side runs", () => {
+    // §13.15.2 step 3 performs the read before step 4 evaluates the RHS, so
+    // the TypeError fires with the side effect never executed.
+    let sideEffects = 0;
+    const base = { missing: null };
+
+    expect(() => {
+      base.missing.x += (sideEffects += 1);
+    }).toThrow(TypeError);
+    expect(sideEffects).toBe(0);
+  });
+});


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- A side-effecting property getter now runs exactly once per compound assignment in the interpreter, matching bytecode mode and ES2026 §13.15.2 step 3 (GetValue once, before the RHS): `o.x += 1` with a counting getter reported 2 reads interpreted vs 1 in bytecode. The read was duplicated — once for the short-circuit predicates, once inside `PerformPropertyCompoundAssignment` after the RHS.
- Fix direction matters: the first (pre-RHS) read is the spec-correct one, so the Perform helpers now receive the already-read value instead of re-reading — dropping the first read instead would have fixed the count but moved the read after the RHS, which is observable. New `ReadPropertyCompoundAssignmentValue` owns the single boxing-aware read (§6.2.5.5); the helpers reduce to steps 5–7.
- Two further divergences closed as side effects: non-strict `"ab".length ||= 9` returned 9 interpreted vs 2 in bytecode (the old short-circuit read was not boxing-aware), and a nullish base now throws the read-flavored TypeError before the RHS runs, matching the VM's message and ordering.
- The threaded value is frame-rooted across the RHS and store (it is now live across those collecting safe points; the base layer's rooting comments are updated accordingly). VM/compiler untouched — the VM's separate compound-assignment operand-order bug is the next stack layer.
- Stack layer 3 of #1159, on #1158.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests — new `tests/language/expressions/compound-assignment-accessor-reads.js` (16 tests / 54 assertions: getter/setter counts for named, computed, inherited, symbol-keyed accessors; short-circuit operators both directions; primitive-base boxing; nullish-base ordering; data-property values), green in both executors; full suite 12,234+ green in both modes. Reviewer negative-control: reverting the source fix fails 6 of these tests in interpreter mode only.
- [x] Updated documentation — no doc claims describe the old double read; spec provenance recorded at the read helper (ES2026 §13.15.2 / §6.2.5.5, tc39-mcp snapshot 0248456c)
- [x] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests — no Pascal-level surface changed shape; full unit-test conformance covered by the JS gate
- [ ] Optional: benchmark coverage — not benchmarked; the change removes one property read per compound assignment on the hot path

Review provenance: fresh-context adversarial review; both in-scope findings (read-flavored guard, primitive/nullish coverage) fixed before commit.
