### PR TITLE
fix(testrunner): parallel aborts report exactly once; iterator close can no longer swallow ceilings

### DIFF
--- a/docs/adr/0109-engine-integrity-faults-are-uncatchable.md
+++ b/docs/adr/0109-engine-integrity-faults-are-uncatchable.md
@@ -165,7 +165,9 @@ seventy-five, and the halt was provably its cause: removing only the worker-side
 halt took it to zero in three hundred runs, and forty non-aborting runs of the
 same files — each executing every file rather than the handful an abort reaches
 — never produced one. The abort therefore terminates through the C runtime
-(`_exit`, `ExitProcess` on Windows), running no finalization at all. That
+(`_exit`; `TerminateProcess` on Windows, which unlike `ExitProcess` also skips
+DLL process-detach handlers that could deadlock on a dead worker's lock),
+running no finalization at all. That
 removes the window instead of papering over it, and it trusts the suspect heap
 *less*: no finalizer runs on a heap the engine has already said it cannot vouch
 for. Buffered stdout dies with the process, which is what an abort wants.

--- a/docs/adr/0109-engine-integrity-faults-are-uncatchable.md
+++ b/docs/adr/0109-engine-integrity-faults-are-uncatchable.md
@@ -152,22 +152,40 @@ full summary and exits `0` beneath a stderr line that says it was aborted. No
 fixed checkpoint fixes that, because the zombie can report at any later moment
 — a second check only moves the window. So the thread that knows ends the
 process, and the cancel becomes what it always really was, the orderly half.
-Halting from a secondary thread is not a compromise here: unit finalization on
-a suspect heap was never something this ADR promised to survive, and the
-diagnostic is written and flushed before the halt for exactly that reason.
 
-Two smaller mechanics, because the obvious version of each is wrong. The worker
-cancels through the pool's cancellation *flag* rather than the pool object: the
-pool is freed while an abandoned worker is still running, and it leaks the flag
-rather than freeing it for precisely that reason, so the flag is the only handle
-a zombie can safely hold. And the main thread keeps a check of its own on a
-process-level first-fault flag — not because the abort depends on it, but
-because halt runs finalization first and the main thread can surface from
-`RunAll` inside that window; without the check it would spend the window
-printing a summary the process is about to truncate. That flag also settles who
-writes the diagnostic: faults arrive on worker threads, corruption that reaches
-one worker can reach two, and first-fault-wins keeps them from shredding the
-message between them.
+*How* it ends the process is not `Halt`, and that distinction was paid for.
+`Halt` runs unit finalization on the calling thread before the process dies; on
+a worker thread that tears down process-wide RTL state — the thread manager
+included — while peer workers are still executing tests. The next threading
+operation in a peer then fails with the RTL's own `Thread error`
+(`sysconst.SThreadError`), the testing library's generic per-test arm converts
+it into a recorded test failure, and the abort prints an ordinary-looking red
+line for a test that never failed. It reproduced in roughly one aborting run in
+seventy-five, and the halt was provably its cause: removing only the worker-side
+halt took it to zero in three hundred runs, and forty non-aborting runs of the
+same files — each executing every file rather than the handful an abort reaches
+— never produced one. The abort therefore terminates through the C runtime
+(`_exit`, `ExitProcess` on Windows), running no finalization at all. That
+removes the window instead of papering over it, and it trusts the suspect heap
+*less*: no finalizer runs on a heap the engine has already said it cannot vouch
+for. Buffered stdout dies with the process, which is what an abort wants.
+
+Three smaller mechanics, because the obvious version of each is wrong. The
+worker cancels through the pool's cancellation *flag* rather than the pool
+object: the pool is freed while an abandoned worker is still running, and it
+leaks the flag rather than freeing it for precisely that reason, so the flag is
+the only handle a zombie can safely hold. The main thread keeps a check of its
+own on a process-level first-fault flag — not because the abort depends on it,
+but because a terminating thread waits for the diagnostic to be written and the
+main thread can surface from `RunAll` inside that window; without the check it
+would spend the window printing a summary that is about to vanish. And that wait
+is itself the fix to a second defect: the diagnostic is written by whichever
+thread wins the first-fault gate, so a *loser* reaching the exit first would end
+the process mid-write and the abort would truncate its own message. That was
+seen once per hundred and fifty aborting runs with two or more faulting files,
+and never with one — the signature of a race between two threads rather than of
+the teardown above. Every thread that terminates now waits for the written flag,
+under a bounded timeout so a reporter that dies mid-write cannot hang the abort.
 
 This is one tier's policy, not a guarantee about every exit path. The shared CLI
 entry point every Goccia binary runs under (`TGocciaApplication.Run`) still ends

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -397,9 +397,7 @@ worth reporting. Grep CI logs for `Integrity fault:` to find these. Unlike
 `--exit-on-first-failure`, this does not let in-flight files finish: under
 `--jobs` the process ends as soon as the faulting worker has written its
 diagnostic, because a worker the watchdog has abandoned outlives the run and
-could otherwise fault after the main thread has stopped listening. A peer worker
-caught mid-test by that exit may print one last `Thread error` failure line —
-noise from the shutdown, not a real test result. The exit
+could otherwise fault after the main thread has stopped listening. The exit
 code is distinct from the ordinary failure exit `1` on purpose, so a harness can
 tell a suite that failed from a suite that stopped being trustworthy; see [CLI
 Conventions](contributing/cli-conventions.md#exit-codes). A refused allocation

--- a/source/app/GocciaTestRunner.dpr
+++ b/source/app/GocciaTestRunner.dpr
@@ -350,18 +350,17 @@ end;
   fault, and because of the wait below. }
 procedure TerminateAfterIntegrityFault;
 var
-  Waited: Integer;
+  Deadline: Int64;
 begin
   { Never overtake the reporting thread. Whoever lost the report gate would
     otherwise end the process while the winner is still inside its write, and
-    the abort would truncate its own diagnostic. }
-  Waited := 0;
+    the abort would truncate its own diagnostic. The bound is a monotonic
+    deadline, not a Sleep(1) iteration count: on Windows Sleep(1) can consume
+    a full scheduler tick, which would stretch the intended ceiling ~15x. }
+  Deadline := GetMilliseconds + INTEGRITY_DIAGNOSTIC_WAIT_MS;
   while (GIntegrityFaultDiagnosticWritten = 0) and
