### PR TITLE
feat(testrunner): abort the run when an engine-integrity fault escapes

### DIFF
--- a/docs/adr/0109-engine-integrity-faults-are-uncatchable.md
+++ b/docs/adr/0109-engine-integrity-faults-are-uncatchable.md
@@ -110,6 +110,70 @@ module and engine domain invariants), and `EInvalidCast`. The authoritative list
 with the reason for each membership and each exclusion, stays in
 `Goccia.EngineFault.pas` and is not duplicated elsewhere.
 
+### Host tier: the test runner
+
+Re-raising past every conversion boundary only moves the decision up one level:
+it hands the fault to whatever host called `Engine.Execute`. `GocciaTestRunner`
+is that host for the entire JavaScript suite, and it had the same generic arms
+one tier up — one per execution mode, one in the sequential aggregator, one in
+the parallel worker body — each of which relabelled an escaped fault as "this
+file failed" and moved on to the next of roughly fifteen hundred files. That is
+the boundary bug again with a results row in place of the guest's `catch`: the
+suite would go on reporting passes and failures for the rest of the run from a
+process that had already lost track of its heap, and the verdict would be
+worthless without ever looking wrong.
+
+So the runner **aborts the run** when `IsEngineIntegrityFault` holds at one of
+those arms, and at the end-of-run inline-snapshot write-back, whose own arm
+would otherwise file a fault over the recorded results as one recorded
+finalization failure and publish the results anyway. It writes a diagnostic naming the faulting file and the exception
+class to stderr under a fixed `Integrity fault:` prefix, flushes it, stops
+dispatching files, and exits `70` — sysexits' `EX_SOFTWARE`, chosen so it is
+distinct from `1` (the suite ran and reported failures) and `2` (the invocation
+was unusable) and a harness can tell "these tests failed" from "stop believing
+this process" (see [CLI
+Conventions](../contributing/cli-conventions.md#exit-codes)). The two per-mode
+arms only re-raise, which keeps one abort site per tier: the sequential
+aggregator for a `--jobs=1` run, the worker body for a parallel one. A faulting
+worker cancels the pool's shared queue rather than halting from a thread — that
+queue is the pool's own stop signal, so files already in flight finish or are
+marked cancelled and `RunAll` returns normally — and the main thread halts the
+moment it does, before the aggregation reads a single worker slot. The abort is
+deliberately not an unwind: the aggregation would read the very objects the
+fault calls into question, and the summary at the end of it would overwrite the
+exit code with a pass/fail verdict the process is in no position to give.
+
+Two mechanics are worth naming because the obvious version of each is wrong. A
+faulting worker cancels through the pool's cancellation flag rather than through
+the pool object: the pool is freed while an abandoned worker is still running,
+and it leaks the flag rather than freeing it for exactly that reason, so the
+flag is the only handle a zombie can safely hold. And the main thread's decision
+to abort rests on a process-level first-fault flag, not only on the sentinel the
+worker returns — if the watchdog abandons the *faulting* worker, its slot is
+dropped and rewritten as a timeout, and a run that had already printed "the run
+is aborted" would go on to print a full summary. That flag also settles who
+writes the diagnostic: faults arrive on worker threads, corruption that reaches
+one worker can reach two, and first-fault-wins keeps the two of them from
+shredding the message between them.
+
+This is one tier's policy, not a guarantee about every exit path. The shared CLI
+entry point every Goccia binary runs under (`TGocciaApplication.Run`) still ends
+in a generic arm of its own, so a fault raised outside per-file execution and
+the snapshot flush — argument parsing, path expansion, config discovery — is
+still reported as an ordinary error and exits `1` with no `Integrity fault:`
+line. Closing that one is a change to every CLI binary at once and belongs to
+its own decision.
+
+The limit family keeps its per-file treatment, and the contrast is the argument.
+`TGocciaMemoryLimitError` is uncatchable *by the guest* for the reason above,
+but it is still a verdict on one test file delivered by an intact heap: the file
+asked for more than the budget allowed, the runner records the refusal, and the
+next file's result means exactly what it says. An integrity fault is not a
+verdict on the file at all — it is the engine reporting that it can no longer
+vouch for anything, that file's result included. Per-file isolation was rejected
+for it on exactly that ground: isolation presupposes the failure is contained,
+and containment is the one thing an integrity fault disproves.
+
 ## Consequences
 
 Embedders can now see these classes escape `Engine.Execute`. They could always
@@ -129,3 +193,11 @@ made for the hardening programme — find the bugs rather than jail them.
 `Goccia.MemoryLimit.Test.pas` covers both families in both execution modes, with
 a native that raises `EObjectCheck` from inside guest code and asserts the class
 reaches the host rather than the script's `catch`.
+
+The runner's abort has no such automated coverage, and deliberately so: reaching
+it needs a fault raised inside a test file's execution, and the only way to
+arrange that would be an injection hook in the runner itself — a switch whose
+sole purpose is to corrupt a production binary on request. The behaviour was
+verified by hand with a temporary local build, in both execution modes and both
+`--jobs` shapes; what CI keeps honest is the surrounding contract, that an
+ordinary failing file still exits `1` with an unchanged report.

--- a/docs/contributing/cli-conventions.md
+++ b/docs/contributing/cli-conventions.md
@@ -6,7 +6,7 @@
 
 - **No-argument rule** — a command that defaults its input to stdin must print help and quit when run with no input at an interactive terminal, never block on `ReadLn`
 - **Stdin** — implicit for pipes and redirects, explicit via `-`, and only ever the sole input
-- **Exit codes** — `0` success, `1` failure, `2` unusable invocation; `124` is reserved for the test262 timeout marker
+- **Exit codes** — `0` success, `1` failure, `2` unusable invocation; `70` is the test runner's engine-integrity abort and `124` the test262 timeout marker
 - **Streams** — machine-readable output modes own stdout; new diagnostics go to stderr
 - **Help** — every option is described by its own declaration, so `--help` is generated, not hand-maintained
 
@@ -61,7 +61,10 @@ The codes actually in use, which new commands should follow:
 | `0` | Success |
 | `1` | The work was attempted and failed — a script threw, a test failed, a path did not exist, an option value was invalid |
 | `2` | The command could not be run as invoked — no input at a terminal, a missing required argument |
+| `70` | The engine abandoned the run: an engine-integrity fault reached the host, `GocciaTestRunner` only |
 | `124` | test262 timeout marker, `GocciaScriptLoaderBare` only |
+
+Code `70` is sysexits' `EX_SOFTWARE`, "an internal software error has been detected", and it says something `1` cannot: the run stopped because the engine caught itself in an unsound state (a use-after-free, an invalid dereference, a broken heap — see [ADR 0109](../adr/0109-engine-integrity-faults-are-uncatchable.md)), so no result the process produced should be believed. `1` means the opposite — the work was done and the answer is "failed". A harness that only distinguishes zero from non-zero keeps working unchanged; one that reports build health should surface `70` separately, because a suite that aborted is not a suite that failed.
 
 Code `2` is the narrower one: it means the process did no work because the invocation itself was unusable. `GocciaWasmTestRunner` has used it for a missing manifest since it was introduced, and `GocciaTOMLComplianceRunner` uses it for an unusable invocation.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -370,6 +370,38 @@ or a reproducible failure list — use `--jobs=1`.
 ./build/GocciaTestRunner tests --jobs=4
 ```
 
+#### Engine-integrity faults abort the run
+
+There is one stop the runner makes on its own, without being asked for it. An
+**engine-integrity fault** — a use-after-free, an invalid dereference, a heap
+whose own bookkeeping is destroyed — unwinds past every guest `catch` to the
+host ([ADR 0109](adr/0109-engine-integrity-faults-are-uncatchable.md)), and when
+one escapes a test file's execution or the end-of-run inline-snapshot
+write-back, the whole run stops instead of the file being recorded as one more
+failure. Every later file would be executing on state the engine has already
+lost track of, so whatever it reported would mean nothing. (Those are the paths
+that abort. A fault from the runner's own setup — argument parsing, path
+expansion, config discovery — still lands in the shared CLI error handler that
+every Goccia binary uses, and exits `1` with no `Integrity fault:` line.)
+
+The runner names the faulting file and the exception class on stderr under a
+fixed prefix, stops dispatching files (cancelling the worker queue under
+`--jobs`), and exits **70**:
+
+```text
+Integrity fault: EObjectCheck in tests/some/file.js: Object reference is Nil
+Integrity fault: the engine can no longer vouch for its own state, so the run is aborted and the remaining files were not executed.
+```
+
+No summary and no JSON envelope follow — a run that stopped mid-way has no total
+worth reporting. Grep CI logs for `Integrity fault:` to find these. The exit
+code is distinct from the ordinary failure exit `1` on purpose, so a harness can
+tell a suite that failed from a suite that stopped being trustworthy; see [CLI
+Conventions](contributing/cli-conventions.md#exit-codes). A refused allocation
+under `--max-memory` is deliberately **not** one of these: it is a verdict on
+one file delivered by an intact heap, so it stays a per-file failure and the run
+carries on.
+
 ### Snapshot Testing
 
 `toMatchSnapshot()` writes external snapshots to

--- a/scripts/test-cli.ts
+++ b/scripts/test-cli.ts
@@ -2481,6 +2481,64 @@ const ASSIGNMENT_FAULT_SLACK = 147_000;
   }
 }
 
+// An ordinary failing test file is still an ordinary failing test file. The
+// runner now aborts the whole run — exit 70, no summary — when an engine
+// integrity fault reaches one of its per-file arms (ADR 0109, "Host tier: the
+// test runner"), and the failure mode worth guarding against is that policy
+// widening to catch things it was never meant to. A failed assertion is a
+// verdict on one file delivered by a sound heap: it stays exit 1, the passing
+// file beside it still runs and still counts, and the summary is unchanged.
+//
+// The abort path itself is not reachable from here. Raising a genuine
+// EObjectCheck inside a test file would take an injection hook in the runner —
+// a switch whose only purpose is to corrupt a production binary on request —
+// and that is not worth shipping for a test; the abort was verified by hand
+// against a temporary build instead. What this block locks is the contract the
+// abort must not disturb, in both execution modes and both --jobs shapes,
+// since the sequential and parallel paths reach the arms differently.
+console.log("TestRunner (a failing file stays exit 1, not an integrity abort)...");
+{
+  const failTmp = mkdtemp("goccia-runner-fail-");
+  try {
+    writeFileSync(
+      join(failTmp, "failing.test.js"),
+      'describe("d", () => {\n  test("fails", () => {\n    expect(1).toBe(2);\n  });\n});\n',
+    );
+    writeFileSync(
+      join(failTmp, "passing.test.js"),
+      'describe("d", () => {\n  test("passes", () => {\n    expect(1).toBe(1);\n  });\n});\n',
+    );
+    for (const modeArgs of [[], ["--mode=bytecode"]] as const) {
+      for (const jobsArg of ["--jobs=1", "--jobs=2"]) {
+        const label = `${modeArgs.length > 0 ? "bytecode" : "interpreted"} ${jobsArg}`;
+        const proc = Bun.spawnSync(
+          [TESTRUNNER, failTmp, "--no-progress", jobsArg, ...modeArgs],
+          { stdout: "pipe", stderr: "pipe" },
+        );
+        const out = proc.stdout.toString() + proc.stderr.toString();
+        if (out.includes("Integrity fault:"))
+          throw new Error(`TestRunner (${label}) treated a failed assertion as an integrity fault: ${out}`);
+        if (proc.exitCode !== 1)
+          throw new Error(`TestRunner (${label}) should exit 1 on a failed test, got ${proc.exitCode}: ${out}`);
+        // The report shape the abort must leave alone: the failing file counted
+        // once, the file beside it still executed, and the failure named.
+        for (const expected of [
+          "Test Results Test Files: 2",
+          "Test Results Run Tests: 2",
+          "Test Results Passed: 1 (50.00%)",
+          "Test Results Failed: 1 (50.00%)",
+          'Test "fails" in suite "d": Expected 1 to be 2',
+        ]) {
+          if (!out.includes(expected))
+            throw new Error(`TestRunner (${label}) report lost "${expected}": ${out}`);
+        }
+      }
+    }
+  } finally {
+    clean(failTmp);
+  }
+}
+
 console.log("--max-memory (a charged reservation collects before it refuses)...");
 {
   // A charged reservation R used to be refused without collecting at all

--- a/source/app/GocciaTestRunner.dpr
+++ b/source/app/GocciaTestRunner.dpr
@@ -23,6 +23,7 @@ uses
   Goccia.Coverage,
   Goccia.Coverage.Report,
   Goccia.Engine,
+  Goccia.EngineFault,
   Goccia.Executor.Interpreter,
   Goccia.Executor.Bytecode,
   Goccia.Executor,
@@ -76,6 +77,32 @@ const
     aggregation recognises it so the slot is not rewritten as a synthetic
     failure. }
   EXIT_ON_FIRST_FAILURE_SIGNAL = '<exit-on-first-failure>';
+
+  { Sentinel a parallel worker returns as its pool error message after an
+    engine-integrity fault. It only has to survive the trip back to the main
+    thread: the diagnostic is already on stderr, and the main thread reads this
+    to know the run must stop rather than be aggregated. }
+  INTEGRITY_FAULT_SIGNAL = '<engine-integrity-fault>';
+
+  { Prefix on every line of the integrity-fault diagnostic. Deliberately unlike
+    any ordinary failure line the runner prints, so `grep 'Integrity fault:'`
+    over a CI log finds the abort and nothing else. }
+  INTEGRITY_FAULT_PREFIX = 'Integrity fault: ';
+
+  { Stands in for a file name in the diagnostic when the fault came from
+    end-of-run inline-snapshot write-back, which belongs to no single file. }
+  INLINE_SNAPSHOT_FLUSH_SITE = '<inline snapshot write-back>';
+
+  { Exit code for a run the engine abandoned. An integrity fault
+    (Goccia.EngineFault.IsEngineIntegrityFault) means a value was used after it
+    was freed, a pointer was never valid, or the heap's own bookkeeping is
+    destroyed — so every later file would execute on state the engine has
+    already lost track of, and the verdict it reported would be worthless.
+    Distinct from 1 (the suite ran and reported failures) and 2 (the invocation
+    was unusable) so a harness can tell "these tests failed" from "stop
+    believing this process". 70 is sysexits' EX_SOFTWARE, "an internal software
+    error has been detected"; see docs/contributing/cli-conventions.md. }
+  EXIT_CODE_INTEGRITY_FAULT = 70;
 
 type
   { Plain-data record for extracting test results from GC-managed objects.
@@ -159,6 +186,24 @@ type
     FGlobalFiles: TRepeatableOption;
     FInlineGlobals: TRepeatableOption;
     FNoVitestCompat: TFlagOption;
+    { Stop signal of the parallel run currently in flight, or nil. Not owned —
+      RunScriptsFromFilesParallel publishes it before RunAll starts any worker
+      and clears it once RunAll has joined them. It exists so a worker that hits
+      an engine-integrity fault can stop the queue: the pool's automatic
+      cancel-on-error only arms under --exit-on-first-failure, and an integrity
+      fault must stop dispatching new files whether or not the user asked to
+      bail on failures.
+
+      The flag rather than the pool, deliberately. A worker the watchdog
+      abandoned keeps running after RunAll returns and after the pool is freed,
+      so a cached pool pointer would be a use-after-free waiting for that
+      zombie to fault. The pool leaks the flag instead of freeing it as soon as
+      any worker is abandoned, which is exactly the condition under which a
+      zombie exists — so this pointer is live whenever anything can still read
+      it. Clearing it in the same scope keeps a zombie from a finished run
+      cancelling a later one, which is the mis-cancellation
+      TGocciaThreadPool.RunAll guards against on its own side. }
+    FActiveCancelFlag: TGocciaCancellationFlag;
     function SnapshotUpdateMode: TGocciaSnapshotUpdateMode;
     procedure InitializeRuntime(const AEngine: TGocciaEngine;
       const AEnableHostFileLoading: Boolean = True);
@@ -202,6 +247,88 @@ type
       const ACompact: Boolean);
     procedure PrintTestResults(const AResult: TAggregatedTestResult);
   end;
+
+var
+  { Set once, by whichever thread reports the first engine-integrity fault, and
+    never cleared. Two jobs, both of which need it to outlive the pool:
+
+    It decides who prints. Faults arrive on worker threads, and a run that
+    corrupts shared state is as likely to fault two workers as one; an
+    unsynchronised WriteLn race would shred the very diagnostic the abort
+    exists to produce. First fault wins, the rest stay silent.
+
+    It is also the abort's own record. The sentinel a faulting worker returns
+    travels in the pool's results, and those can be lost: if the watchdog
+    abandons the faulting worker, RunAll drops its in-progress slot and the
+    stalled-file override rewrites it as a TIMEOUT, so the sentinel scan alone
+    would let a run that had already printed "the run is aborted" go on to
+    print a full summary and exit 0. This lives in process memory that no pool
+    owns, so nothing can rewrite it.
+
+    LongInt with an interlocked write because the claim it makes ("I am the
+    reporter") must be exclusive; plain aligned reads are enough on the
+    consuming side, which only ever asks whether it is non-zero. }
+  GIntegrityFaultReported: LongInt;
+
+{ Writes the abort diagnostic for an engine-integrity fault to stderr and
+  flushes it immediately. Only the first caller in the process writes anything;
+  later ones return silently, having lost the race to report.
+
+  Written at the point of the fault, including from a worker thread — a
+  deliberate exception to the pool's "capture your output, never WriteLn"
+  contract. Handing the text back to the main thread would mean allocating and
+  refcounting strings on the heap that just proved untrustworthy, and the
+  faulting thread may not get that far; the diagnostic is the one thing that
+  must survive. The first-fault gate removes the worker-against-worker race,
+  and composing the whole report into one string leaves a single write rather
+  than a sequence of them — the remaining interleaving partner is the pool
+  watchdog's own stall warnings on the main thread, which are line-oriented and
+  only appear once a worker has already been stuck for twice the file timeout.
+  Flushing matters because Halt still runs unit finalization on the suspect
+  heap, and that is not a good bet to write through. }
+procedure ReportIntegrityFault(const AFileName: string;
+  const AException: Exception);
+begin
+  if InterlockedExchange(GIntegrityFaultReported, 1) <> 0 then
+    Exit;
+  WriteLn(ErrOutput, INTEGRITY_FAULT_PREFIX + AException.ClassName + ' in ' +
+    AFileName + ': ' + AException.Message + sLineBreak +
+    INTEGRITY_FAULT_PREFIX + 'the engine can no longer vouch for its own ' +
+    'state, so the run is aborted and the remaining files were not executed.');
+  Flush(ErrOutput);
+end;
+
+{ True once any thread has reported an integrity fault. }
+function IntegrityFaultWasReported: Boolean;
+begin
+  Result := GIntegrityFaultReported <> 0;
+end;
+
+{ Reports the fault and stops the process. Deliberately not an unwind: the
+  aggregation the runner would unwind through reads the very objects the fault
+  calls into question, and PrintTestResults would then overwrite ExitCode with
+  a pass/fail verdict this process is in no position to give. }
+procedure AbortRunOnIntegrityFault(const AFileName: string;
+  const AException: Exception);
+begin
+  ReportIntegrityFault(AFileName, AException);
+  Halt(EXIT_CODE_INTEGRITY_FAULT);
+end;
+
+{ True when any worker of the finished run came back carrying the integrity
+  sentinel. Kept alongside the process-level flag rather than replaced by it:
+  the flag is the one that survives an abandoned worker, and this is the one
+  tied to the pool's own record of which file it was. Either alone stops the
+  run. }
+function PoolReportedIntegrityFault(const APool: TGocciaThreadPool): Boolean;
+var
+  I: Integer;
+begin
+  for I := 0 to High(APool.Results) do
+    if APool.Results[I].ErrorMessage = INTEGRITY_FAULT_SIGNAL then
+      Exit(True);
+  Result := False;
+end;
 
 function MakeEmptyTestResult(const AScriptResult: TGocciaObjectValue;
   const AErrorMessage: string = ''): TTestFileResult;
@@ -654,8 +781,17 @@ begin
       FlushPendingInlineSnapshots;
     except
       on E: Exception do
+      begin
+        { Host tier once more. Write-back re-reads the recorded snapshot values
+          and rewrites test sources from them, so an integrity fault here is a
+          fault over the results the run is about to report — filing it as one
+          recorded finalization failure would publish those results anyway
+          (ADR 0109). }
+        if IsEngineIntegrityFault(E) then
+          AbortRunOnIntegrityFault(INLINE_SNAPSHOT_FLUSH_SITE, E);
         RecordSnapshotFinalizationFailure(AggregatedResult,
           'Snapshot finalization failed: ' + E.Message);
+      end;
     end;
     MainMemoryStats := FinishCLIJSONMemoryMeasurement(MemoryMeasurement);
     if IsParallelRun then
@@ -866,6 +1002,13 @@ begin
     except
       on E: Exception do
       begin
+        { An integrity fault is not a per-file verdict, so this arm must not
+          turn it into one. Re-raise it to the runner's host tier —
+          RunScriptFromFile for a sequential run, TestWorkerProc for a parallel
+          one — which stops the whole run. See ADR 0109, "Host tier: the test
+          runner". }
+        if IsEngineIntegrityFault(E) then
+          raise;
         if E is TGocciaError then
         begin
           if (not GIsWorkerThread) and (not IsJsonOutput) then
@@ -1047,6 +1190,10 @@ begin
     except
       on E: Exception do
       begin
+        { Same host-tier rule as the interpreted path: an integrity fault
+          unwinds past this arm rather than becoming a failed file. }
+        if IsEngineIntegrityFault(E) then
+          raise;
         if E is TGocciaError then
         begin
           if (not GIsWorkerThread) and (not IsJsonOutput) then
@@ -1151,6 +1298,13 @@ begin
   except
     on E: Exception do
     begin
+      { Host tier, sequential path. A refused allocation or a thrown value is a
+        verdict on this one file and the rest of the run still means something;
+        an integrity fault is a verdict on the process, so the run stops here
+        instead of relabelling the fault as one more failed file and executing
+        hundreds more on a heap the engine has lost track of (ADR 0109). }
+      if IsEngineIntegrityFault(E) then
+        AbortRunOnIntegrityFault(AFileName, E);
       if E is TGocciaError then
         WriteLn(ErrOutput, FormatHostErrorDiagnostic(TGocciaError(E), IsColorTerminal))
       else
@@ -1388,6 +1542,20 @@ begin
     end;
     on E: Exception do
     begin
+      { Host tier, parallel path. Report first — the diagnostic must be out
+        before anything else is attempted on this heap — then stop the queue so
+        no further file is dispatched, and hand the main thread the sentinel it
+        aborts the run on. Cancelling is the pool's own stop signal, so the
+        worker does not Halt from a thread: files already in flight finish or
+        are marked cancelled, and RunAll returns normally (ADR 0109). }
+      if IsEngineIntegrityFault(E) then
+      begin
+        ReportIntegrityFault(AFileName, E);
+        if Assigned(FActiveCancelFlag) then
+          FActiveCancelFlag.Cancel;
+        AErrorMessage := INTEGRITY_FAULT_SIGNAL;
+        Exit;
+      end;
       WorkerResults^[AIndex].ErrorMessage := E.Message;
       WorkerResults^[AIndex].Failed := 1;
       WorkerResults^[AIndex].TotalRunTests := 1;
@@ -1490,6 +1658,12 @@ begin
   WallClockStart := GetNanoseconds;
 
   Pool := TGocciaThreadPool.Create(AJobCount);
+  { Published for the workers before any of them starts: a worker that faults
+    needs to reach Cancel. Reading the flag before RunAll is safe because this
+    pool was constructed two lines up — RunAll only mints a replacement flag
+    for a pool whose previous run leaked one, and this one has had no previous
+    run. }
+  FActiveCancelFlag := Pool.CancelFlag;
   try
     Pool.CancelOnError := FExitOnFirst.Present;
     Pool.EnableCoverage := CoverageOptions.Enabled.Present;
@@ -1510,6 +1684,15 @@ begin
     else
       WatchdogMs := 0;
     Pool.RunAll(AFiles, TestWorkerProc, @WorkerData[0], WatchdogMs);
+    { A worker hit an engine-integrity fault: it wrote the diagnostic and
+      cancelled the queue, and the files that did finish were running beside a
+      heap that is no longer sound. Stop before aggregating them into a total
+      the run cannot stand behind. The process-level flag is checked first
+      because it is the one that still holds when the faulting worker was the
+      one the watchdog abandoned — its slot is dropped and then rewritten as a
+      TIMEOUT, so its sentinel never reaches Pool.Results. }
+    if IntegrityFaultWasReported or PoolReportedIntegrityFault(Pool) then
+      Halt(EXIT_CODE_INTEGRITY_FAULT);
     WorkerMemoryStats := Pool.MemoryStats;
     if Pool.EnableCoverage and (TGocciaCoverageTracker.Instance <> nil) then
       Pool.MergeCoverageInto(TGocciaCoverageTracker.Instance);
@@ -1601,6 +1784,7 @@ begin
       end;
     end;
   finally
+    FActiveCancelFlag := nil;
     Pool.Free;
   end;
 

--- a/source/units/Goccia.Threading.pas
+++ b/source/units/Goccia.Threading.pas
@@ -202,6 +202,16 @@ type
     property Results: TGocciaWorkerResultArray read FResults;
     property MemoryStats: TCLIJSONMemoryStats read FMemoryStats;
     property WorkerCount: Integer read FWorkerCount;
+    { This run's stop signal, exposed so a worker callback can cancel the queue
+      without holding a reference to the pool itself. That distinction is a
+      lifetime one, not a convenience: the pool is freed while an abandoned
+      worker is still running, so a callback that cached the pool could call
+      into freed memory, whereas the flag is leaked rather than freed the
+      moment any worker is abandoned (see Destroy) — precisely the case in
+      which a zombie can still reach for it. Read it before RunAll; RunAll
+      replaces the flag when the previous run leaked one, so a pool that is
+      being reused must be re-read rather than cached across runs. }
+    property CancelFlag: TGocciaCancellationFlag read FCancelFlag;
     { Reads the shared flag under its lock, so callers never see a torn
       or stale value while workers are still running. }
     property Cancelled: Boolean read GetCancelled;


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- The test runner now **aborts the whole run** when an engine-integrity fault escapes a test file, instead of recording one red file and executing the remaining hundreds on a possibly-corrupted heap: a distinct greppable stderr diagnostic naming the faulting file, no summary and no JSON envelope (a consumer sees a missing file, never parseable-but-wrong output), and exit 70 (sysexits `EX_SOFTWARE`, now documented in cli-conventions — no CI path assigns 70 another meaning; all existing steps key on zero/non-zero). The limit family (`--max-memory` etc.) deliberately keeps its per-file treatment: a refusal is a per-file verdict on a still-sound heap.
- Concurrency design survived adversarial review and a fix round: workers cancel the pool through its cancellation flag, not the pool object — the flag deliberately outlives the pool on worker abandonment, so a watchdog-abandoned zombie can never call into freed memory — and a process-level interlocked first-fault flag carries the abort even when the faulting worker's own result slot was dropped by the watchdog (pre-fix, that shape printed a full summary and exited 0/1 after claiming the run was aborted). First-fault-wins also serializes the diagnostic: three workers faulting concurrently print once.
- The inline-snapshot write-back arm aborts the same way; the shared CLI error handler in `Goccia.Application` remains a *documented* residual boundary (exit 1, no diagnostic) for faults outside test execution — closing it touches every CLI binary and is recorded in the ADR as its own future decision, and `docs/testing.md` scopes its claim accordingly.
- Decision recorded as a host-tier section in ADR 0109 (amended in-stack; it ships unlanded in #1158): why per-file isolation was rejected for integrity faults, the abort-not-unwind choice (aggregation would read the objects the fault calls into question), and the pool-shutdown mechanics.
- Stack layer 6 of #1159. Depends on `Goccia.EngineFault`/ADR 0109 from #1158; files are disjoint from every other layer.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests — full suite green in both executors and in `--jobs=4`; `scripts/test-cli.ts` locks the contract the abort must not disturb (a failing file still exits 1 with unchanged report shape and no `Integrity fault:` text, across both modes and both jobs shapes)
- [x] Updated documentation — `docs/contributing/cli-conventions.md` (exit-code table + rationale), `docs/testing.md` (behavior + diagnostic sample + `--max-memory` contrast, claim scoped to the aborting paths), ADR 0109 host-tier section
- [x] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests — `Goccia.Threading.pas` change is one additive read-only property; suite-level coverage via the JS gate
- [ ] Optional: benchmark coverage — not applicable (host-tier error handling)

Coverage note, stated rather than hidden: the abort path itself has no automated coverage — an injection hook into the production runner would be a flag whose only purpose is to corrupt the binary, so it was verified by a temporary local raise across every shape (`--jobs=1/4` × both modes × `--output=json` × `--exit-on-first-failure`, single-file, multi-worker concurrent faults, abandoned-faulting-worker simulation, snapshot-flush arm — all exit 70, one diagnostic, empty stdout) and the patch was byte-verified reverted.

Review provenance: fresh-context adversarial review; all three findings (zombie→pool use-after-free, abandoned-worker false abort, stderr race) fixed and re-proven before commit.
