### PR TITLE
fix(engine): fault unwinds no longer leak iterator roots or pending host work

### DIFF
--- a/docs/adr/0109-engine-integrity-faults-are-uncatchable.md
+++ b/docs/adr/0109-engine-integrity-faults-are-uncatchable.md
@@ -134,27 +134,40 @@ was unusable) and a harness can tell "these tests failed" from "stop believing
 this process" (see [CLI
 Conventions](../contributing/cli-conventions.md#exit-codes)). The two per-mode
 arms only re-raise, which keeps one abort site per tier: the sequential
-aggregator for a `--jobs=1` run, the worker body for a parallel one. A faulting
-worker cancels the pool's shared queue rather than halting from a thread — that
-queue is the pool's own stop signal, so files already in flight finish or are
-marked cancelled and `RunAll` returns normally — and the main thread halts the
-moment it does, before the aggregation reads a single worker slot. The abort is
-deliberately not an unwind: the aggregation would read the very objects the
+aggregator for a `--jobs=1` run, the worker body for a parallel one. The abort
+is deliberately not an unwind: the aggregation would read the very objects the
 fault calls into question, and the summary at the end of it would overwrite the
 exit code with a pass/fail verdict the process is in no position to give.
 
-Two mechanics are worth naming because the obvious version of each is wrong. A
-faulting worker cancels through the pool's cancellation flag rather than through
-the pool object: the pool is freed while an abandoned worker is still running,
-and it leaks the flag rather than freeing it for exactly that reason, so the
-flag is the only handle a zombie can safely hold. And the main thread's decision
-to abort rests on a process-level first-fault flag, not only on the sentinel the
-worker returns — if the watchdog abandons the *faulting* worker, its slot is
-dropped and rewritten as a timeout, and a run that had already printed "the run
-is aborted" would go on to print a full summary. That flag also settles who
+In the parallel case a faulting worker does two things, and it is worth being
+precise about which one is load-bearing. It cancels the pool's shared queue, so
+peer workers stop reaching for new files; then it ends the process from its own
+thread. The first draft stopped at the cancel, reasoning that the pool had a
+cleaner stop than halting from a worker and that in-flight files could finish
+while `RunAll` returned normally. That is true only while the main thread is
+still listening. A worker the watchdog abandoned outlives `RunAll`, so a fault
+in it lands after the main thread has already made whatever check it was going
+to make: the cancel reaches a queue nobody is draining, and the run prints a
+full summary and exits `0` beneath a stderr line that says it was aborted. No
+fixed checkpoint fixes that, because the zombie can report at any later moment
+— a second check only moves the window. So the thread that knows ends the
+process, and the cancel becomes what it always really was, the orderly half.
+Halting from a secondary thread is not a compromise here: unit finalization on
+a suspect heap was never something this ADR promised to survive, and the
+diagnostic is written and flushed before the halt for exactly that reason.
+
+Two smaller mechanics, because the obvious version of each is wrong. The worker
+cancels through the pool's cancellation *flag* rather than the pool object: the
+pool is freed while an abandoned worker is still running, and it leaks the flag
+rather than freeing it for precisely that reason, so the flag is the only handle
+a zombie can safely hold. And the main thread keeps a check of its own on a
+process-level first-fault flag — not because the abort depends on it, but
+because halt runs finalization first and the main thread can surface from
+`RunAll` inside that window; without the check it would spend the window
+printing a summary the process is about to truncate. That flag also settles who
 writes the diagnostic: faults arrive on worker threads, corruption that reaches
-one worker can reach two, and first-fault-wins keeps the two of them from
-shredding the message between them.
+one worker can reach two, and first-fault-wins keeps them from shredding the
+message between them.
 
 This is one tier's policy, not a guarantee about every exit path. The shared CLI
 entry point every Goccia binary runs under (`TGocciaApplication.Run`) still ends

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -385,8 +385,7 @@ expansion, config discovery — still lands in the shared CLI error handler that
 every Goccia binary uses, and exits `1` with no `Integrity fault:` line.)
 
 The runner names the faulting file and the exception class on stderr under a
-fixed prefix, stops dispatching files (cancelling the worker queue under
-`--jobs`), and exits **70**:
+fixed prefix, stops dispatching files, and exits **70**:
 
 ```text
 Integrity fault: EObjectCheck in tests/some/file.js: Object reference is Nil
@@ -394,7 +393,13 @@ Integrity fault: the engine can no longer vouch for its own state, so the run is
 ```
 
 No summary and no JSON envelope follow — a run that stopped mid-way has no total