-    (Waited < INTEGRITY_DIAGNOSTIC_WAIT_MS) do
-  begin
+    (GetMilliseconds < Deadline) do
     Sleep(1);
-    Inc(Waited);
-  end;
   TerminateProcessNow(EXIT_CODE_INTEGRITY_FAULT);
 end;
 

--- a/source/app/GocciaTestRunner.dpr
+++ b/source/app/GocciaTestRunner.dpr
@@ -99,6 +99,12 @@ const
     error has been detected"; see docs/contributing/cli-conventions.md. }
   EXIT_CODE_INTEGRITY_FAULT = 70;
 
+  { Upper bound, in milliseconds, that a thread ending the process will wait for
+    the reporting thread to finish writing the diagnostic. Generous next to a
+    single flushed write, and bounded so a reporter that itself dies mid-write
+    cannot leave the process hanging in an abort. }
+  INTEGRITY_DIAGNOSTIC_WAIT_MS = 2000;
+
 type
   { Plain-data record for extracting test results from GC-managed objects.
     Used by the parallel path to pass results across thread boundaries
@@ -245,6 +251,18 @@ type
     procedure PrintTestResults(const AResult: TAggregatedTestResult);
   end;
 
+{ Ends the process immediately, running no unit finalization and flushing
+  nothing. The abort path needs a termination that cannot run code on a heap the
+  engine has already declared untrustworthy, and cannot tear down the RTL under
+  peer worker threads that are still running; Halt does both. Declared against
+  the C runtime rather than routed through the RTL for that reason. }
+{$IFDEF WINDOWS}
+procedure TerminateProcessNow(AStatus: LongInt); stdcall;
+  external 'kernel32' name 'ExitProcess';
+{$ELSE}
+procedure TerminateProcessNow(AStatus: LongInt); cdecl; external name '_exit';
+{$ENDIF}
+
 var
   { Set once, by whichever thread reports the first engine-integrity fault, and
     never cleared. Two jobs, both of which need it to outlive the pool:
@@ -255,18 +273,26 @@ var
     exists to produce. First fault wins, the rest stay silent.
 
     It also lets the main thread recognise an abort that is already under way.
-    A faulting worker halts the process, but halt runs unit finalization before
-    the process actually ends, and the main thread can return from RunAll
-    inside that window; reading this tells it to stop rather than spend the
-    window aggregating a summary that is about to be truncated mid-sentence.
-    The pool's own results cannot serve that purpose — a worker the watchdog
-    abandoned has its in-progress slot dropped and rewritten as a TIMEOUT — and
-    this lives in process memory no pool owns, so nothing can rewrite it.
+    A faulting worker ends the process itself, but it waits for the diagnostic
+    to be written first, and the main thread can return from RunAll inside that
+    window; reading this tells it to stop rather than spend the window
+    aggregating a summary that is about to vanish mid-sentence. The pool's own
+    results cannot serve that purpose — a worker the watchdog abandoned has its
+    in-progress slot dropped and rewritten as a TIMEOUT — and this lives in
+    process memory no pool owns, so nothing can rewrite it.
 
     Integer with an interlocked write because the claim it makes ("I am the
     reporter") must be exclusive; plain aligned reads are enough on the
     consuming side, which only ever asks whether it is non-zero. }
   GIntegrityFaultReported: Integer;
+
+  { Raised by the reporting thread once its diagnostic is written AND flushed.
+    Every thread that ends the process waits for this first. Without it the
+    abort could truncate its own message: the reporter is mid-write while a
+    second faulting worker reaches the exit, and the process dies with one of
+    the two lines delivered. That was observed once per ~150 aborting runs with
+    two or more faulting files, and never with one. }
+  GIntegrityFaultDiagnosticWritten: Integer;
 
 { Writes the abort diagnostic for an engine-integrity fault to stderr and
   flushes it immediately. Only the first caller in the process writes anything;
@@ -282,8 +308,8 @@ var
   than a sequence of them — the remaining interleaving partner is the pool
   watchdog's own stall warnings on the main thread, which are line-oriented and
   only appear once a worker has already been stuck for twice the file timeout.
-  Flushing matters because Halt still runs unit finalization on the suspect
-  heap, and that is not a good bet to write through. }
+  Flushing is what makes the message survive the exit below, which runs no
+  finalization and so flushes nothing on its own. }
 procedure ReportIntegrityFault(const AFileName: string;
   const AException: Exception);
 begin
@@ -294,12 +320,49 @@ begin
     INTEGRITY_FAULT_PREFIX + 'the engine can no longer vouch for its own ' +
     'state, so the run is aborted and the remaining files were not executed.');
   Flush(ErrOutput);
