### PR TITLE
perf(gc): O(1) active-root frame ops; descriptors learn PushRoots

### DIFF
--- a/source/units/Goccia.GarbageCollector.Test.pas
+++ b/source/units/Goccia.GarbageCollector.Test.pas
@@ -8,10 +8,21 @@ uses
   Goccia.GarbageCollector,
   TestingPascalLibrary,
 
-  Goccia.TestSetup;
+  Goccia.TestSetup,
+  Goccia.Values.ObjectPropertyDescriptor,
+  Goccia.Values.ObjectValue,
+  Goccia.Values.Primitives;
 
 type
   TChildManaged = class(TGCManagedObject)
+  public
+    destructor Destroy; override;
+  end;
+
+  { A real TGocciaValue, so a descriptor can hold it, that reports its own
+    sweep. Created with a nil prototype: nothing here reads a property, and a
+    standalone object keeps the suite free of engine setup. }
+  TCountedObjectValue = class(TGocciaObjectValue)
   public
     destructor Destroy; override;
   end;
@@ -34,11 +45,16 @@ type
     procedure TestReservationCollectsBeyondPressureReserve;
     procedure TestReservationRefusesWhatCollectionCannotFit;
     procedure TestRepeatedRefusalCollectsOnlyOnce;
+    procedure TestDataDescriptorPushRootsProtectsValue;
+    procedure TestAccessorDescriptorPushRootsProtectsBothHalves;
+    procedure TestInnerFrameClearLeavesOuterFrameRootsIntact;
+    procedure TestActiveRootStackGrowsPastInitialCapacity;
   end;
 
 var
   GParentDestructorCount: Integer;
   GChildDestructorCount: Integer;
+  GCountedValueDestructorCount: Integer;
 
 destructor TChildManaged.Destroy;
 begin
@@ -49,6 +65,12 @@ end;
 destructor TParentManaged.Destroy;
 begin
   Inc(GParentDestructorCount);
+  inherited;
+end;
+
+destructor TCountedObjectValue.Destroy;
+begin
+  Inc(GCountedValueDestructorCount);
   inherited;
 end;
 
@@ -73,6 +95,163 @@ begin
     TestReservationRefusesWhatCollectionCannotFit);
   Test('Repeated refusal of the same size collects only once',
     TestRepeatedRefusalCollectsOnlyOnce);