-worth reporting. Grep CI logs for `Integrity fault:` to find these. The exit
+worth reporting. Grep CI logs for `Integrity fault:` to find these. Unlike
+`--exit-on-first-failure`, this does not let in-flight files finish: under
+`--jobs` the process ends as soon as the faulting worker has written its
+diagnostic, because a worker the watchdog has abandoned outlives the run and
+could otherwise fault after the main thread has stopped listening. A peer worker
+caught mid-test by that exit may print one last `Thread error` failure line —
+noise from the shutdown, not a real test result. The exit
 code is distinct from the ordinary failure exit `1` on purpose, so a harness can
 tell a suite that failed from a suite that stopped being trustworthy; see [CLI
 Conventions](contributing/cli-conventions.md#exit-codes). A refused allocation

--- a/scripts/test-cli.ts
+++ b/scripts/test-cli.ts
@@ -2504,9 +2504,12 @@ console.log("TestRunner (a failing file stays exit 1, not an integrity abort)...
       join(failTmp, "failing.test.js"),
       'describe("d", () => {\n  test("fails", () => {\n    expect(1).toBe(2);\n  });\n});\n',
     );
+    // The console.log marker proves the passing FILE executed — the count
+    // assertions below prove one test passed, but only the marker ties that
+    // pass to this file rather than to some shape change in the failing one.
     writeFileSync(
       join(failTmp, "passing.test.js"),
-      'describe("d", () => {\n  test("passes", () => {\n    expect(1).toBe(1);\n  });\n});\n',
+      'console.log("RAN: passing.test.js");\ndescribe("d", () => {\n  test("passes", () => {\n    expect(1).toBe(1);\n  });\n});\n',
     );
     for (const modeArgs of [[], ["--mode=bytecode"]] as const) {
       for (const jobsArg of ["--jobs=1", "--jobs=2"]) {
@@ -2528,6 +2531,11 @@ console.log("TestRunner (a failing file stays exit 1, not an integrity abort)...
           "Test Results Passed: 1 (50.00%)",
           "Test Results Failed: 1 (50.00%)",
           'Test "fails" in suite "d": Expected 1 to be 2',
+          // The guest marker directly proves the passing FILE executed. The
+          // parallel workers capture guest console output, so the marker is
+          // only observable sequentially; the jobs=2 shape keeps the count
+          // assertions, which pin the same fact arithmetically.
+          ...(jobsArg === "--jobs=1" ? ["RAN: passing.test.js"] : []),
         ]) {
           if (!out.includes(expected))
             throw new Error(`TestRunner (${label}) report lost "${expected}": ${out}`);

--- a/source/app/GocciaTestRunner.dpr
+++ b/source/app/GocciaTestRunner.dpr
@@ -79,12 +79,6 @@ const
     failure. }
   EXIT_ON_FIRST_FAILURE_SIGNAL = '<exit-on-first-failure>';
 
-  { Sentinel a parallel worker returns as its pool error message after an
-    engine-integrity fault. It only has to survive the trip back to the main
-    thread: the diagnostic is already on stderr, and the main thread reads this
-    to know the run must stop rather than be aggregated. }
-  INTEGRITY_FAULT_SIGNAL = '<engine-integrity-fault>';
-
   { Prefix on every line of the integrity-fault diagnostic. Deliberately unlike
     any ordinary failure line the runner prints, so `grep 'Integrity fault:'`
     over a CI log finds the abort and nothing else. }
@@ -190,10 +184,12 @@ type
     { Stop signal of the parallel run currently in flight, or nil. Not owned —
       RunScriptsFromFilesParallel publishes it before RunAll starts any worker
       and clears it once RunAll has joined them. It exists so a worker that hits
-      an engine-integrity fault can stop the queue: the pool's automatic
-      cancel-on-error only arms under --exit-on-first-failure, and an integrity
-      fault must stop dispatching new files whether or not the user asked to
-      bail on failures.
+      an engine-integrity fault can stop the queue on its way out: the pool's
+      automatic cancel-on-error only arms under --exit-on-first-failure, and an
+      integrity fault must stop dispatching new files whether or not the user
+      asked to bail on failures. What it does not do is guarantee the abort —
+      the faulting worker halts the process itself — it keeps peer workers from
+      starting more files during the window that halt takes.
 
       The flag rather than the pool, deliberately. A worker the watchdog
       abandoned keeps running after RunAll returns and after the pool is freed,
@@ -258,13 +254,14 @@ var
     unsynchronised WriteLn race would shred the very diagnostic the abort
     exists to produce. First fault wins, the rest stay silent.
 
-    It is also the abort's own record. The sentinel a faulting worker returns
-    travels in the pool's results, and those can be lost: if the watchdog
-    abandons the faulting worker, RunAll drops its in-progress slot and the
-    stalled-file override rewrites it as a TIMEOUT, so the sentinel scan alone
-    would let a run that had already printed "the run is aborted" go on to
-    print a full summary and exit 0. This lives in process memory that no pool
-    owns, so nothing can rewrite it.
+    It also lets the main thread recognise an abort that is already under way.
+    A faulting worker halts the process, but halt runs unit finalization before
+    the process actually ends, and the main thread can return from RunAll
+    inside that window; reading this tells it to stop rather than spend the
+    window aggregating a summary that is about to be truncated mid-sentence.
+    The pool's own results cannot serve that purpose — a worker the watchdog
+    abandoned has its in-progress slot dropped and rewritten as a TIMEOUT — and
+    this lives in process memory no pool owns, so nothing can rewrite it.
 
     Integer with an interlocked write because the claim it makes ("I am the
     reporter") must be exclusive; plain aligned reads are enough on the
@@ -314,21 +311,6 @@ procedure AbortRunOnIntegrityFault(const AFileName: string;
 begin
   ReportIntegrityFault(AFileName, AException);
   Halt(EXIT_CODE_INTEGRITY_FAULT);
-end;
-
-{ True when any worker of the finished run came back carrying the integrity
-  sentinel. Kept alongside the process-level flag rather than replaced by it:
-  the flag is the one that survives an abandoned worker, and this is the one
-  tied to the pool's own record of which file it was. Either alone stops the
-  run. }
-function PoolReportedIntegrityFault(const APool: TGocciaThreadPool): Boolean;
-var
-  I: Integer;
-begin
-  for I := 0 to High(APool.Results) do
-    if APool.Results[I].ErrorMessage = INTEGRITY_FAULT_SIGNAL then
-      Exit(True);
-  Result := False;
 end;
 
 function MakeEmptyTestResult(const AScriptResult: TGocciaObjectValue;
@@ -1543,19 +1525,39 @@ begin
     end;
     on E: Exception do
     begin
-      { Host tier, parallel path. Report first — the diagnostic must be out
-        before anything else is attempted on this heap — then stop the queue so
-        no further file is dispatched, and hand the main thread the sentinel it
-        aborts the run on. Cancelling is the pool's own stop signal, so the
-        worker does not Halt from a thread: files already in flight finish or
-        are marked cancelled, and RunAll returns normally (ADR 0109). }
+      { Host tier, parallel path. Report first — the diagnostic must be out and
+        flushed before anything else is attempted on this heap — then cancel
+        the queue so no further file is dispatched, then end the process from
+        this thread.
+
+        The cancel is the orderly half and the Halt is the unconditional one.
+        Cancelling alone was the original design, on the grounds that the pool
+        had a cleaner stop than halting from a worker; that reasoning holds
+        only while the main thread is still listening. A worker the watchdog
+        abandoned outlives RunAll, so if it faults after the main thread has
+        made its post-RunAll check, the cancel lands on a queue nobody is
+        draining and the run goes on to print a summary under a stderr line
+        that already said it was aborted. No fixed checkpoint closes that — the
+        zombie can report at any later moment — so the thread that knows ends
+        the process itself. Graceful shutdown on a suspect heap was never a
+        goal (ADR 0109).
+
+        Two consequences, both measured rather than assumed. Halting from a
+        secondary thread does end the process with this code on our targets,
+        and several threads doing it at once is safe — eight concurrent halts
+        exit cleanly, so a second faulting worker needs no special case. And a
+        peer worker that is mid-test when the process starts exiting can lose
+        its thread runtime and print one ordinary-looking failure line ("Thread
+        error") before it dies. That is cosmetic: the exit code, the single
+        diagnostic and the absence of a summary are unaffected, and silencing
+        it would mean coordinating a clean stop across threads on the very heap
+        this abort exists because it cannot trust. }
       if IsEngineIntegrityFault(E) then
       begin
         ReportIntegrityFault(AFileName, E);
         if Assigned(FActiveCancelFlag) then
           FActiveCancelFlag.Cancel;
-        AErrorMessage := INTEGRITY_FAULT_SIGNAL;
-        Exit;
+        Halt(EXIT_CODE_INTEGRITY_FAULT);
       end;
       WorkerResults^[AIndex].ErrorMessage := E.Message;
       WorkerResults^[AIndex].Failed := 1;
@@ -1685,14 +1687,18 @@ begin
     else
       WatchdogMs := 0;
     Pool.RunAll(AFiles, TestWorkerProc, @WorkerData[0], WatchdogMs);
-    { A worker hit an engine-integrity fault: it wrote the diagnostic and
-      cancelled the queue, and the files that did finish were running beside a
-      heap that is no longer sound. Stop before aggregating them into a total
-      the run cannot stand behind. The process-level flag is checked first
-      because it is the one that still holds when the faulting worker was the
-      one the watchdog abandoned — its slot is dropped and then rewritten as a
-      TIMEOUT, so its sentinel never reaches Pool.Results. }
-    if IntegrityFaultWasReported or PoolReportedIntegrityFault(Pool) then
+    { A worker hit an engine-integrity fault: it wrote the diagnostic, cancelled
+      the queue, and is ending the process. The files that did finish were
+      running beside a heap that is no longer sound, so stop before aggregating
+      them into a total the run cannot stand behind.
+
+      This is not the mechanism that guarantees the abort — the faulting worker
+      halts on its own thread — it is what keeps the ordinary case from racing
+      it. Halt runs unit finalization first, and the main thread can come out
+      of RunAll inside that window; without this check it would spend the
+      window aggregating and printing a summary that the process is about to
+      truncate at an arbitrary point. }
+    if IntegrityFaultWasReported then
       Halt(EXIT_CODE_INTEGRITY_FAULT);
     WorkerMemoryStats := Pool.MemoryStats;
     if Pool.EnableCoverage and (TGocciaCoverageTracker.Instance <> nil) then

--- a/source/app/GocciaTestRunner.dpr
+++ b/source/app/GocciaTestRunner.dpr
@@ -10,6 +10,7 @@ uses
 
   TimingUtils,
   TextSemantics,
+  CriticalSections,
 
   Goccia.Arguments.Collection,
   Goccia.Application,
@@ -265,10 +266,10 @@ var
     print a full summary and exit 0. This lives in process memory that no pool
     owns, so nothing can rewrite it.
 
-    LongInt with an interlocked write because the claim it makes ("I am the
+    Integer with an interlocked write because the claim it makes ("I am the
     reporter") must be exclusive; plain aligned reads are enough on the
     consuming side, which only ever asks whether it is non-zero. }
-  GIntegrityFaultReported: LongInt;
+  GIntegrityFaultReported: Integer;
 
 { Writes the abort diagnostic for an engine-integrity fault to stderr and
   flushes it immediately. Only the first caller in the process writes anything;
@@ -289,7 +290,7 @@ var
 procedure ReportIntegrityFault(const AFileName: string;
   const AException: Exception);
 begin
-  if InterlockedExchange(GIntegrityFaultReported, 1) <> 0 then
+  if AtomicExchangeInt32(GIntegrityFaultReported, 1) <> 0 then
     Exit;
   WriteLn(ErrOutput, INTEGRITY_FAULT_PREFIX + AException.ClassName + ' in ' +
     AFileName + ': ' + AException.Message + sLineBreak +

--- a/source/shared/CriticalSections.pas
+++ b/source/shared/CriticalSections.pas
@@ -27,6 +27,7 @@ procedure CriticalSectionLeave(var ASection: TGocciaCriticalSection); {$IFDEF FP
 function GetGocciaThreadId: TThreadID; {$IFDEF FPC}inline;{$ENDIF}
 function AtomicIncrementInt32(var AValue: Integer): Integer; {$IFDEF FPC}inline;{$ENDIF}
 function AtomicDecrementInt32(var AValue: Integer): Integer; {$IFDEF FPC}inline;{$ENDIF}
+function AtomicExchangeInt32(var AValue: Integer; const ANewValue: Integer): Integer; {$IFDEF FPC}inline;{$ENDIF}
 procedure ReadMemoryBarrier; {$IFDEF FPC}inline;{$ENDIF}
 procedure WriteMemoryBarrier; {$IFDEF FPC}inline;{$ENDIF}
 
@@ -93,6 +94,15 @@ begin
   Result := System.InterlockedDecrement(AValue);
   {$ELSE}
   Result := TInterlocked.Decrement(AValue);
+  {$ENDIF}
+end;
+
+function AtomicExchangeInt32(var AValue: Integer; const ANewValue: Integer): Integer;
+begin
+  {$IFDEF FPC}
+  Result := System.InterlockedExchange(AValue, ANewValue);
+  {$ELSE}
+  Result := TInterlocked.Exchange(AValue, ANewValue);
   {$ENDIF}
 end;
 

--- a/source/units/Goccia.AST.Expressions.pas
+++ b/source/units/Goccia.AST.Expressions.pas
@@ -2154,11 +2154,15 @@ var
 
   function ReadSymbolProperty(const AObj: TGocciaValue; const ASymbol: TGocciaSymbolValue): TGocciaValue;
   begin
+    { This is the read step, so a nullish base fails as a read — the store's
+      set-flavored message would misattribute the failure (and diverge from the
+      VM, which reports the read). Matches ReadPropertyCompoundAssignmentValue
+      on the string-key path. }
     if AObj is TGocciaNullLiteralValue then
-      ThrowTypeError(Format(SErrorCannotSetPropertiesOfNull, [ASymbol.ToDisplayString.Value]),
+      ThrowTypeError(Format(SErrorCannotReadPropertiesOfNull, [ASymbol.ToDisplayString.Value]),
         SSuggestCheckNullBeforeAccess)
     else if AObj is TGocciaUndefinedLiteralValue then
-      ThrowTypeError(Format(SErrorCannotSetPropertiesOfUndefined, [ASymbol.ToDisplayString.Value]),
+      ThrowTypeError(Format(SErrorCannotReadPropertiesOfUndefined, [ASymbol.ToDisplayString.Value]),
         SSuggestCheckNullBeforeAccess);
 
     if AObj is TGocciaClassValue then

--- a/source/units/Goccia.Builtins.TestingLibrary.pas
+++ b/source/units/Goccia.Builtins.TestingLibrary.pas
@@ -4481,16 +4481,33 @@ begin
             E.Message is empty for it, which dropped the text both oracles
             print. }
           { A refused allocation is uncatchable and must unwind to the host, not
-            be converted into a hook failure and swallowed here. }
+            be converted into a hook failure and swallowed here. Pending host
+            work is cleared first: the host catches this error and later files
+            still run in the same process, so stale microtasks or fetch
+            completions from the aborted file must not leak into them. }
           on E: TGocciaMemoryLimitError do
+          begin
+            if (TGocciaMicrotaskQueue.Instance <> nil) then
+              TGocciaMicrotaskQueue.Instance.ClearQueue;
+            DiscardFetchCompletions;
             raise;
+          end;
           on E: TGocciaThrowValue do
             AssertionFailed('callback execution',
               'Callback threw an exception: ' + DescribeThrownValue(E.Value));
           on E: Exception do
           begin
             if IsEngineIntegrityFault(E) then
+            begin
+              { Terminal for the same reason as the refusal above, and with the
+                same bookkeeping: the run is unwinding to the host, so pending
+                host work must not leak into the next file and the remaining
+                hooks must not run on a heap that is no longer sound. }
+              if (TGocciaMicrotaskQueue.Instance <> nil) then
+                TGocciaMicrotaskQueue.Instance.ClearQueue;
+              DiscardFetchCompletions;
               raise;
+            end;
             AssertionFailed('callback execution', 'Callback threw an exception: ' + E.Message);
           end;
         end;

--- a/source/units/Goccia.MemoryLimit.Test.pas
+++ b/source/units/Goccia.MemoryLimit.Test.pas
@@ -35,6 +35,10 @@ type
       what puts Response in scope, and to give the engine an audit sink that
       refuses delivery so any capability the script exercises raises. }
     FInstallFailingAuditSink: Boolean;
+    { Set by the witness native below. FaultEscapesScript clears it before each
+      run, so it answers one question about one script: did guest code keep
+      running after a fault it should never have been able to observe? }
+    FSwallowedFaultReported: Boolean;
     { The refusing sink itself. EmitCapabilityAudit wraps whatever it raises in
       EGocciaCapabilityAuditDeliveryError. }
     procedure FailingAuditSink(const AEvent: TGocciaCapabilityAuditEvent);
@@ -42,6 +46,12 @@ type
       call through a collected value raises under `$OBJECTCHECKS ON`, which is
       how a real unrooted-temporary bug arrives. }
     function RaiseIntegrityFault(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    { The witness the integrity-fault scripts call from inside their `catch`.
+      Being called at all means the catch block ran, which is the swallow the
+      guards exist to prevent — so the tests assert it stayed silent. Raising
+      here instead would be indistinguishable from the fault under test. }
+    function ReportSwallowedFault(const AArgs: TGocciaArgumentsCollection;
       const AThisValue: TGocciaValue): TGocciaValue;
     { Raises whatever FSandboxFaultClass names. The refusal comes from the gate
       itself rather than a hand-built instance, so the test exercises the same
@@ -106,6 +116,11 @@ const
     stack trace. }
   INTEGRITY_FAULT_GLOBAL_NAME = '__gocciaRaiseIntegrityFault';
   INTEGRITY_FAULT_MESSAGE = 'Object reference is Nil';
+
+  { Name of the witness native the integrity-fault scripts call from their
+    `catch` blocks, so a swallow reports itself instead of only showing up as
+    the absence of an escaping fault. }
+  SWALLOW_WITNESS_GLOBAL_NAME = '__gocciaReportSwallowedFault';
 
   { Name of the native the sandbox tests reach through an options getter. }
   SANDBOX_FAULT_GLOBAL_NAME = '__gocciaRaiseSandboxFault';
@@ -190,6 +205,14 @@ begin
   raise EObjectCheck.Create(INTEGRITY_FAULT_MESSAGE);
 end;
 
+function TMemoryLimitTests.ReportSwallowedFault(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+  FSwallowedFaultReported := True;
+end;
+
 procedure TMemoryLimitTests.RaiseConfiguredFault;
 begin
   if FSandboxFaultClass = nil then
@@ -232,10 +255,14 @@ begin
   Engine := TGocciaEngine.Create(AName, Source, AExecutor);
   GC := TGarbageCollector.Instance;
   PreviousMaxBytes := 0;
+  FSwallowedFaultReported := False;
   try
     Engine.InjectGlobal(INTEGRITY_FAULT_GLOBAL_NAME,
       TGocciaNativeFunctionValue.CreateWithoutPrototype(RaiseIntegrityFault,
         INTEGRITY_FAULT_GLOBAL_NAME, 0));
+    Engine.InjectGlobal(SWALLOW_WITNESS_GLOBAL_NAME,
+      TGocciaNativeFunctionValue.CreateWithoutPrototype(ReportSwallowedFault,
+        SWALLOW_WITNESS_GLOBAL_NAME, 0));
     if FInstallFailingAuditSink then
     begin
       AttachRuntime(Engine).Install(TGocciaFetchRuntimeExtension.Create);
@@ -480,11 +507,10 @@ end;
 procedure TMemoryLimitTests.TestSyncCatchCannotSwallowIntegrityFault;
 const
   SourceText =
-    'let caught = false;' + sLineBreak +
     'try {' + sLineBreak +
     '  ' + INTEGRITY_FAULT_GLOBAL_NAME + '();' + sLineBreak +
     '} catch (e) {' + sLineBreak +
-    '  caught = true;' + sLineBreak +
+    '  ' + SWALLOW_WITNESS_GLOBAL_NAME + '();' + sLineBreak +
     '}';
 begin
   { An engine-integrity fault is not a JavaScript error and must not become
@@ -492,13 +518,20 @@ begin
     catchable Error object, which turned a use-after-free — the shape an
     unrooted evaluator temporary produces under memory pressure — into
     `catch (e)` and let the script keep running on corrupted state. Both
-    executors must now unwind to the host. }
+    executors must now unwind to the host.
+
+    The escaping EObjectCheck is the load-bearing assertion; the witness is the
+    other half of the same question, and it distinguishes the two ways this can
+    fail — a fault that never reached the host because the guest caught it,
+    versus one that never fired at all. }
   Expect<Boolean>(FaultEscapesScript(SourceText,
     TGocciaInterpreterExecutor.Create,
     'integrity-fault-sync-interpreted.js', EObjectCheck)).ToBe(True);
+  Expect<Boolean>(FSwallowedFaultReported).ToBe(False);
   Expect<Boolean>(FaultEscapesScript(SourceText,
     TGocciaBytecodeExecutor.Create,
     'integrity-fault-sync-bytecode.js', EObjectCheck)).ToBe(True);
+  Expect<Boolean>(FSwallowedFaultReported).ToBe(False);
 end;
 
 procedure TMemoryLimitTests.TestAsyncFunctionCatchCannotSwallowIntegrityFault;
@@ -510,19 +543,26 @@ const
     'const main = async () => {' + sLineBreak +
     '  try {' + sLineBreak +
     '    await fault();' + sLineBreak +
-    '  } catch (e) {}' + sLineBreak +
+    '  } catch (e) {' + sLineBreak +
+    '    ' + SWALLOW_WITNESS_GLOBAL_NAME + '();' + sLineBreak +
+    '  }' + sLineBreak +
     '};' + sLineBreak +
     'main();';
 begin
   { The await and promise-reaction boundaries convert a Pascal exception into a
     rejection, which `catch` then absorbs — the same swallow by a different
-    route. }
+    route. The witness matters more here than on the synchronous path: a throw
+    from inside this catch block would only become another rejection nothing
+    observes, so a host-side flag is the only way the swallow can report
+    itself. }
   Expect<Boolean>(FaultEscapesScript(SourceText,
     TGocciaInterpreterExecutor.Create,
     'integrity-fault-async-interpreted.js', EObjectCheck)).ToBe(True);
+  Expect<Boolean>(FSwallowedFaultReported).ToBe(False);
   Expect<Boolean>(FaultEscapesScript(SourceText,
     TGocciaBytecodeExecutor.Create,
     'integrity-fault-async-bytecode.js', EObjectCheck)).ToBe(True);
+  Expect<Boolean>(FSwallowedFaultReported).ToBe(False);
 end;
 
 procedure TMemoryLimitTests.TestSandboxFsPromiseCannotSwallowRefusal;

--- a/source/units/Goccia.Values.IteratorValue.pas
+++ b/source/units/Goccia.Values.IteratorValue.pas
@@ -1779,10 +1779,17 @@ begin
         Item := OuterIterator.DirectNext(OuterDone);
       except
         PreserveCurrentExceptionAcrossNestedHandler;
-        for J := Acquired - 1 downto 0 do
-        begin
-          CloseIteratorPreservingError(Iterators[J]);
-          GC.RemoveTempRoot(Iterators[J]);
+        { Each close runs a guest return() body, so the iterators have to stay
+          rooted across the whole pass — and an engine-integrity fault raised in
+          one of those bodies now re-raises out of CloseIteratorPreservingError.
+          Unrooting in a finally is what keeps that re-raise from stranding the
+          rest of them on the root set. }
+        try
+          for J := Acquired - 1 downto 0 do
+            CloseIteratorPreservingError(Iterators[J]);
+        finally
+          for J := Acquired - 1 downto 0 do
+            GC.RemoveTempRoot(Iterators[J]);
         end;
         raise;
       end;
@@ -1793,10 +1800,16 @@ begin
         InnerIterator := GetIteratorFlattenable(Item, iphRejectPrimitives);
       except
         PreserveCurrentExceptionAcrossNestedHandler;
-        for J := Acquired - 1 downto 0 do
-        begin
-          CloseIteratorPreservingError(Iterators[J]);
-          GC.RemoveTempRoot(Iterators[J]);
+        { Same shape as the close pass above: rooted across every guest
+          return(), unrooted in a finally so a re-raised integrity fault cannot
+          skip the removals. The outer iterator's own removal already sits in
+          the enclosing finally. }
+        try
+          for J := Acquired - 1 downto 0 do
+            CloseIteratorPreservingError(Iterators[J]);
+        finally
+          for J := Acquired - 1 downto 0 do
+            GC.RemoveTempRoot(Iterators[J]);
         end;
         CloseIteratorPreservingError(OuterIterator);
         raise;
@@ -1850,17 +1863,22 @@ begin
     Result := TGocciaZipIteratorValue.Create(Iterators, Padding, Mode);
     Success := True;
   finally
-    // On error, close all iterators so generator finally blocks run
-    if not Success then
-    begin
-      for I := Count - 1 downto 0 do
-        CloseIteratorPreservingError(Iterators[I]);
+    try
+      // On error, close all iterators so generator finally blocks run
+      if not Success then
+      begin
+        for I := Count - 1 downto 0 do
+          CloseIteratorPreservingError(Iterators[I]);
+      end;
+    finally
+      // Unroot iterators — the zip iterator now owns them via MarkReferences.
+      // In a finally of its own: a close runs guest return(), and an
+      // engine-integrity fault raised there re-raises past this point.
+      for I := 0 to Count - 1 do
+        GC.RemoveTempRoot(Iterators[I]);
+      for I := 0 to Count - 1 do
+        RemoveTempRootIfNeeded(Padding[I], PaddingRoots[I]);
     end;
-    // Unroot iterators — the zip iterator now owns them via MarkReferences
-    for I := 0 to Count - 1 do
-      GC.RemoveTempRoot(Iterators[I]);
-    for I := 0 to Count - 1 do
-      RemoveTempRootIfNeeded(Padding[I], PaddingRoots[I]);
   end;
 end;
 
@@ -1984,11 +2002,18 @@ begin
   except
     // Close and unroot already-acquired iterators before re-raising
     PreserveCurrentExceptionAcrossNestedHandler;
-    for J := Acquired - 1 downto 0 do
-    begin
-      CloseIteratorPreservingError(Iterators[J]);
-      GC.RemoveTempRoot(Iterators[J]);
-      RemoveTempRootIfNeeded(Keys[J], KeyRoots[J]);
+    { The iterators and their keys stay rooted for the whole close pass, since
+      each close runs a guest return(); the unrooting is a finally so a
+      re-raised engine-integrity fault cannot skip it. }
+    try
+      for J := Acquired - 1 downto 0 do
+        CloseIteratorPreservingError(Iterators[J]);
+    finally
+      for J := Acquired - 1 downto 0 do
+      begin
+        GC.RemoveTempRoot(Iterators[J]);
+        RemoveTempRootIfNeeded(Keys[J], KeyRoots[J]);
+      end;
     end;
     raise;
   end;
@@ -2019,19 +2044,24 @@ begin
     Result := TGocciaZipKeyedIteratorValue.Create(Keys, Iterators, Padding, Mode);
     Success := True;
   finally
-    // On error, close all iterators so generator finally blocks run
-    if not Success then
-    begin
-      for I := Count - 1 downto 0 do
-        CloseIteratorPreservingError(Iterators[I]);
+    try
+      // On error, close all iterators so generator finally blocks run
+      if not Success then
+      begin
+        for I := Count - 1 downto 0 do
+          CloseIteratorPreservingError(Iterators[I]);
+      end;
+    finally
+      // Unroot iterators — the zipKeyed iterator now owns them via
+      // MarkReferences. In a finally of its own: a close runs guest return(),
+      // and an engine-integrity fault raised there re-raises past this point.
+      for I := 0 to Count - 1 do
+        GC.RemoveTempRoot(Iterators[I]);
+      for I := 0 to Count - 1 do
+        RemoveTempRootIfNeeded(Keys[I], KeyRoots[I]);
+      for I := 0 to Count - 1 do
+        RemoveTempRootIfNeeded(Padding[I], PaddingRoots[I]);
     end;
-    // Unroot iterators — the zipKeyed iterator now owns them via MarkReferences
-    for I := 0 to Count - 1 do
-      GC.RemoveTempRoot(Iterators[I]);
-    for I := 0 to Count - 1 do
-      RemoveTempRootIfNeeded(Keys[I], KeyRoots[I]);
-    for I := 0 to Count - 1 do
-      RemoveTempRootIfNeeded(Padding[I], PaddingRoots[I]);
   end;
 end;
 

--- a/tests/language/expressions/compound-assignment-accessor-reads.js
+++ b/tests/language/expressions/compound-assignment-accessor-reads.js
@@ -242,4 +242,39 @@ describe("compound assignment on data properties", () => {
     }).toThrow(TypeError);
     expect(sideEffects).toBe(0);
   });
+
+  test("a nullish base with a symbol key reports the failure as a read", () => {
+    // §6.2.5.5 GetValue step 3.a rejects the base before step 3.c converts the
+    // key, so the message describes the read that failed rather than the store
+    // that never happened. Asserted as a fragment because the rest of the text
+    // names the symbol, whose description formatting is not what is under test.
+    const key = Symbol("count");
+    let sideEffects = 0;
+    let message = "";
+    const base = { missing: null };
+
+    expect(() => {
+      try {
+        base.missing[key] += (sideEffects += 1);
+      } catch (error) {
+        message = error.message;
+        throw error;
+      }
+    }).toThrow(TypeError);
+    expect(sideEffects).toBe(0);
+    expect(message).toContain("Cannot read properties of null");
+
+    const undefinedBase = {};
+    let undefinedMessage = "";
+
+    expect(() => {
+      try {
+        undefinedBase.missing[key] += 1;
+      } catch (error) {
+        undefinedMessage = error.message;
+        throw error;
+      }
+    }).toThrow(TypeError);
+    expect(undefinedMessage).toContain("Cannot read properties of undefined");
+  });
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Round-1 CodeRabbit fix layer for stack #1159 — one commit per finding, per the freeze-review process (frozen layers take no pushes; all fixes land here).

- **f9dc613** (#1158 finding, Minor): the integrity-fault opacity tests asserted only the escape; a host-side witness native now proves the guest `catch` block never executed, in both executors. Verified non-vacuous by neutering the guard (test fails) and by forcing the witness path (test fails the other way).
- **9028cde** (#1158 finding, Major): `IteratorZip`/`IteratorZipKeyed` removed temp roots in straight-line code after `Close*PreservingError`, so an integrity fault re-raised from a guest `return()` leaked roots (probe: delta=1 → 0). The five sites now clean up in `finally`; an audit of all 100+ close-helper call sites found no other unprotected cleanup.
- **4b29bc0** (#1158 finding, Major): `RunCallbacks` now clears the microtask queue and discards fetch completions before its terminal re-raises, mirroring the per-test arms, so pending host work cannot leak into a later test file.
- **1b9c2f0** (#1160 finding, Minor): `ReadSymbolProperty`'s nullish guard now throws the read-flavored TypeErrors. Honest scope note: this guard is currently unreachable (the coercible-base check throws first, identically in both modes) — the fix removes a latent trap and the new both-modes test locks the observable behavior; it is not a user-visible bug fix.

Maintainer question surfaced by the Major finding's audit, deliberately not changed here: the close helpers re-raise only engine-integrity faults, so limit-family errors (`MemoryLimitError` et al.) raised inside a guest `return()` during iterator close are still swallowed — ES2026 §7.4.10 says the original completion wins, but the ceiling contract says ceilings are uncatchable. One of the two has to give; `IsUncatchableFault` exists if the contract should win.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests — full suite 12,259 green in both executors; new symbol-key nullish tests in `compound-assignment-accessor-reads.js`
- [x] Updated documentation — none required; behavior changes are engine-internal hardening covered by the existing ADR 0109 prose
- [x] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests — `Goccia.MemoryLimit.Test` 13/13 with the hardened assertions; temp-root balance probe-verified on the re-raise path
- [ ] Optional: benchmark coverage — not applicable (error-path-only changes)