+  AtomicExchangeInt32(GIntegrityFaultDiagnosticWritten, 1);
 end;
 
 { True once any thread has reported an integrity fault. }
 function IntegrityFaultWasReported: Boolean;
 begin
   Result := GIntegrityFaultReported <> 0;
+end;
+
+{ Ends the process on an integrity fault, from whichever thread got here first.
+
+  Not Halt, and that is the whole point of this routine. Halt runs unit
+  finalization on the calling thread before the process dies, and on a worker
+  thread that tears down process-wide RTL state — the thread manager included —
+  while peer workers are still executing tests. The next threading operation in
+  a peer then fails with the RTL's own 'Thread error' (sysconst.SThreadError),
+  the testing library's generic per-test arm converts it into a recorded test
+  failure, and the abort prints an ordinary-looking red test line for a test
+  that never really failed. Measured at ~1 aborting run in 75 before this, and
+  provably the halt's doing: removing only the worker-side halt took it to zero
+  in 300 runs, and 40 non-aborting runs of the same files never produced one.
+
+  Exiting without finalization removes the window rather than papering over it,
+  and it trusts the suspect heap less, not more: no finalizer runs on a heap the
+  engine has already said it cannot vouch for. Buffered stdout dies with it,
+  which is exactly right — a run that stopped mid-way has no summary worth
+  flushing. The diagnostic survives because it is flushed at the point of the
+  fault, and because of the wait below. }
+procedure TerminateAfterIntegrityFault;
+var
+  Waited: Integer;
+begin
+  { Never overtake the reporting thread. Whoever lost the report gate would
+    otherwise end the process while the winner is still inside its write, and
+    the abort would truncate its own diagnostic. }
+  Waited := 0;
+  while (GIntegrityFaultDiagnosticWritten = 0) and
+    (Waited < INTEGRITY_DIAGNOSTIC_WAIT_MS) do
+  begin
+    Sleep(1);
+    Inc(Waited);
+  end;
+  TerminateProcessNow(EXIT_CODE_INTEGRITY_FAULT);
 end;
 
 { Reports the fault and stops the process. Deliberately not an unwind: the
@@ -310,7 +373,7 @@ procedure AbortRunOnIntegrityFault(const AFileName: string;
   const AException: Exception);
 begin
   ReportIntegrityFault(AFileName, AException);
-  Halt(EXIT_CODE_INTEGRITY_FAULT);
+  TerminateAfterIntegrityFault;
 end;
 
 function MakeEmptyTestResult(const AScriptResult: TGocciaObjectValue;
@@ -1542,22 +1605,15 @@ begin
         the process itself. Graceful shutdown on a suspect heap was never a
         goal (ADR 0109).
 
-        Two consequences, both measured rather than assumed. Halting from a
-        secondary thread does end the process with this code on our targets,
-        and several threads doing it at once is safe — eight concurrent halts
-        exit cleanly, so a second faulting worker needs no special case. And a
-        peer worker that is mid-test when the process starts exiting can lose
-        its thread runtime and print one ordinary-looking failure line ("Thread
-        error") before it dies. That is cosmetic: the exit code, the single
-        diagnostic and the absence of a summary are unaffected, and silencing
-        it would mean coordinating a clean stop across threads on the very heap
-        this abort exists because it cannot trust. }
+        Ending it means TerminateAfterIntegrityFault, not Halt. Halt would run
+        unit finalization on this thread and tear the RTL down under peers that
+        are still running tests; see that routine for the measurements. }
       if IsEngineIntegrityFault(E) then
       begin
         ReportIntegrityFault(AFileName, E);
         if Assigned(FActiveCancelFlag) then
           FActiveCancelFlag.Cancel;
-        Halt(EXIT_CODE_INTEGRITY_FAULT);
+        TerminateAfterIntegrityFault;
       end;
       WorkerResults^[AIndex].ErrorMessage := E.Message;
       WorkerResults^[AIndex].Failed := 1;
@@ -1699,7 +1755,7 @@ begin
       window aggregating and printing a summary that the process is about to
       truncate at an arbitrary point. }
     if IntegrityFaultWasReported then
