### PR TITLE
fix(vm): read a compound assignment's target before the right-hand side

### DIFF
--- a/source/units/Goccia.Compiler.Expressions.pas
+++ b/source/units/Goccia.Compiler.Expressions.pas
@@ -5899,7 +5899,8 @@ procedure CompileCompoundAssignment(const ACtx: TGocciaCompilationContext;
   const AExpr: TGocciaCompoundAssignmentExpression; const ADest: UInt16);
 var
   LocalIdx, UpvalIdx: Integer;
-  Slot, RegVal, RegResult, RegTemp, CondReg, ArgReg, ObjReg, KeyReg: UInt16;
+  Slot, RegVal, RegOld, RegResult, RegTemp, CondReg, ArgReg, ObjReg,
+    KeyReg: UInt16;
   ReferenceReg: Integer;
   NameIdx: UInt16;
   Op, FloatOp: TGocciaOpCode;
@@ -6122,17 +6123,33 @@ begin
       Exit;
     end;
     Slot := ACtx.Scope.GetLocal(LocalIdx).Slot;
+    // The type hint has to be sampled here, together with the value it
+    // describes: compiling the right-hand side can rebind the target and
+    // rewrite its hint, and the operand registers below still hold the value
+    // read before that happened. Reading the hint afterwards would let
+    // `let x = 'a'; x += ((x = 5), 2)` take the unguarded float path against a
+    // string operand.
+    LocalType := ACtx.Scope.GetLocal(LocalIdx).TypeHint;
+    // ES2026 §13.15.2 step 3: GetValue(lRef) runs BEFORE step 4 evaluates the
+    // right-hand side, so the old value has to be captured into its own
+    // register first. Naming the local's slot as the operator's operand would
+    // instead sample it after the right-hand side ran, and a right-hand side
+    // that rebinds the target (`x += ((x = 10), 100)`) would then be folded
+    // against the new value. OP_GET_LOCAL also performs the GetValue TDZ check
+    // that reading the raw slot skips.
+    RegOld := ACtx.Scope.AllocateRegister;
+    EmitInstruction(ACtx, EncodeABx(OP_GET_LOCAL, RegOld, Slot));
     RegVal := ACtx.Scope.AllocateRegister;
     ACtx.CompileExpression(AExpr.Value, RegVal);
 
-    LocalType := ACtx.Scope.GetLocal(LocalIdx).TypeHint;
     if ACtx.Scope.GetLocal(LocalIdx).IsConst then
     begin
       if ShouldIgnoreNonStrictImmutableLocalAssignment(ACtx,
          ACtx.Scope.GetLocal(LocalIdx)) then
-        EmitInstruction(ACtx, EncodeABC(Op, ADest, Slot, RegVal))
+        EmitInstruction(ACtx, EncodeABC(Op, ADest, RegOld, RegVal))
       else
         EmitConstAssignmentError(ACtx);
+      ACtx.Scope.FreeRegister;
       ACtx.Scope.FreeRegister;
       Exit;
     end;
@@ -6143,10 +6160,10 @@ begin
        IsArithmeticCompoundAssign(AExpr.Operator, ArithOp) and
        TryFloatOp(ArithOp, FloatOp) then
     begin
-      EmitInstruction(ACtx, EncodeABC(FloatOp, RegTemp, Slot, RegVal))
+      EmitInstruction(ACtx, EncodeABC(FloatOp, RegTemp, RegOld, RegVal))
     end
     else
-      EmitInstruction(ACtx, EncodeABC(Op, RegTemp, Slot, RegVal));
+      EmitInstruction(ACtx, EncodeABC(Op, RegTemp, RegOld, RegVal));
     ResultType := sltUntyped;
     if IsArithmeticCompoundAssign(AExpr.Operator, ArithOp) and
        IsKnownNumeric(LocalType) and IsKnownNumeric(ValType) then
@@ -6162,6 +6179,7 @@ begin
     end;
     if ADest <> Slot then
       EmitInstruction(ACtx, EncodeABC(OP_MOVE, ADest, RegTemp, 0));
+    ACtx.Scope.FreeRegister;
     ACtx.Scope.FreeRegister;
     ACtx.Scope.FreeRegister;
     Exit;