+  Test('Data descriptor PushRoots keeps its value alive across a collection',
+    TestDataDescriptorPushRootsProtectsValue);
+  Test('Accessor descriptor PushRoots keeps getter and setter alive',
+    TestAccessorDescriptorPushRootsProtectsBothHalves);
+  Test('Clearing an inner frame leaves an outer frame''s roots intact',
+    TestInnerFrameClearLeavesOuterFrameRootsIntact);
+  Test('The active-root stack grows past its initial capacity and releases',
+    TestActiveRootStackGrowsPastInitialCapacity);
+end;
+
+procedure TTestGarbageCollector.TestDataDescriptorPushRootsProtectsValue;
+var
+  Descriptor: TGocciaPropertyDescriptorData;
+  GC: TGarbageCollector;
+  Roots: TGocciaActiveRootFrame;
+begin
+  GC := TGarbageCollector.Instance;
+  GC.Collect;
+  GCountedValueDestructorCount := 0;
+
+  { The descriptor is a plain class, not a managed object, so it is not itself
+    a root: without PushRoots the value it points at is unreachable the moment
+    the only other reference to it is a Pascal local. }
+  Descriptor := TGocciaPropertyDescriptorData.Create(
+    TCountedObjectValue.Create, [pfWritable, pfEnumerable, pfConfigurable]);
+  try
+    Roots.Initialize;
+    try
+      Descriptor.PushRoots(Roots);
+      GC.Collect;
+      Expect<Integer>(GCountedValueDestructorCount).ToBe(0);
+    finally
+      Roots.Clear;
+    end;
+
+    { Clearing twice must be a no-op, not a second release: the frames this
+      primitive serves are cleared in nested finally blocks during unwind. }
+    Roots.Clear;
+
+    GC.Collect;
+    Expect<Integer>(GCountedValueDestructorCount).ToBe(1);
+  finally
+    Descriptor.Free;
+  end;
+end;
+
+procedure TTestGarbageCollector.TestAccessorDescriptorPushRootsProtectsBothHalves;
+var
+  Descriptor: TGocciaPropertyDescriptorAccessor;
+  GC: TGarbageCollector;
+  GetterOnly: TGocciaPropertyDescriptorAccessor;
+  Roots: TGocciaActiveRootFrame;
+begin
+  GC := TGarbageCollector.Instance;
+  GC.Collect;
+  GCountedValueDestructorCount := 0;
+
+  Descriptor := TGocciaPropertyDescriptorAccessor.Create(
+    TCountedObjectValue.Create, TCountedObjectValue.Create, [pfConfigurable]);
+  { A setter-less accessor is the ordinary case, and PushRoots must drop the
+    nil half rather than push it. }
+  GetterOnly := TGocciaPropertyDescriptorAccessor.Create(
+    TCountedObjectValue.Create, nil, [pfConfigurable]);
+  try
+    Roots.Initialize;
+    try
+      Descriptor.PushRoots(Roots);
+      GetterOnly.PushRoots(Roots);
+      GC.Collect;
+      Expect<Integer>(GCountedValueDestructorCount).ToBe(0);
+    finally
+      Roots.Clear;
+    end;
+
+    GC.Collect;
+    Expect<Integer>(GCountedValueDestructorCount).ToBe(3);
+  finally
+    Descriptor.Free;
+    GetterOnly.Free;
+  end;
+end;
+
+procedure TTestGarbageCollector.TestInnerFrameClearLeavesOuterFrameRootsIntact;
+var
+  GC: TGarbageCollector;
+  InnerRoots: TGocciaActiveRootFrame;
+  InnerValue: TCountedObjectValue;
+  OuterRoots: TGocciaActiveRootFrame;
+  OuterValue: TCountedObjectValue;
+begin
+  GC := TGarbageCollector.Instance;
+  GC.Collect;
+  GCountedValueDestructorCount := 0;
+
+  { Both frames are Initialized at the same depth and then added to in
+    interleaved order — a strictly harder shape than the promise combinators,
+    where the inner frame is merely Initialized before the outer has pushed.
+    Releasing to a recorded base depth would make the inner Clear take the
+    outer frame's entry with it; releasing the frame's own count cannot. }
+  OuterRoots.Initialize;
+  InnerRoots.Initialize;
+  try
+    OuterValue := TCountedObjectValue.Create;
+    OuterRoots.Add(OuterValue);
+    InnerValue := TCountedObjectValue.Create;
+    InnerRoots.Add(InnerValue);
+
+    GC.Collect;
+    Expect<Integer>(GCountedValueDestructorCount).ToBe(0);
+
+    InnerRoots.Clear;
+    GC.Collect;
+    Expect<Integer>(GCountedValueDestructorCount).ToBe(1);
+
+    { Re-adding after a Clear rolls back against the current depth, so a frame
+      reused across loop iterations stays correct. }
+    InnerRoots.Add(OuterValue);
+    InnerRoots.Clear;
+    GC.Collect;
+    Expect<Integer>(GCountedValueDestructorCount).ToBe(1);
+  finally
+    OuterRoots.Clear;
+  end;
+
+  GC.Collect;
+  Expect<Integer>(GCountedValueDestructorCount).ToBe(2);
+end;
+
+procedure TTestGarbageCollector.TestActiveRootStackGrowsPastInitialCapacity;
+const
+  { Two doublings past the stack's initial 256-slot capacity, so the growth
+    path itself is under test, not just the fast path the other tests touch. }
+  PUSH_COUNT = 600;
+var
+  GC: TGarbageCollector;
+  I: Integer;
+  Roots: TGocciaActiveRootFrame;
+begin
+  GC := TGarbageCollector.Instance;
+  GC.Collect;
+  GCountedValueDestructorCount := 0;
+
+  Roots.Initialize;
+  try
+    for I := 1 to PUSH_COUNT do
+      Roots.Add(TCountedObjectValue.Create);
+
+    { Every pushed value must survive a collection while the frame holds it —
+      a growth bug that dropped or duplicated slots would surface here. }
+    GC.Collect;
+    Expect<Integer>(GCountedValueDestructorCount).ToBe(0);
+  finally
+    Roots.Clear;
+  end;
+
+  GC.Collect;
+  Expect<Integer>(GCountedValueDestructorCount).ToBe(PUSH_COUNT);
 end;
 
 procedure TTestGarbageCollector.TestReservationCollectsAndRetries;

--- a/source/units/Goccia.GarbageCollector.pas
+++ b/source/units/Goccia.GarbageCollector.pas
@@ -53,6 +53,13 @@ type
   end;
 
   TGCManagedObjectList = TObjectList<TGCManagedObject>;
