### PR TITLE
fix(sandbox): stop promise boundaries from swallowing uncatchable faults

### DIFF
--- a/source/units/Goccia.Builtins.Benchmark.pas
+++ b/source/units/Goccia.Builtins.Benchmark.pas
@@ -137,6 +137,7 @@ uses
   Goccia.FetchManager,
   Goccia.FloatingPoint,
   Goccia.MicrotaskQueue,
+  Goccia.UncatchableFault,
   Goccia.Values.ArrayValue,
   Goccia.Values.Await,
   Goccia.Values.Error,
@@ -1062,9 +1063,19 @@ begin
       except
         on E: Exception do
         begin
+          { Pending host work is cleared before either outcome: on the recorded
+            path the next case must not inherit this one's microtasks, and on
+            the unwind path the host catches the fault and keeps running. }
           if (TGocciaMicrotaskQueue.Instance <> nil) then
             TGocciaMicrotaskQueue.Instance.ClearQueue;
           DiscardFetchCompletions;
+
+          { A benchmark loop is the worst place to absorb an uncatchable fault:
+            recording it as this case's `error` string starts the next case
+            immediately, so a ceiling is re-tripped case after case and an
+            integrity fault keeps the process measuring on freed memory. }
+          if IsUncatchableFault(E) then
+            raise;
 
           SingleResult := TGocciaObjectValue.Create;
           if Assigned(GC) then
@@ -1160,9 +1171,19 @@ begin
       except
         on E: Exception do
         begin
+          { Pending host work is cleared before either outcome: on the recorded
+            path the next case must not inherit this one's microtasks, and on
+            the unwind path the host catches the fault and keeps running. }
           if (TGocciaMicrotaskQueue.Instance <> nil) then
             TGocciaMicrotaskQueue.Instance.ClearQueue;
           DiscardFetchCompletions;
+
+          { A benchmark loop is the worst place to absorb an uncatchable fault:
+            recording it as this case's `error` string starts the next case
+            immediately, so a ceiling is re-tripped case after case and an
+            integrity fault keeps the process measuring on freed memory. }
+          if IsUncatchableFault(E) then
+            raise;
 
           SingleResult := TGocciaObjectValue.Create;
           if Assigned(GC) then

--- a/source/units/Goccia.MemoryLimit.Test.pas
+++ b/source/units/Goccia.MemoryLimit.Test.pas
@@ -6,15 +6,21 @@ uses
   Classes,
   SysUtils,
 
+  SandboxVirtualFileSystem,
   TestingPascalLibrary,
 
   Goccia.Arguments.Collection,
+  Goccia.CapabilityAudit,
   Goccia.Engine,
   Goccia.Executor,
   Goccia.Executor.Bytecode,
   Goccia.Executor.Interpreter,
   Goccia.GarbageCollector,
   Goccia.MemoryLimit,
+  Goccia.Runtime,
+  Goccia.RuntimeExtensions.Fetch,
+  Goccia.RuntimeExtensions.Sandbox,
+  Goccia.Sandbox.Context,
   Goccia.TestSetup,
   Goccia.Values.NativeFunction,
   Goccia.Values.Primitives;
@@ -22,10 +28,33 @@ uses
 type
   TMemoryLimitTests = class(TTestSuite)
   private