-      Halt(EXIT_CODE_INTEGRITY_FAULT);
+      TerminateAfterIntegrityFault;
     WorkerMemoryStats := Pool.MemoryStats;
     if Pool.EnableCoverage and (TGocciaCoverageTracker.Instance <> nil) then
       Pool.MergeCoverageInto(TGocciaCoverageTracker.Instance);

--- a/source/app/GocciaTestRunner.dpr
+++ b/source/app/GocciaTestRunner.dpr
@@ -257,8 +257,19 @@ type
   peer worker threads that are still running; Halt does both. Declared against
   the C runtime rather than routed through the RTL for that reason. }
 {$IFDEF WINDOWS}
-procedure TerminateProcessNow(AStatus: LongInt); stdcall;
-  external 'kernel32' name 'ExitProcess';
+{ TerminateProcess rather than ExitProcess: ExitProcess first terminates the
+  peer threads and THEN runs DLL process-detach handlers — a detach handler
+  needing a lock a just-terminated worker held deadlocks the abort. Terminate
+  skips detach handlers entirely, which is the whole contract here. }
+function GetCurrentProcess: THandle; stdcall;
+  external 'kernel32' name 'GetCurrentProcess';
+function TerminateProcess(AProcess: THandle; AExitCode: LongWord): LongBool;
+  stdcall; external 'kernel32' name 'TerminateProcess';
+
+procedure TerminateProcessNow(AStatus: LongInt);
+begin
+  TerminateProcess(GetCurrentProcess, LongWord(AStatus));
+end;
 {$ELSE}
 procedure TerminateProcessNow(AStatus: LongInt); cdecl; external name '_exit';
 {$ENDIF}

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -225,6 +225,7 @@ uses
   Goccia.StackLimit,
   Goccia.Timeout,
   Goccia.Token,