+  // Backing store for the active-root stack only. A bare array rather than
+  // TGCManagedObjectList because that stack is pushed and popped once per
+  // rooted evaluator temporary: TObjectList pays a virtual Notify dispatch per
+  // Add and per Delete, and Delete additionally moves the tail, none of which
+  // buys anything for a non-owning LIFO stack whose element type is a plain
+  // class reference.
+  TGCManagedObjectArray = array of TGCManagedObject;
   TGCRootSourceList = TList<TGCRootSource>;
   TGCObjectSet = THashMap<TGCManagedObject, Boolean>;
   TGCObjectRefCounts = THashMap<TGCManagedObject, Integer>;
@@ -63,8 +70,42 @@ type
     Added: Boolean;
   end;
 
+  // A stack-local group of GC roots. Initialize before first use, Add every
+  // value that must survive a collecting safe point, and Clear in a finally so
+  // the exception path is covered. Add tolerates nil and tolerates the same
+  // object twice, which is what makes it the right tool for evaluator
+  // temporaries where two locals can hold one object.
+  //
+  // Release is a count rollback, not a per-entry pop: Clear releases exactly
+  // the top FCount entries of the collector's active-root stack in one
+  // assignment. That is what the pop loop it replaces did, entry for entry, so
+  // frames that share a base depth keep behaving as they do today — in the
+  // promise combinators the inner per-iteration frame is Initialized before
+  // the outer frame has pushed anything, so its recorded base depth sits
+  // below the outer frame's entries, and releasing to that base depth instead
+  // would let the inner frame's Clear take the outer frame's roots with it.
+  //
+  // FBaseDepth is therefore a floor, not a target: Clear never unwinds past
+  // the depth the frame was Initialized at, so a frame cannot eat an enclosing
+  // frame's roots even if the stack is left unbalanced beneath it. Clear is
+  // idempotent — the second call has no entries to release and returns without
+  // touching the stack, which is what makes clearing a frame in an inner
+  // finally and again in an outer one safe during exception unwind.
   TGocciaActiveRootFrame = record
   private
+    // Resolved once in Initialize: Add runs per rooted temporary on the
+    // property-store path, and re-reading the collector threadvar there costs
+    // more than the push itself. nil means "no collector on this thread", and
+    // the frame stays a no-op for its whole lifetime.
+    //
+    // Invariant: a frame must not outlive the collector it was Initialized
+    // against. Clear dereferences this cached pointer, so a frame still live
+    // across TGarbageCollector.Shutdown would touch freed memory — and an
+    // Assigned check could not save it, because the stale pointer stays
+    // non-nil. Every current Shutdown site (thread runtime teardown, app
+    // mains, test suite teardowns) runs with no frame live; keep it that way.
+    FCollector: TGarbageCollector;
+    FBaseDepth: Integer;
     FCount: Integer;
   public
     procedure Initialize; {$IFDEF FPC}inline;{$ENDIF}
@@ -81,7 +122,8 @@ type
     FQueuedRoots: TGCObjectRefCounts;
     FKeptObjects: TGCObjectSet;
     FRootObjects: TGCObjectSet;
-    FActiveRootStack: TGCManagedObjectList;
+    FActiveRootStack: TGCManagedObjectArray;
+    FActiveRootCount: Integer;
     // Weak containers (WeakMap/WeakSet/WeakRef/FinalizationRegistry) that have
     // held weak data: a container joins on its first weak insertion and leaves
     // only when it is itself collected, so an emptied-but-live container stays
@@ -122,6 +164,7 @@ type
     function GetManagedObjectCount: Integer;
     function GetWatermark: Integer; {$IFDEF FPC}inline;{$ENDIF}
     procedure ClearActiveRootEntries(const AObject: TGCManagedObject);
+    procedure GrowActiveRootStack;
     function ShouldForceReservationCollection(const ABytes: Int64): Boolean;
   protected
     procedure MarkRoots; virtual;
@@ -155,7 +198,13 @@ type
     procedure AddRootObject(const AObject: TGCManagedObject);
     procedure RemoveRootObject(const AObject: TGCManagedObject);
     procedure PushActiveRoot(const AObject: TGCManagedObject);
-    procedure PopActiveRoot;
+    procedure PopActiveRoot; {$IFDEF FPC}inline;{$ENDIF}
+
+    // Release the top ACount active roots in one step, never unwinding below
+    // AFloorDepth. Equivalent to ACount PopActiveRoot calls at O(1) instead of
+    // O(ACount); the floor is the guard described at TGocciaActiveRootFrame.
+    procedure ReleaseActiveRoots(const ACount: Integer;
+      const AFloorDepth: Integer);
 
     // Full mark-and-sweep of all managed objects. Unconditional — ignores
     // the Enabled flag and always runs. Use when a clean heap is required