+    { The class the sandbox injection points raise, or nil for "raise nothing".
+      Set by SandboxFaultEscapesScript for the duration of one run. }
+    FSandboxFaultClass: ExceptClass;
+    { Arms FaultEscapesScript to install the fetch runtime extension, which is
+      what puts Response in scope, and to give the engine an audit sink that
+      refuses delivery so any capability the script exercises raises. }
+    FInstallFailingAuditSink: Boolean;
+    { The refusing sink itself. EmitCapabilityAudit wraps whatever it raises in
+      EGocciaCapabilityAuditDeliveryError. }
+    procedure FailingAuditSink(const AEvent: TGocciaCapabilityAuditEvent);
     { The native the integrity-fault tests call. Raises the same class a virtual
       call through a collected value raises under `$OBJECTCHECKS ON`, which is
       how a real unrooted-temporary bug arrives. }
     function RaiseIntegrityFault(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    { Raises whatever FSandboxFaultClass names. The refusal comes from the gate
+      itself rather than a hand-built instance, so the test exercises the same
+      object a real over-budget allocation produces. }
+    procedure RaiseConfiguredFault;
+    { Root-clamp hook, installed on the sandbox filesystem after the extension
+      has taken its own. It fires from inside TGocciaSandboxFsJob.Execute, so it
+      injects the fault at the job's completion boundary. }
+    procedure SandboxRootClamp(const APath, ABase, ACanonicalPath: string);
+    { Guest-callable native, reached through an options-object getter, so it
+      injects the same fault at the synchronous fs.promises argument boundary
+      that RejectedPromiseFromException guards. }
+    function RaiseSandboxFault(const AArgs: TGocciaArgumentsCollection;
       const AThisValue: TGocciaValue): TGocciaValue;
     { Runs ASource under a budget that cannot fit the over-budget allocation and
       with that native bound as a global, and answers whether AFaultClass
@@ -34,6 +63,13 @@ type
     function FaultEscapesScript(const ASource: string;
       const AExecutor: TGocciaExecutor; const AName: string;
       const AFaultClass: ExceptClass): Boolean;
+    { The same question for a module running against the sandbox runtime
+      extension. Both sandbox injection points are armed to raise
+      AInjectedClass; pass nil to arm neither and let the ordinary filesystem
+      error through. }
+    function SandboxFaultEscapesScript(const ASource: string;
+      const AExecutor: TGocciaExecutor; const AName: string;
+      const AEscapingClass, AInjectedClass: ExceptClass): Boolean;
     procedure TestGateRefusesOverBudgetRequest;
     procedure TestGatePermitsInBudgetRequest;
     procedure TestSyncCatchCannotSwallowRefusal;
@@ -43,6 +79,10 @@ type
     procedure TestScriptErrorsStayCatchable;
     procedure TestSyncCatchCannotSwallowIntegrityFault;
     procedure TestAsyncFunctionCatchCannotSwallowIntegrityFault;
+    procedure TestSandboxFsPromiseCannotSwallowRefusal;
+    procedure TestSandboxFsPromiseCannotSwallowIntegrityFault;
+    procedure TestSandboxFsPromiseErrorsStayCatchable;
+    procedure TestResponseJsonCannotSwallowAuditDeliveryFailure;
   protected
     procedure BeforeEach; override;
   public
@@ -66,6 +106,37 @@ const
     stack trace. }
   INTEGRITY_FAULT_GLOBAL_NAME = '__gocciaRaiseIntegrityFault';
   INTEGRITY_FAULT_MESSAGE = 'Object reference is Nil';
+
+  { Name of the native the sandbox tests reach through an options getter. }
+  SANDBOX_FAULT_GLOBAL_NAME = '__gocciaRaiseSandboxFault';
+
+  { A path that escapes the sandbox root, so normalising it clamps and calls the
+    root-clamp hook. The clamp happens inside the queued filesystem job rather
+    than at the call, which is what puts the injected fault on the job's
+    completion boundary. }
+  SANDBOX_CLAMPING_PATH = '../../missing.txt';
+
+  { The queued filesystem job normalises the escaping path, the clamp hook
+    raises, and the job's completion boundary decides whether the guest's
+    `catch` sees it. }
+  SANDBOX_JOB_SOURCE =
+    'import fs from "fs";' + sLineBreak +
+    'try {' + sLineBreak +
+    '  await fs.promises.readFile("' + SANDBOX_CLAMPING_PATH + '", "utf8");' +
+    sLineBreak +
+    '} catch (e) {}';
+
+  { The options getter runs while fs.promises.readFile is still validating its
+    arguments, before anything is queued, so the fault arrives at the
+    synchronous boundary that RejectedPromiseFromException guards. }
+  SANDBOX_ARGUMENT_SOURCE =
+    'import fs from "fs";' + sLineBreak +
+    'try {' + sLineBreak +
+    '  await fs.promises.readFile("/present.txt", {' + sLineBreak +
+    '    get encoding() { return ' + SANDBOX_FAULT_GLOBAL_NAME + '(); },' +
+    sLineBreak +
+    '  });' + sLineBreak +
+    '} catch (e) {}';
 
 procedure TMemoryLimitTests.BeforeEach;
 begin
@@ -95,6 +166,20 @@ begin
     TestSyncCatchCannotSwallowIntegrityFault);
   Test('An async function body cannot swallow an engine-integrity fault',
     TestAsyncFunctionCatchCannotSwallowIntegrityFault);
+  Test('A sandbox fs promise cannot swallow a refusal',
+    TestSandboxFsPromiseCannotSwallowRefusal);
+  Test('A sandbox fs promise cannot swallow an engine-integrity fault',
+    TestSandboxFsPromiseCannotSwallowIntegrityFault);
+  Test('Sandbox filesystem errors stay catchable',
+    TestSandboxFsPromiseErrorsStayCatchable);
+  Test('Response.json cannot swallow an audit delivery failure',
+    TestResponseJsonCannotSwallowAuditDeliveryFailure);
+end;
+
+procedure TMemoryLimitTests.FailingAuditSink(
+  const AEvent: TGocciaCapabilityAuditEvent);
+begin
+  raise Exception.Create('audit sink refused ' + AEvent.Subject);
 end;
 
 function TMemoryLimitTests.RaiseIntegrityFault(
@@ -103,6 +188,33 @@ function TMemoryLimitTests.RaiseIntegrityFault(
 begin
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
   raise EObjectCheck.Create(INTEGRITY_FAULT_MESSAGE);
+end;
+
+procedure TMemoryLimitTests.RaiseConfiguredFault;
+begin
+  if FSandboxFaultClass = nil then
+    Exit;
+  if FSandboxFaultClass = TGocciaMemoryLimitError then
+    { Ask the gate for more than the budget the caller installed, so the test
+      asserts on the exception the engine really raises rather than one the
+      test built. }
+    RequireNativeBytes(Int64(BUDGET_HEADROOM_BYTES) * 4)
+  else
+    raise EObjectCheck.Create(INTEGRITY_FAULT_MESSAGE);
+end;
+
+procedure TMemoryLimitTests.SandboxRootClamp(const APath, ABase,
+  ACanonicalPath: string);
+begin
+  RaiseConfiguredFault;
+end;
+
+function TMemoryLimitTests.RaiseSandboxFault(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+  RaiseConfiguredFault;
 end;
 
 function TMemoryLimitTests.FaultEscapesScript(const ASource: string;
@@ -124,6 +236,11 @@ begin
     Engine.InjectGlobal(INTEGRITY_FAULT_GLOBAL_NAME,
       TGocciaNativeFunctionValue.CreateWithoutPrototype(RaiseIntegrityFault,
         INTEGRITY_FAULT_GLOBAL_NAME, 0));
+    if FInstallFailingAuditSink then
+    begin
+      AttachRuntime(Engine).Install(TGocciaFetchRuntimeExtension.Create);
+      Engine.CapabilityAuditSink := FailingAuditSink;
+    end;
     if Assigned(GC) then
     begin
       PreviousMaxBytes := GC.MaxBytes;
@@ -142,6 +259,61 @@ begin
     if Assigned(GC) then
       GC.MaxBytes := PreviousMaxBytes;
     Engine.Free;
+    AExecutor.Free;
+    Source.Free;
+  end;
+end;
+
+function TMemoryLimitTests.SandboxFaultEscapesScript(const ASource: string;
+  const AExecutor: TGocciaExecutor; const AName: string;
+  const AEscapingClass, AInjectedClass: ExceptClass): Boolean;
+var
+  Source: TStringList;
+  Engine: TGocciaEngine;
+  Runtime: TGocciaRuntimeCore;
+  Context: TGocciaSandboxContext;
+  GC: TGarbageCollector;
+  PreviousMaxBytes: Int64;
+begin
+  Result := False;
+  Source := TStringList.Create;
+  Source.Text := ASource;
+  Engine := TGocciaEngine.Create(AName, Source, AExecutor);
+  Context := TGocciaSandboxContext.Create;
+  GC := TGarbageCollector.Instance;
+  PreviousMaxBytes := 0;
+  FSandboxFaultClass := AInjectedClass;
+  try
+    Engine.SourceType := stModule;
+    Engine.InjectGlobal(SANDBOX_FAULT_GLOBAL_NAME,
+      TGocciaNativeFunctionValue.CreateWithoutPrototype(RaiseSandboxFault,
+        SANDBOX_FAULT_GLOBAL_NAME, 0));
+    Runtime := AttachRuntime(Engine);
+    Runtime.Install(TGocciaSandboxRuntimeExtension.Create(Context));
+    { After Install, so the extension's own audit-emitting hook is the one being
+      replaced rather than the other way round. }
+    Context.Fs.RootClampCallback := SandboxRootClamp;
+
+    if Assigned(GC) then
+    begin
+      PreviousMaxBytes := GC.MaxBytes;
+      GC.MaxBytes := GC.BytesAllocated + BUDGET_HEADROOM_BYTES;
+    end;
+    try
+      Engine.Execute;
+    except
+      on E: Exception do
+        if E.InheritsFrom(AEscapingClass) then
+          Result := True
+        else
+          raise;
+    end;
+  finally
+    FSandboxFaultClass := nil;
+    if Assigned(GC) then
+      GC.MaxBytes := PreviousMaxBytes;
+    Engine.Free;
+    Context.Free;
     AExecutor.Free;
     Source.Free;
   end;
@@ -351,6 +523,111 @@ begin
   Expect<Boolean>(FaultEscapesScript(SourceText,
     TGocciaBytecodeExecutor.Create,
     'integrity-fault-async-bytecode.js', EObjectCheck)).ToBe(True);
+end;
+
+procedure TMemoryLimitTests.TestSandboxFsPromiseCannotSwallowRefusal;
+begin
+  { fs.promises hands the guest a promise, and a promise is a `catch` away from
+    absorbing whatever settles it. Both sandbox boundaries used to convert every
+    Pascal exception into a rejection, so the budget stopped being a ceiling the
+    moment a script wrapped its filesystem calls in try/catch. }
+  Expect<Boolean>(SandboxFaultEscapesScript(SANDBOX_JOB_SOURCE,
+    TGocciaInterpreterExecutor.Create, 'sandbox-refusal-job-interpreted.js',
+    TGocciaMemoryLimitError, TGocciaMemoryLimitError)).ToBe(True);
+  Expect<Boolean>(SandboxFaultEscapesScript(SANDBOX_JOB_SOURCE,
+    TGocciaBytecodeExecutor.Create, 'sandbox-refusal-job-bytecode.js',
+    TGocciaMemoryLimitError, TGocciaMemoryLimitError)).ToBe(True);
+  Expect<Boolean>(SandboxFaultEscapesScript(SANDBOX_ARGUMENT_SOURCE,
+    TGocciaInterpreterExecutor.Create,
+    'sandbox-refusal-argument-interpreted.js',
+    TGocciaMemoryLimitError, TGocciaMemoryLimitError)).ToBe(True);
+  Expect<Boolean>(SandboxFaultEscapesScript(SANDBOX_ARGUMENT_SOURCE,
+    TGocciaBytecodeExecutor.Create, 'sandbox-refusal-argument-bytecode.js',
+    TGocciaMemoryLimitError, TGocciaMemoryLimitError)).ToBe(True);
+end;
+
+procedure TMemoryLimitTests.TestSandboxFsPromiseCannotSwallowIntegrityFault;
+begin
+  { The stronger half of the same guard: a use-after-free reaching either
+    sandbox boundary must not become a rejected promise the guest catches and
+    carries on from. }
+  Expect<Boolean>(SandboxFaultEscapesScript(SANDBOX_JOB_SOURCE,
+    TGocciaInterpreterExecutor.Create, 'sandbox-integrity-job-interpreted.js',
+    EObjectCheck, EObjectCheck)).ToBe(True);
+  Expect<Boolean>(SandboxFaultEscapesScript(SANDBOX_JOB_SOURCE,
+    TGocciaBytecodeExecutor.Create, 'sandbox-integrity-job-bytecode.js',
+    EObjectCheck, EObjectCheck)).ToBe(True);
+  Expect<Boolean>(SandboxFaultEscapesScript(SANDBOX_ARGUMENT_SOURCE,
+    TGocciaInterpreterExecutor.Create,
+    'sandbox-integrity-argument-interpreted.js',
+    EObjectCheck, EObjectCheck)).ToBe(True);
+  Expect<Boolean>(SandboxFaultEscapesScript(SANDBOX_ARGUMENT_SOURCE,
+    TGocciaBytecodeExecutor.Create, 'sandbox-integrity-argument-bytecode.js',
+    EObjectCheck, EObjectCheck)).ToBe(True);
+end;
+
+procedure TMemoryLimitTests.TestSandboxFsPromiseErrorsStayCatchable;
+const
+  { Nothing is armed here, so the only thing that can settle the promise is the
+    ENOENT the virtual filesystem produces. The script asserts it arrived as a
+    Node-shaped error object; if it did not, the throw escapes as an exception
+    that is not the class under test and the helper propagates it. }
+  SourceText =
+    'import fs from "fs";' + sLineBreak +
+    'let caught = null;' + sLineBreak +
+    'try {' + sLineBreak +
+    '  await fs.promises.readFile("/missing.txt", "utf8");' + sLineBreak +
+    '} catch (e) {' + sLineBreak +
+    '  caught = e;' + sLineBreak +
+    '}' + sLineBreak +
+    'if (caught === null || caught.code !== "ENOENT") {' + sLineBreak +
+    '  throw new Error("sandbox fs rejection was not catchable");' +
+    sLineBreak +
+    '}';
+begin
+  { The counterweight to the two guards above: hardening the boundary must not
+    cost the sandbox its ordinary, guest-visible filesystem errors. Asserting
+    against Exception rather than a specific class makes any escape at all a
+    failure. }
+  Expect<Boolean>(SandboxFaultEscapesScript(SourceText,
+    TGocciaInterpreterExecutor.Create, 'sandbox-catchable-interpreted.js',
+    Exception, nil)).ToBe(False);
+  Expect<Boolean>(SandboxFaultEscapesScript(SourceText,
+    TGocciaBytecodeExecutor.Create, 'sandbox-catchable-bytecode.js',
+    Exception, nil)).ToBe(False);
+end;
+
+procedure TMemoryLimitTests.TestResponseJsonCannotSwallowAuditDeliveryFailure;
+const
+  { ES2026 §27.2.1.3.2 step 9 has Resolve read `then` off the parsed body, and
+    that read walks the prototype chain, so a getter on Object.prototype runs
+    guest code inside Response.json's conversion arm. The getter calls the
+    Function constructor, which is capability-audited; with a sink that cannot
+    deliver, EmitCapabilityAudit raises from there. }
+  SourceText =
+    'Object.defineProperty(Object.prototype, "then", {' + sLineBreak +
+    '  get: () => { Function("return 1"); },' + sLineBreak +
+    '  configurable: true,' + sLineBreak +
+    '});' + sLineBreak +
+    'new Response(''{"a":1}'').json();';
+begin
+  { The arm around the parse rejects with a SyntaxError, so before the guard it
+    reported an undeliverable audit record as a malformed body and the host
+    heard nothing at all. Being the only guarded block in this change that runs
+    guest code, it is also the only one where omitting the capability-audit
+    class from the allowlist was observable — which is why the allowlist is now
+    stated once, in Goccia.UncatchableFault.pas, rather than per boundary. }
+  FInstallFailingAuditSink := True;
+  try
+    Expect<Boolean>(FaultEscapesScript(SourceText,
+      TGocciaInterpreterExecutor.Create, 'response-json-audit-interpreted.js',
+      EGocciaCapabilityAuditDeliveryError)).ToBe(True);
+    Expect<Boolean>(FaultEscapesScript(SourceText,
+      TGocciaBytecodeExecutor.Create, 'response-json-audit-bytecode.js',
+      EGocciaCapabilityAuditDeliveryError)).ToBe(True);
+  finally
+    FInstallFailingAuditSink := False;
+  end;
 end;
 
 begin

--- a/source/units/Goccia.MemoryLimit.pas
+++ b/source/units/Goccia.MemoryLimit.pas
@@ -34,11 +34,16 @@ type
     that would otherwise convert a Pascal exception into something the guest
     can observe — the evaluator's try/catch statement paths, the VM's
     async-iterator and dynamic-import arms, the microtask, await, generator
-    and promise-reaction boundaries, Array.fromAsync, and the test library's
-    toThrow — names this class in its re-raise allowlist ahead of its generic
-    `on E: Exception` arm. A new boundary that omits the arm makes the
-    ceiling catchable again, which is what Goccia.MemoryLimit.Test.pas
-    guards against in both execution modes.
+    and promise-reaction boundaries, Array.fromAsync, the sandbox's
+    fs.promises and shell boundaries, Response.json, the benchmark run loop,
+    and the test library's toThrow — names this class in its re-raise
+    allowlist ahead of its generic `on E: Exception` arm, either as an
+    explicit `on E: TGocciaMemoryLimitError do raise;` or through the shared
+    IsUncatchableFault predicate in Goccia.UncatchableFault.pas. A new
+    boundary that omits it makes the ceiling catchable again, which is what
+    Goccia.MemoryLimit.Test.pas guards against in both execution modes.
+    Prefer the shared predicate at new boundaries: an allowlist spelled out by
+    hand is one that can be spelled out incompletely.
 
     The same boundary list carries a second, wider guard: where the allowlist
     above names a class, the generic arm opens with

--- a/source/units/Goccia.RuntimeExtensions.Sandbox.pas
+++ b/source/units/Goccia.RuntimeExtensions.Sandbox.pas
@@ -156,6 +156,7 @@ uses
   Goccia.Realm,
   Goccia.Sandbox.FileSystemErrors,
   Goccia.Shims,
+  Goccia.UncatchableFault,
   Goccia.Utils,
   Goccia.Values.ArrayValue,
   Goccia.Values.Error,
@@ -280,8 +281,20 @@ end;
 function RejectedPromiseFromException(
   const AException: Exception): TGocciaPromiseValue;
 begin
-  if AException is EGocciaCapabilityAuditDeliveryError then
-    raise AException
+  { Opacity is decided before conversion, because everything below this test
+    turns a Pascal exception into something `.catch` can absorb.
+
+    This runs inside the `on E: Exception` handler that caught AException, but
+    not lexically, so a bare `raise` will not compile. `raise AException`
+    re-raised the object by name, which starts a second propagation of an
+    exception the enclosing handler still owns and frees on exit — the dangling
+    re-raise behind the spurious access violations on the async paths (see the
+    same note at PromiseRejectionReasonFromException in
+    Goccia.Builtins.GlobalPromise.pas). AcquireExceptionObject takes a
+    reference to the in-flight exception so the enclosing handler no longer
+    frees it out from under this re-raise. }
+  if IsUncatchableFault(AException) then
+    raise Exception(AcquireExceptionObject)
   else if AException is EGocciaBytecodeThrow then
     Result := RejectedPromise(EGocciaBytecodeThrow(AException).ThrownValue)
   else if AException is TGocciaThrowValue then
@@ -424,10 +437,16 @@ begin
       CompleteFailure(E.Value);
       Exit;
     end;
-    on E: EGocciaCapabilityAuditDeliveryError do
-      raise;
     on E: Exception do
     begin
+      { CompleteFailure settles the promise the guest is awaiting (or calls its
+        callback with an Error), so absorbing a ceiling or an integrity fault
+        here would hand it straight to `catch`. The job runs from
+        TGocciaMicrotaskQueue.ExecuteTask on the engine's own thread, and the
+        task carries no result promise, so every arm there re-raises too and
+        the fault keeps unwinding out of DrainQueue to the host. }
+      if IsUncatchableFault(E) then
+        raise;
       CompleteFailure(CreateErrorObject(ERROR_NAME, E.Message));
       Exit;
     end;
@@ -1070,10 +1089,14 @@ begin
   except
     on E: TGocciaThrowValue do
       Result := RejectedPromise(E.Value);
-    on E: EGocciaCapabilityAuditDeliveryError do
-      raise;
     on E: Exception do
+    begin
+      { A rejected promise is guest-catchable, so the opaque families must be
+        turned away before the conversion below. }
+      if IsUncatchableFault(E) then
+        raise;
       Result := RejectedPromise(TGocciaStringLiteralValue.Create(E.Message));
+    end;
   end;
 end;
 
@@ -1090,10 +1113,14 @@ begin
   except
     on E: TGocciaThrowValue do
       Result := RejectedPromise(E.Value);
-    on E: EGocciaCapabilityAuditDeliveryError do
-      raise;
     on E: Exception do
+    begin
+      { A rejected promise is guest-catchable, so the opaque families must be
+        turned away before the conversion below. }
+      if IsUncatchableFault(E) then
+        raise;
       Result := RejectedPromise(TGocciaStringLiteralValue.Create(E.Message));
+    end;
   end;
 end;
 
@@ -1116,10 +1143,14 @@ begin
   except
     on E: TGocciaThrowValue do
       Result := RejectedPromise(E.Value);
-    on E: EGocciaCapabilityAuditDeliveryError do
-      raise;
     on E: Exception do
+    begin
+      { A rejected promise is guest-catchable, so the opaque families must be
+        turned away before the conversion below. }
+      if IsUncatchableFault(E) then
+        raise;
       Result := RejectedPromise(TGocciaStringLiteralValue.Create(E.Message));
+    end;
   end;
 end;
 

--- a/source/units/Goccia.UncatchableFault.pas
+++ b/source/units/Goccia.UncatchableFault.pas
@@ -1,0 +1,76 @@
+unit Goccia.UncatchableFault;
+
+{$I Goccia.inc}
+
+interface
+
+uses
+  SysUtils;
+
+{ Answers whether AException must keep unwinding to the host instead of being
+  converted into something script code can observe.
+
+  Three separate contracts converge on one answer, which is why they are stated
+  once here rather than re-spelled at each boundary:
+
+    The resource ceilings — TGocciaTimeoutError, TGocciaInstructionLimitError,
+    TGocciaMemoryLimitError — are opaque because a ceiling the guest can catch
+    is a ceiling it can ignore in a loop. The full argument, and the inventory
+    of boundaries that honour it, live in Goccia.MemoryLimit.pas.
+
+    EGocciaCapabilityAuditDeliveryError is opaque because an embedder whose
+    audit sink failed must not be told the guarded call merely failed; losing
+    the record is the more serious event of the two, and only the host can
+    decide what to do about it.
+
+    The engine-integrity family is opaque for the strongest reason of all: it
+    means a pointer was already freed or the heap is unsound, so there is no
+    defined continuation to hand back. Goccia.EngineFault.pas is the
+    authoritative list and docs/adr/0109-engine-integrity-faults-are-uncatchable.md
+    records the decision.
+
+  Why this unit exists on top of Goccia.EngineFault: that unit is deliberately
+  SysUtils-only, so it cannot name the engine's own exception classes. This one
+  can, and it keeps the union from being spelled a second and third way as new
+  boundaries are hardened — a boundary that lists three of the four families is
+  a hole that reads like a guard.
+
+  Boundaries that predate this unit keep their explicit `on E: ... do raise;`
+  arms: those arms carry per-class commentary about the specific path they
+  guard, and the classes they name are exactly this set.
+
+  Use it as the first statement of a generic conversion arm, so the bare
+  `raise` re-raises inside the handler that caught it:
+
+      on E: Exception do
+      begin
+        if IsUncatchableFault(E) then
+          raise;
+        ...convert E into a guest value...
+      end;
+
+  From a helper function called by such an arm — where a bare `raise` will not
+  compile because the handler is not lexically enclosing — re-raise with
+  `raise Exception(AcquireExceptionObject)` instead, so the in-flight exception
+  is not freed out from under the second propagation. }
+function IsUncatchableFault(const AException: Exception): Boolean;
+
+implementation
+
+uses
+  Goccia.CapabilityAudit,
+  Goccia.EngineFault,
+  Goccia.InstructionLimit,
+  Goccia.MemoryLimit,
+  Goccia.Timeout;
+
+function IsUncatchableFault(const AException: Exception): Boolean;
+begin
+  Result := (AException is TGocciaTimeoutError) or
+    (AException is TGocciaInstructionLimitError) or
+    (AException is TGocciaMemoryLimitError) or
+    (AException is EGocciaCapabilityAuditDeliveryError) or
+    IsEngineIntegrityFault(AException);
+end;
+
+end.

--- a/source/units/Goccia.Values.ResponseValue.pas
+++ b/source/units/Goccia.Values.ResponseValue.pas
@@ -86,6 +86,7 @@ uses
   Goccia.Error.Suggestions,
   Goccia.JSON,
   Goccia.Realm,
+  Goccia.UncatchableFault,
   Goccia.Utils,
   Goccia.Values.ArrayBufferValue,
   Goccia.Values.ErrorHelper,
@@ -350,7 +351,19 @@ begin
       P.Resolve(Parsed);
     except
       on E: Exception do
+      begin
+        { Two live paths reach this arm, and rejecting with a SyntaxError would
+          let `res.json().catch(...)` absorb either. The parser materializes
+          objects, arrays and strings for a body the guest controls the size
+          of, so a refused allocation and the use-after-free an unrooted
+          temporary produces both arrive here. And Resolve is inside the try:
+          ES2026 §27.2.1.3.2 step 9 reads `then` off the parsed value, which a
+          guest `Object.prototype.then` getter can answer with arbitrary code —
+          including a capability-guarded call whose audit sink fails. }
+        if IsUncatchableFault(E) then
+          raise;
         P.Reject(CreateErrorObject('SyntaxError', E.Message));
+      end;
     end;
   finally
     Parser.Free;


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Guest code can no longer catch resource-ceiling refusals or engine-integrity faults through the sandbox's promise surfaces: `await sandbox.fs.promises.*`, the three `$\`cmd\`` shell boundaries, `Response.json()`, and the benchmark run loops all converted every Pascal exception into guest-catchable rejections — so `try { await fs.promises.readFile(p) } catch {}` could absorb a memory-budget refusal (a ceiling the guest can catch is a ceiling it can ignore) or a use-after-free fault (per ADR 0109, uncatchable by construction elsewhere since #1158).
- `Response.json()` had a subtler second hole, caught in review: `Promise.Resolve` reads `then` off the parsed value synchronously, so a guest `Object.prototype.then` getter runs arbitrary code inside the guarded block — including capability-audited calls. An audit sink's delivery failure was converted into a catchable `SyntaxError` rejection, so the host never learned the audit record was lost.
- New `Goccia.UncatchableFault.IsUncatchableFault` is the single spelling of the union (limit family ∪ capability-audit ∪ engine-integrity family) — the review found the allowlist drifting into four hand-spelled variants within one round, which is exactly how the `Response.json` hole happened. Pre-existing boundaries keep their explicit arms (documented in the unit header); new boundaries get one predicate. The `RejectedPromiseFromException` rework also fixes a latent dangling re-raise on its audit arm (`raise AException` by name — the hazard `GlobalPromise` documents).
- The fs-job re-raise was traced, not assumed: it unwinds on the engine thread through the microtask drain to the host with nothing converting en route. Two surfaces are deliberately untouched with recorded reasons: the fetch worker thread (no engine code, results cross by plain record; a re-raise would vanish into `TThread.FatalException`) and the snapshot `Finish` path (host-side I/O, no guest conversion).
- Ordinary errors stay catchable: `ENOENT`-style failures still reject with Node-shaped errors the guest can handle — covered by a non-vacuous control test.
- Stack layer 5 of #1159. Depends on `Goccia.EngineFault`/ADR 0109 from #1158; files are disjoint from the #1160/#1161 layers.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests — full suite green in both executors (12,220 in this layer's tree)
- [x] Updated documentation — `Goccia.MemoryLimit.pas` boundary contract now names the sandbox/fetch/benchmark boundaries and prefers the shared predicate at new boundaries ("an allowlist spelled out by hand is one that can be spelled out incompletely")
- [x] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests — `Goccia.MemoryLimit.Test` grew four sandbox/fetch boundary tests (13/13): memory-limit refusal and integrity fault cannot be swallowed at either the argument-validation or the fs-job boundary, in both executors, against the real `fs.promises` surface with real gate refusals; `Response.json` cannot swallow an audit delivery failure; sandbox filesystem errors stay catchable. Each guard proven non-vacuous by per-arm negative controls (reverting a single arm fails exactly its test). `Goccia.CapabilityAudit.Test` 7/7, `Goccia.Sandbox.FileSystemErrors.Test` 5/5.
- [ ] Optional: benchmark coverage — behavior-only change on the benchmark error path (a ceiling now aborts the run instead of failing every remaining case); no perf-relevant code touched

Review provenance: fresh-context adversarial review with independently re-run negative controls; both findings (audit arm on `Response.json`, allowlist consolidation) fixed before commit.