--- a/tests/language/expressions/assignment-gc-roots.js
+++ b/tests/language/expressions/assignment-gc-roots.js
@@ -100,13 +100,13 @@ describe.runIf(hasGoccia)("assignment expression GC roots", () => {
   });
 
   test("compound assignment survives a right-hand side that rebinds the target", () => {
-    // The left operand is read before the right-hand side runs, and the
-    // right-hand side drops the binding's reference to it: the old string is
-    // then reachable only from the evaluator. The replacement has the same
-    // contents so the assertion does not depend on which of the two instances
-    // the executor adds to.
+    // §13.15.2 step 3 reads the left operand before the right-hand side runs,
+    // and the right-hand side then drops the binding's only other reference to
+    // it: the old string is reachable from the executor's own temporaries
+    // alone while gc() runs. The replacement is empty, so a value that was not
+    // rooted across the collection cannot produce the expected result.
     let text = "a".repeat(20);
-    text += ((text = "a".repeat(20)), churn(), "tail");
+    text += ((text = ""), churn(), "tail");
 
     expect(text).toBe("a".repeat(20) + "tail");
   });

--- a/tests/language/expressions/compound-assignment-evaluation-order.js
+++ b/tests/language/expressions/compound-assignment-evaluation-order.js
@@ -1,0 +1,309 @@
+/*---
+description: Compound assignment reads its target before evaluating the right-hand side
+features: [compound-assignment-operators, Symbol, accessor-properties, private-fields]
+---*/
+
+// ES2026 §13.15.2 evaluates `target op= value` in a fixed order: step 3 takes
+// GetValue(lRef) and only step 4 evaluates the AssignmentExpression, so a
+// right-hand side that rebinds the target is folded against the value the
+// target held *before* it ran.
+
+let moduleBinding = "A";
+
+describe("compound assignment on identifiers", () => {
+  test("a function-scoped binding is read before the right-hand side", () => {
+    let text = "A";
+
+    text += ((text = "B"), "C");
+
+    expect(text).toBe("AC");
+  });
+
+  test("the numeric result folds against the value read first", () => {
+    let value = 1;
+
+    value += ((value = 10), 100);
+
+    expect(value).toBe(101);
+  });
+
+  test("the expression result is the stored value", () => {
+    let value = 1;
+
+    expect((value += ((value = 10), 100))).toBe(101);
+    expect(value).toBe(101);
+  });
+
+  test("every arithmetic and bitwise operator reads the target first", () => {
+    let subtract = 1;
+    subtract -= ((subtract = 10), 100);
+    expect(subtract).toBe(-99);
+
+    let multiply = 2;
+    multiply *= ((multiply = 10), 100);
+    expect(multiply).toBe(200);
+
+    let divide = 1000;
+    divide /= ((divide = 10), 100);
+    expect(divide).toBe(10);
+
+    let remainder = 7;
+    remainder %= ((remainder = 100), 5);
+    expect(remainder).toBe(2);
+
+    let power = 2;
+    power **= ((power = 10), 3);
+    expect(power).toBe(8);
+
+    let bitAnd = 6;
+    bitAnd &= ((bitAnd = 15), 3);
+    expect(bitAnd).toBe(2);
+
+    let bitOr = 4;
+    bitOr |= ((bitOr = 15), 1);
+    expect(bitOr).toBe(5);
+
+    let bitXor = 6;
+    bitXor ^= ((bitXor = 15), 3);
+    expect(bitXor).toBe(5);
+
+    let shiftLeft = 1;
+    shiftLeft <<= ((shiftLeft = 8), 2);
+    expect(shiftLeft).toBe(4);
+
+    let shiftRight = 16;
+    shiftRight >>= ((shiftRight = 1024), 2);
+    expect(shiftRight).toBe(4);
+
+    let shiftRightUnsigned = 16;
+    shiftRightUnsigned >>>= ((shiftRightUnsigned = 1024), 2);
+    expect(shiftRightUnsigned).toBe(4);
+  });
+
+  test("a non-numeric target rebound to a number keeps string semantics", () => {
+    // The operand read in step 3 carries its own type, so the concatenation is
+    // decided by the string the target held — not by the number the
+    // right-hand side left behind.
+    let text = "a";
+
+    text += ((text = 5), 2);
+
+    expect(text).toBe("a2");
+    expect(typeof text).toBe("string");
+    // A following expression must still see a string, not a number.
+    expect(text + 1).toBe("a21");
+  });
+
+  test("a numeric-looking string target is not folded as a number", () => {
+    let text = "10";
+
+    text += ((text = 5), 2);
+
+    expect(text).toBe("102");
+    expect(typeof text).toBe("string");
+  });
+
+  test("a binding last written through a closure reads that written value", () => {
+    // The write goes through the closure's view of `count`; the compound
+    // assignment has to read the same binding rather than a stale copy.
+    let count = 1;
+    const set = (next) => {
+      count = next;
+    };
+
+    set(50);
+    count += 1;
+
+    expect(count).toBe(51);
+  });
+
+  test("a string binding last written through a closure reads that value", () => {
+    let text = "A";
+    const set = (next) => {
+      text = next;
+    };
+
+    set("Q");
+    text += "C";
+
+    expect(text).toBe("QC");
+  });
+
+  test("a target in its temporal dead zone throws before the right-hand side", () => {
+    // GetValue(lRef) in step 3 fails on an uninitialized binding, so step 4
+    // never evaluates the right-hand side.
+    const log = [];
+    const run = () => {
+      dead += (log.push("rhs"), 1);
+      let dead = 1;
+      return dead;
+    };
+
+    expect(run).toThrow(ReferenceError);
+    expect(log).toEqual([]);
+  });
+
+  test("a captured binding is read before a call that rebinds it", () => {
+    let text = "A";
+    const rebind = () => {
+      text = "B";
+      return "C";
+    };
+
+    text += rebind();
+
+    expect(text).toBe("AC");
+  });
+
+  test("an outer binding reached as an upvalue is read first", () => {
+    const run = () => {
+      let text = "A";
+      const compound = () => {
+        text += ((text = "B"), "C");
+      };
+
+      compound();
+      return text;
+    };
+
+    expect(run()).toBe("AC");
+  });
+
+  test("a module-level binding is read first", () => {
+    moduleBinding = "A";
+
+    moduleBinding += ((moduleBinding = "B"), "C");
+
+    expect(moduleBinding).toBe("AC");
+  });
+});
+
+describe("compound assignment on properties", () => {
+  test("a named target is read before the right-hand side", () => {
+    const object = { slot: "A" };
+
+    object.slot += ((object.slot = "B"), "C");
+
+    expect(object.slot).toBe("AC");
+  });
+
+  test("a computed string key is read before the right-hand side", () => {
+    const object = { slot: "A" };
+    const key = "slot";
+
+    object[key] += ((object[key] = "B"), "C");
+
+    expect(object[key]).toBe("AC");
+  });
+
+  test("a computed symbol key is read before the right-hand side", () => {
+    const key = Symbol("slot");
+    const object = { [key]: "A" };
+
+    object[key] += ((object[key] = "B"), "C");
+
+    expect(object[key]).toBe("AC");
+  });
+
+  test("an array element is read before the right-hand side", () => {
+    const values = ["A"];
+
+    values[0] += ((values[0] = "B"), "C");
+
+    expect(values[0]).toBe("AC");
+  });
+
+  test("a private field is read before the right-hand side", () => {
+    class Box {
+      #slot = "A";
+
+      compound() {
+        this.#slot += ((this.#slot = "B"), "C");
+        return this.#slot;
+      }
+    }
+
+    expect(new Box().compound()).toBe("AC");
+  });
+});
+
+describe("compound assignment ordering is observable through accessors", () => {
+  test("the getter runs before the right-hand side and the setter after it", () => {
+    const log = [];
+    const target = {
+      get slot() {
+        log.push("get");
+        return "A";
+      },
+      set slot(next) {
+        log.push("set:" + next);
+      },
+    };
+
+    target.slot += ((log.push("rhs"), "C"));
+
+    expect(log).toEqual(["get", "rhs", "set:AC"]);
+  });
+
+  test("the base and the key are evaluated before the target is read", () => {
+    const log = [];
+    const object = {
+      get slot() {
+        log.push("get");
+        return 1;
+      },
+      set slot(next) {
+        log.push("set:" + next);
+      },
+    };
+    const base = () => {
+      log.push("base");
+      return object;
+    };
+    const key = () => {
+      log.push("key");
+      return "slot";
+    };
+
+    base()[key()] += ((log.push("rhs"), 2));
+
+    expect(log).toEqual(["base", "key", "get", "rhs", "set:3"]);
+  });
+});
+
+describe("short-circuiting compound assignment keeps its own order", () => {
+  // §13.15.2 for `??=`, `&&=` and `||=` reads the target first as well, but the
+  // right-hand side decides the stored value on its own — there is nothing to
+  // fold, so a rebinding right-hand side is simply overwritten by the store.
+  test("??= stores the right-hand side over a rebinding side effect", () => {
+    let value = null;
+
+    value ??= ((value = 5), 7);
+
+    expect(value).toBe(7);
+  });
+
+  test("&&= evaluates the right-hand side only for a truthy target", () => {
+    let truthy = "A";
+    truthy &&= ((truthy = "B"), "C");
+    expect(truthy).toBe("C");
+
+    let falsy = "";
+    let evaluated = 0;
+    falsy &&= ((evaluated += 1), "C");
+    expect(falsy).toBe("");
+    expect(evaluated).toBe(0);
+  });
+
+  test("||= evaluates the right-hand side only for a falsy target", () => {
+    let falsy = "";
+    falsy ||= ((falsy = "B"), "C");
+    expect(falsy).toBe("C");
+
+    let truthy = "A";
+    let evaluated = 0;
+    truthy ||= ((evaluated += 1), "C");
+    expect(truthy).toBe("A");
+    expect(evaluated).toBe(0);
+  });
+});


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Bytecode mode now reads a compound assignment's target **before** the right-hand side, per ES2026 §13.15.2 step 3: `let x = 1; x += ((x = 10), 100)` returned 110 in the VM vs the spec's (and interpreter's) 101. Only identifiers bound to plain function-local register slots were affected — the compiler named the slot itself as the binary opcode's operand, so the VM sampled it after the RHS had rebound it; property, computed, private, upvalue, and module-global forms already read in spec order (verified per form).
- The fix captures the old value with a cell-aware `OP_GET_LOCAL` into its own register before the RHS compiles. That choice closes two more divergences at no cost: closure-written locals no longer read a stale frame register in bytecode mode (`let x = 1; const set = v => { x = v; }; set(50); x += 1` gave 2 instead of 51 — a plain-correctness bug in ordinary code, not just ordering shapes), and a target in its temporal dead zone now throws ReferenceError before the RHS runs, where the VM previously did not throw at all.
- The float fast-path's type hint is sampled together with the value it now describes (pre-RHS) — sampled after the RHS, a rebinding like `let x = "a"; x += ((x = 5), 2)` mis-gated the float opcode and produced `NaN` with a poisoned downstream type hint (caught in review, fixed, and covered).
- No new opcode and no bytecode-format change; register allocation stays LIFO-balanced on every path. A hot-loop microbenchmark showed no regression.
- Stack layer 4 of #1159, on #1160 (whose interpreter fix makes the ordering tests meaningful in both executors).

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests — new `tests/language/expressions/compound-assignment-evaluation-order.js` (22 tests: all 11 arithmetic/bitwise operators, closure-written and TDZ targets, string-semantics-under-rebinding, per-form ordering, accessor sequence, short-circuit forms; validated against bun as the JS oracle); `assignment-gc-roots.js`'s workaround assertion restored to its intended rebinding shape. Full suite 12,258 green in both executors. Regression guard proven: 10 assertions fail with the fix reverted, in bytecode mode only.
- [x] Updated documentation — no doc describes the old operand order; spec provenance in the compiler comment (ES2026 §13.15.2, tc39-mcp snapshot 0248456c)
- [x] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests — `Goccia.Compiler.Test` 51/51, `Goccia.VM.Test` 14/14, `Goccia.Bytecode.Binary.Test` 4/4
- [x] Optional: Verified no benchmark regressions — hot compound-assignment loop measured within noise (fixed build measured faster than baseline across 3 runs)

Review provenance: fresh-context adversarial review; the HIGH finding (float-gate hint sampled post-RHS) and coverage gaps were fixed before commit.