@@ -203,6 +252,11 @@ type
     property TotalCollections: Integer read FTotalCollections;
     property ManagedObjectCount: Integer read GetManagedObjectCount;
 
+    // Current depth of the active-root stack. Captured by
+    // TGocciaActiveRootFrame.Initialize as the floor its Clear may not
+    // unwind past.
+    property ActiveRootDepth: Integer read FActiveRootCount;
+
     // Byte-level memory tracking. BytesAllocated is the approximate
     // number of bytes currently tracked by the GC (InstanceSize per
     // registered object). Set MaxBytes to a positive value to impose
@@ -247,6 +301,11 @@ uses
   SysUtils
   {$IFDEF GC_TIMING}, TimingUtils{$ENDIF}
   {$ENDIF};
+
+const
+  // Slots pre-allocated for the active-root stack, and the unit it doubles
+  // from. Deep enough that ordinary evaluator nesting never reallocates.
+  ACTIVE_ROOT_STACK_INITIAL_CAPACITY = 256;
 
 function DetectDefaultMaxBytes: Int64;
 var
@@ -391,37 +450,30 @@ end;
 
 procedure TGocciaActiveRootFrame.Initialize;
 begin
+  FCollector := TGarbageCollector.Instance;
+  if Assigned(FCollector) then
+    FBaseDepth := FCollector.ActiveRootDepth
+  else
+    FBaseDepth := 0;
   FCount := 0;
 end;
 
 procedure TGocciaActiveRootFrame.Add(const AObject: TGCManagedObject);
-var
-  GC: TGarbageCollector;
 begin
-  if not Assigned(AObject) then
+  if not Assigned(AObject) or not Assigned(FCollector) then
     Exit;
-  GC := TGarbageCollector.Instance;
-  if not Assigned(GC) then
-    Exit;
-  GC.PushActiveRoot(AObject);
+  FCollector.PushActiveRoot(AObject);
   Inc(FCount);
 end;
 
 procedure TGocciaActiveRootFrame.Clear;
-var
-  GC: TGarbageCollector;
 begin
+  // FCount > 0 implies a collector: Add is the only thing that increments it,
+  // and it only does so after pushing onto an assigned collector.
   if FCount <= 0 then
     Exit;
-  GC := TGarbageCollector.Instance;
-  if Assigned(GC) then
-    while FCount > 0 do
-    begin
-      GC.PopActiveRoot;
-      Dec(FCount);
-    end
-  else
-    FCount := 0;
+  FCollector.ReleaseActiveRoots(FCount, FBaseDepth);
+  FCount := 0;
 end;
 
 { TGarbageCollector }
@@ -457,7 +509,8 @@ begin
   FQueuedRoots := TGCObjectRefCounts.Create;
   FKeptObjects := TGCObjectSet.Create;
   FRootObjects := TGCObjectSet.Create;
-  FActiveRootStack := TGCManagedObjectList.Create(False);
+  SetLength(FActiveRootStack, ACTIVE_ROOT_STACK_INITIAL_CAPACITY);
+  FActiveRootCount := 0;
   FWeakContainers := TGCObjectSet.Create;
   FAllocationsSinceLastGC := 0;
   FGCThreshold := DEFAULT_GC_THRESHOLD;
@@ -507,7 +560,8 @@ begin
   FQueuedRoots.Free;
   FKeptObjects.Free;
   FRootObjects.Free;
-  FActiveRootStack.Free;
+  FActiveRootCount := 0;
+  SetLength(FActiveRootStack, 0);
   FWeakContainers.Free;
   inherited;
 end;