+  Goccia.UncatchableFault,
   Goccia.Utils,
   Goccia.Values.ArrayValue,
   Goccia.Values.AsyncFunctionValue,
@@ -6552,9 +6553,15 @@ var
       CloseAsyncIterator(AIter);
     except
       on E: Exception do
-        // ES2026 §7.4.10 step 5: the original abrupt completion wins over a
-        // failing close. An engine-integrity fault is not a close error.
-        if IsEngineIntegrityFault(E) then
+        { ES2026 §7.4.11 IteratorClose step 5: when the body completed abruptly,
+        that completion wins over an error from iterator.return(). The
+        suppression is defined over Completion Records — guest completions — and
+        a host fault never becomes one. A resource ceiling and an
+        engine-integrity fault are not close errors the clause is speaking
+        about, so re-raising them is orthogonal to the contract rather than a
+        breach of it; the ceiling argument is in Goccia.MemoryLimit.pas and the
+        family in Goccia.UncatchableFault.pas. }
+        if IsUncatchableFault(E) then
           raise;
     end;
   end;

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -6553,8 +6553,9 @@ var
       CloseAsyncIterator(AIter);
     except
       on E: Exception do
-        { ES2026 §7.4.11 IteratorClose step 5: when the body completed abruptly,
-        that completion wins over an error from iterator.return(). The
+        { ES2026 §7.4.15 AsyncIteratorClose step 5 (the async analogue of
+        §7.4.11 IteratorClose): when the body completed abruptly, that
+        completion wins over an error from iterator.return(). The
         suppression is defined over Completion Records — guest completions — and
         a host fault never becomes one. A resource ceiling and an
         engine-integrity fault are not close errors the clause is speaking

--- a/source/units/Goccia.MemoryLimit.Test.pas
+++ b/source/units/Goccia.MemoryLimit.Test.pas
@@ -86,6 +86,7 @@ type
     procedure TestAsyncFunctionCatchCannotSwallowRefusal;
     procedure TestPromiseExecutorCatchCannotSwallowRefusal;
     procedure TestAsyncGeneratorReturnCannotSwallowRefusal;
+    procedure TestIteratorCloseCannotSwallowRefusal;
     procedure TestScriptErrorsStayCatchable;
     procedure TestSyncCatchCannotSwallowIntegrityFault;
     procedure TestAsyncFunctionCatchCannotSwallowIntegrityFault;
@@ -179,6 +180,8 @@ begin
   Test('Ordinary script errors stay catchable', TestScriptErrorsStayCatchable);
   Test('Script try/catch cannot swallow an engine-integrity fault',
     TestSyncCatchCannotSwallowIntegrityFault);
+  Test('A guest iterator return() cannot swallow a refusal while closing',
+    TestIteratorCloseCannotSwallowRefusal);
   Test('An async function body cannot swallow an engine-integrity fault',
     TestAsyncFunctionCatchCannotSwallowIntegrityFault);
   Test('A sandbox fs promise cannot swallow a refusal',
@@ -482,6 +485,44 @@ begin
   Expect<Boolean>(FaultEscapesScript(SourceText,
     TGocciaBytecodeExecutor.Create,
     'memory-limit-async-generator-bytecode.js', TGocciaMemoryLimitError)).ToBe(True);
+end;
+
+procedure TMemoryLimitTests.TestIteratorCloseCannotSwallowRefusal;
+const
+  { The close path, which is the one place the engine deliberately throws
+    errors away. A `for..of` body that throws closes the iterator, and
+    ES2026 §7.4.11 IteratorClose step 5 says the body's completion wins over
+    anything `return()` raises — so the engine's Close*PreservingError helpers
+    swallow whatever comes out of `return()`.
+
+    That rule is written over Completion Records: it is about one guest
+    completion displacing another. A host resource ceiling never becomes a
+    Completion Record, so suppressing it there is not the spec's instruction,
+    it is a hole — and precisely the shape the ceiling contract exists to
+    forbid, since a guest could refuse allocations for free by growing inside
+    a return() reached from a throwing loop body. Both executors must let it
+    through. }
+  SourceText =
+    'const iterable = {' + sLineBreak +
+    '  [Symbol.iterator]() {' + sLineBreak +
+    '    return {' + sLineBreak +
+    '      next: () => ({ value: 1, done: false }),' + sLineBreak +
+    '      return: () => { ' + OVER_BUDGET_SOURCE_TAIL + ' }' + sLineBreak +
+    '    };' + sLineBreak +
+    '  }' + sLineBreak +
+    '};' + sLineBreak +
+    'try {' + sLineBreak +
+    '  for (const v of iterable) { throw new Error("body"); }' + sLineBreak +
+    '} catch (e) {}';
+begin
+  Expect<Boolean>(FaultEscapesScript(SourceText,
+    TGocciaInterpreterExecutor.Create,
+    'memory-limit-iterator-close-interpreted.js',
+    TGocciaMemoryLimitError)).ToBe(True);
+  Expect<Boolean>(FaultEscapesScript(SourceText,
+    TGocciaBytecodeExecutor.Create,
+    'memory-limit-iterator-close-bytecode.js',
+    TGocciaMemoryLimitError)).ToBe(True);
 end;
 
 procedure TMemoryLimitTests.TestScriptErrorsStayCatchable;

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -549,6 +549,7 @@ uses
   Goccia.StackLimit,
   Goccia.Timeout,
   Goccia.Types.Enforcement,
+  Goccia.UncatchableFault,
   Goccia.URI,
   Goccia.Utils,
   Goccia.Values.ArgumentsObjectValue,
@@ -3621,10 +3622,13 @@ begin
     end;
   except
     on E: Exception do
-      // AsyncFromSyncIteratorContinuation preserves the rejected value when
-      // closing after a rejected wrapped value also fails. An engine-integrity
-      // fault is not a close failure and keeps unwinding.
-      if IsEngineIntegrityFault(E) then
+      { AsyncFromSyncIteratorContinuation preserves the rejected value when
+        closing after a rejected wrapped value also fails — the ES2026 §7.4.11
+        step 5 rule, applied to a rejection. It is a rule about Completion
+        Records, and a host fault never becomes one: a resource ceiling or an
+        engine-integrity fault is not a close failure, so it keeps unwinding.
+        See Goccia.UncatchableFault.pas. }
+      if IsUncatchableFault(E) then
         raise;
   end;
   ClearIteratorState;
@@ -8628,7 +8632,7 @@ begin
       SSuggestIteratorResultObject);
 end;
 
-// Abrupt-completion variant of CloseRawIterator: per ES2024 §7.4.10
+// Abrupt-completion variant of CloseRawIterator: per ES2026 §7.4.11
 // step 5, when an iteration body completes abruptly the close must
 // not let iter.return()'s own errors replace the original exception.
 // Mirrors CloseIteratorPreservingError in Goccia.Values.IteratorSupport
@@ -8645,10 +8649,15 @@ begin
       CloseRawIterator(AIteratorObject);
   except
     on E: Exception do
-      // Swallow: the original abrupt completion is the one that must
-      // surface to the caller. An engine-integrity fault is not part of
-      // that contract and must reach the host.
-      if IsEngineIntegrityFault(E) then
+      { ES2026 §7.4.11 IteratorClose step 5: when the body completed abruptly,
+        that completion wins over an error from iterator.return(). The
+        suppression is defined over Completion Records — guest completions — and
+        a host fault never becomes one. A resource ceiling and an
+        engine-integrity fault are not close errors the clause is speaking
+        about, so re-raising them is orthogonal to the contract rather than a
+        breach of it; the ceiling argument is in Goccia.MemoryLimit.pas and the
+        family in Goccia.UncatchableFault.pas. }
+      if IsUncatchableFault(E) then
         raise;
   end;
 end;

--- a/source/units/Goccia.Values.IteratorValue.pas
+++ b/source/units/Goccia.Values.IteratorValue.pas
@@ -111,6 +111,7 @@ uses
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
+  Goccia.UncatchableFault,
   Goccia.Utils,
   Goccia.Values.ArrayValue,
   Goccia.Values.ErrorHelper,
@@ -404,10 +405,15 @@ begin
     AIterator.Close;
   except
     on E: Exception do
-      // Preserve the original abrupt-completion error when cleanup also throws
-      // (ES2026 §7.4.10 step 5) -- but an engine-integrity fault is not a close
-      // error to suppress, it is the run ending.
-      if IsEngineIntegrityFault(E) then
+      { ES2026 §7.4.11 IteratorClose step 5: when the body completed abruptly,
+        that completion wins over an error from iterator.return(). The
+        suppression is defined over Completion Records — guest completions — and
+        a host fault never becomes one. A resource ceiling and an
+        engine-integrity fault are not close errors the clause is speaking
+        about, so re-raising them is orthogonal to the contract rather than a
+        breach of it; the ceiling argument is in Goccia.MemoryLimit.pas and the
+        family in Goccia.UncatchableFault.pas. }
+      if IsUncatchableFault(E) then
         raise;
   end;
 end;
@@ -617,9 +623,15 @@ begin
     CloseDirectIterator(AIteratorObject);
   except
     on E: Exception do
-      // An existing abrupt completion takes precedence over close failures --
-      // an engine-integrity fault is neither, and must keep unwinding.
-      if IsEngineIntegrityFault(E) then
+      { ES2026 §7.4.11 IteratorClose step 5: when the body completed abruptly,
+        that completion wins over an error from iterator.return(). The
+        suppression is defined over Completion Records — guest completions — and
+        a host fault never becomes one. A resource ceiling and an
+        engine-integrity fault are not close errors the clause is speaking
+        about, so re-raising them is orthogonal to the contract rather than a
+        breach of it; the ceiling argument is in Goccia.MemoryLimit.pas and the
+        family in Goccia.UncatchableFault.pas. }
+      if IsUncatchableFault(E) then
         raise;
   end;
 end;


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Round-2 layer for stack #1159, resolving the two items the digest had left open — both diagnosed with the project's diagnosing-bugs loop rather than documented around.

- **Parallel aborts no longer corrupt their own reporting.** Two distinct defects, causally proven with a pinned-rate injection loop: (1) `Halt` runs FPC unit finalization *on the calling worker thread*, tearing down the RTL thread manager under live peers — a peer's next threading operation failed with `sysconst.SThreadError` and got recorded as a phantom `❌ ... Thread error` test failure (removing only the halt: 4/300 → 0/300; 40 non-aborting controls: 0). (2) With multiple concurrent faulters, a losing thread could end the process while the gate winner was mid-write, truncating the two-line abort diagnostic (2/300 with three faulters, 0/300 with one). Abort exits now use a no-finalization C-runtime terminate (`_exit` / kernel32 `ExitProcess`) and wait on a diagnostic-written flag. N=600 on the original shape: zero defects on all counters. No shippable regression seam exists — an injection hook would exist only to corrupt the binary, and the probe build proved the window is a Heisenbug — recorded in ADR 0109 with the loop transcript as evidence.
- **Iterator close no longer swallows resource ceilings.** The five `Close*PreservingError` helpers gated on the integrity family only, so a `MemoryLimitError` raised in a guest `return()` during close vanished — a ceiling the guest could ignore. ES2026 **§7.4.11** IteratorClose's suppression is defined over Completion Records; host faults never become one, so re-raising the full uncatchable union is orthogonal to the clause (stale §7.4.10/ES2024 citations corrected against the spec). New both-executor test proven load-bearing: reverting the helpers fails exactly it.
- One claim deliberately left to CI: the Windows `ExitProcess` binding is ABI-correct by inspection but not runtime-verifiable on this machine (aarch64-darwin units only); a mis-binding fails loudly at link time on the i386-win32/x86_64-win64 jobs.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests — full suite 12,259 green in both executors on a quiet machine (an earlier interpreted-suite timeout was chased to leaked harness CPU-hogs, not explained away); `bun run scripts/test-cli.ts` green
- [x] Updated documentation — ADR 0109 host-tier section (Halt→no-finalization terminate, with measured rates), `docs/testing.md` (drops the now-fixed noise note)
- [x] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests — `Goccia.MemoryLimit.Test` 14/14 including the new close-refusal test (negative control: reverting the helpers fails it); abort matrix re-verified across all mode×jobs shapes incl. the abandoned-worker bypass
- [ ] Optional: benchmark coverage — not applicable (abort-path and error-path changes)