@@ -627,9 +681,7 @@ procedure TGarbageCollector.ClearActiveRootEntries(
 var
   I: Integer;
 begin
-  if not Assigned(FActiveRootStack) then
-    Exit;
-  for I := FActiveRootStack.Count - 1 downto 0 do
+  for I := FActiveRootCount - 1 downto 0 do
     if FActiveRootStack[I] = AObject then
       FActiveRootStack[I] := nil;
 end;
@@ -717,16 +769,43 @@ begin
   FRootObjects.Remove(AObject);
 end;
 
+procedure TGarbageCollector.GrowActiveRootStack;
+begin
+  if Length(FActiveRootStack) = 0 then
+    SetLength(FActiveRootStack, ACTIVE_ROOT_STACK_INITIAL_CAPACITY)
+  else
+    SetLength(FActiveRootStack, Length(FActiveRootStack) * 2);
+end;
+
 procedure TGarbageCollector.PushActiveRoot(
   const AObject: TGCManagedObject);
 begin
-  FActiveRootStack.Add(AObject);
+  if FActiveRootCount = Length(FActiveRootStack) then
+    GrowActiveRootStack;
+  FActiveRootStack[FActiveRootCount] := AObject;
+  Inc(FActiveRootCount);
 end;
 
 procedure TGarbageCollector.PopActiveRoot;
 begin
-  if FActiveRootStack.Count > 0 then
-    FActiveRootStack.Delete(FActiveRootStack.Count - 1);
+  if FActiveRootCount > 0 then
+    Dec(FActiveRootCount);
+end;
+
+procedure TGarbageCollector.ReleaseActiveRoots(const ACount: Integer;
+  const AFloorDepth: Integer);
+var
+  Target: Integer;
+begin
+  if ACount <= 0 then
+    Exit;
+  Target := FActiveRootCount - ACount;
+  if Target < AFloorDepth then
+    Target := AFloorDepth;
+  if Target < 0 then
+    Target := 0;
+  if Target < FActiveRootCount then
+    FActiveRootCount := Target;
 end;
 
 procedure TGarbageCollector.MarkRoots;
@@ -750,7 +829,7 @@ begin
   for Pair in FRootObjects do
     Pair.Key.MarkReferences;
 
-  for I := 0 to FActiveRootStack.Count - 1 do
+  for I := 0 to FActiveRootCount - 1 do
     if Assigned(FActiveRootStack[I]) then
       FActiveRootStack[I].MarkReferences;
 
@@ -912,12 +991,12 @@ begin
      FCollecting then
     Exit;
   if Assigned(AProtect) then
-    FActiveRootStack.Add(AProtect);
+    PushActiveRoot(AProtect);
   try
     Collect;
   finally
     if Assigned(AProtect) then
-      FActiveRootStack.Delete(FActiveRootStack.Count - 1);
+      PopActiveRoot;
   end;
 end;
 
@@ -952,7 +1031,7 @@ begin
     Exit;
 
   if Assigned(AProtect) then
-    FActiveRootStack.Add(AProtect);
+    PushActiveRoot(AProtect);
   WasFiring := FMemoryLimitFiring;
   FMemoryLimitFiring := True;
   try
@@ -960,7 +1039,7 @@ begin
   finally
     FMemoryLimitFiring := WasFiring;
     if Assigned(AProtect) then
-      FActiveRootStack.Delete(FActiveRootStack.Count - 1);
+      PopActiveRoot;
   end;
 end;
 

--- a/source/units/Goccia.Values.ObjectPropertyDescriptor.pas
+++ b/source/units/Goccia.Values.ObjectPropertyDescriptor.pas
@@ -7,6 +7,7 @@ interface
 uses
   OrderedStringMap,
 
+  Goccia.GarbageCollector,
   Goccia.Values.Primitives;
 
 type
@@ -40,6 +41,21 @@ type
       const AFields: TPropertyDescriptorFields);
     procedure MarkValues; virtual;
 
+    // Root what this descriptor points at RIGHT NOW for the lifetime of
+    // AFrame. MarkValues answers the collector's question — "what does this
+    // descriptor reach?" — from inside a collection; this answers the
+    // caller's — "what must survive the safe point I am about to cross?" —
+    // from outside one. A descriptor read out of a property map is a plain
+    // class, not a managed object, so nothing roots the values it points at
+    // once the map entry it came from can be replaced.
+    //
+    // "Right now" is load-bearing for lazy descriptors: they push their
+    // pinned placeholder, not the value their factory would produce, so a
+    // caller must Materialize BEFORE PushRoots — push-then-materialize
+    // leaves the freshly built value unrooted, which is the exact hazard
+    // this method exists to close.
+    procedure PushRoots(var AFrame: TGocciaActiveRootFrame); virtual;
+
     property Flags: TPropertyFlags read FFlags;
     property Fields: TPropertyDescriptorFields read FFields;
     property Enumerable: Boolean read GetEnumerable;
@@ -61,6 +77,7 @@ type
     constructor CreatePartial(const AValue: TGocciaValue;
       const AFlags: TPropertyFlags; const AFields: TPropertyDescriptorFields);
     procedure MarkValues; override;
+    procedure PushRoots(var AFrame: TGocciaActiveRootFrame); override;
 
     property Value: TGocciaValue read FValue write FValue;
   end;
@@ -102,6 +119,7 @@ type
       const ASetter: TGocciaValue; const AFlags: TPropertyFlags;
       const AFields: TPropertyDescriptorFields);
     procedure MarkValues; override;
+    procedure PushRoots(var AFrame: TGocciaActiveRootFrame); override;
 
     property Getter: TGocciaValue read FGetter;
     property Setter: TGocciaValue read FSetter;
@@ -186,6 +204,13 @@ begin
   // No-op base: subclasses override to mark their value references
 end;
 
+procedure TGocciaPropertyDescriptor.PushRoots(
+  var AFrame: TGocciaActiveRootFrame);
+begin
+  // No-op base: a descriptor with neither a value nor an accessor pair holds
+  // nothing to root. Subclasses override to push what they hold.
+end;
+
 constructor TGocciaPropertyDescriptorData.Create(const AValue: TGocciaValue; const AFlags: TPropertyFlags);
 begin
   inherited Create(AFlags,
@@ -205,6 +230,15 @@ procedure TGocciaPropertyDescriptorData.MarkValues;
 begin
   if Assigned(FValue) then
     FValue.MarkReferences;
+end;
+
+procedure TGocciaPropertyDescriptorData.PushRoots(
+  var AFrame: TGocciaActiveRootFrame);
+begin
+  // Deliberately not materialized: a lazy descriptor's placeholder is what is
+  // reachable right now, and forcing the factory here would allocate on a path
+  // whose only job is to protect what already exists.
+  AFrame.Add(FValue);
 end;
 
 constructor TGocciaLazyPropertyDescriptorData.Create(
@@ -264,6 +298,15 @@ begin
     FGetter.MarkReferences;
   if Assigned(FSetter) then
     FSetter.MarkReferences;
+end;
+
+procedure TGocciaPropertyDescriptorAccessor.PushRoots(
+  var AFrame: TGocciaActiveRootFrame);
+begin
+  // Either half may be nil — a getter-only or setter-only accessor is the
+  // ordinary case, and the frame drops nil without pushing.
+  AFrame.Add(FGetter);
+  AFrame.Add(FSetter);
 end;
 
 function TGocciaPropertyDescriptorAccessor.GetWritable: Boolean;


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Layer L1 of the #1157 rooting train (design record in the train's tracking discussion): the active-root frame primitive gets cheap before the store-internal layers put more weight on it. No behavior change.
- Two measured costs removed: `TGocciaActiveRootFrame.Add` re-read the collector threadvar on every push (now cached at `Initialize`), and pops paid `TObjectList.Delete`'s `Notify` dispatch and element move (the stack is now a raw non-owning array with count truncation — O(1) push, pop, and frame `Clear`).
- `Clear` is a **count rollback, not absolute truncation** — the promise combinators `Initialize` an inner frame before the outer frame has pushed anything, so truncating to the recorded base depth would silently release the outer frame's roots. The base depth survives only as a clamp floor, and the nesting test fails the absolute-truncation mutation. The frame-must-not-outlive-its-collector invariant is documented where the cached pointer lives.
- `TGocciaPropertyDescriptor` gains virtual `PushRoots` (data → value; accessor → both halves, nil-tolerant) — the API the L2/L3 store-internal layers consume. Lazy descriptors push their pinned placeholder: the contract is materialize-before-push, documented at the base method.
- Measured on production builds (5-run medians, interleaved A/B): interpreter store shapes +1.0–3.5% (create-8-props +3.0%), bytecode all within ±0.55% — expected, the VM roots registers separately.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests — full suite 12,259 green in both executors
- [x] Updated documentation — invariants documented at the declaration sites (frame/collector lifetime, rollback-vs-truncation rationale, lazy-descriptor push contract); no docs/ page describes the primitive's internals
- [x] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests — `Goccia.GarbageCollector.Test` 9/9 including three new tests (descriptor PushRoots ×2, frame nesting) and a growth test crossing two stack doublings; mutation-checked (absolute truncation and stubbed PushRoots each fail exactly their test)
- [x] Optional: Verified no benchmark regressions — the store-hot-path microbenchmark table above; neutral-to-positive on every shape in both modes

Review provenance: fresh-context adversarial review; all findings (teardown invariant, lazy-push contract, comment accuracy, growth coverage) applied before commit.
