### PR TITLE
fix(ci): coverage CLI checks no longer flake on broken-pipe races

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,8 +322,8 @@ jobs:
       - name: Check GocciaTestRunner coverage CLI
         run: |
           cov_output="$(./build/GocciaTestRunner tests/built-ins/Array/array-creation.js --coverage 2>&1)"
-          printf '%s\n' "$cov_output" | grep -q 'Coverage Summary:'
-          printf '%s\n' "$cov_output" | grep -q 'array-creation.js'
+          [[ "$cov_output" == *'Coverage Summary:'* ]]
+          [[ "$cov_output" == *'array-creation.js'* ]]
 
           ./build/GocciaTestRunner tests/built-ins/Array/array-creation.js --coverage --coverage-format=lcov --coverage-output=cov.lcov
           grep -q '^SF:' cov.lcov
@@ -341,10 +341,11 @@ jobs:
           rm cov2.lcov
 
           detail_output="$(./build/GocciaTestRunner tests/built-ins/Array/array-creation.js --coverage 2>&1)"
-          printf '%s\n' "$detail_output" | grep -Eq '[0-9]+x \|'
+          detail_re='[0-9]+x \|'
+          [[ "$detail_output" =~ $detail_re ]]
 
           bytecode_cov="$(./build/GocciaTestRunner tests/built-ins/Array/array-creation.js --mode=bytecode --coverage 2>&1)"
-          printf '%s\n' "$bytecode_cov" | grep -q 'Coverage Summary:'
+          [[ "$bytecode_cov" == *'Coverage Summary:'* ]]
 
           ./build/GocciaTestRunner tests/language/statements/if/if-else-statements.js --coverage --coverage-format=lcov --coverage-output=branch-cov.lcov
           grep -q '^BRDA:' branch-cov.lcov

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -163,8 +163,8 @@ jobs:
         run: |
           # --coverage prints a summary to stdout
           cov_output="$(./build/GocciaTestRunner tests/built-ins/Array/array-creation.js ${{ matrix.mode == 'bytecode' && '--mode=bytecode' || '' }} --coverage 2>&1)"
-          printf '%s\n' "$cov_output" | grep -q 'Coverage Summary:'
-          printf '%s\n' "$cov_output" | grep -q 'array-creation.js'
+          [[ "$cov_output" == *'Coverage Summary:'* ]]
+          [[ "$cov_output" == *'array-creation.js'* ]]
 
           # --coverage-format=lcov --coverage-output writes an lcov file
           ./build/GocciaTestRunner tests/built-ins/Array/array-creation.js ${{ matrix.mode == 'bytecode' && '--mode=bytecode' || '' }} --coverage --coverage-format=lcov --coverage-output=cov.lcov
@@ -186,7 +186,8 @@ jobs:
 
           # single-file detail view shows line annotations
           detail_output="$(./build/GocciaTestRunner tests/built-ins/Array/array-creation.js ${{ matrix.mode == 'bytecode' && '--mode=bytecode' || '' }} --coverage 2>&1)"
-          printf '%s\n' "$detail_output" | grep -Eq '[0-9]+x \|'
+          detail_re='[0-9]+x \|'
+          [[ "$detail_output" =~ $detail_re ]]
 
           # branch coverage: lcov contains BRDA/BRF entries for branching code
           ./build/GocciaTestRunner tests/language/statements/if/if-else-statements.js ${{ matrix.mode == 'bytecode' && '--mode=bytecode' || '' }} --coverage --coverage-format=lcov --coverage-output=branch-cov.lcov


### PR DESCRIPTION
## Impact

The `Check GocciaTestRunner coverage CLI` step no longer intermittently fails CI (`printf: write error: Broken pipe` → exit 1), as it did on main run [32146906847](https://github.com/frostney/GocciaScript/actions/runs/32146906847) (test x86_64-darwin, macos-15-intel).

## Cause

The step runs under `bash -e -o pipefail` and piped multi-kilobyte coverage output into `grep -q`:

```bash
printf '%s\n' "$cov_output" | grep -q 'Coverage Summary:'
```

`grep -q` exits on the first match and closes the pipe. When the output exceeds the pipe buffer and `printf` is still writing, `printf` takes SIGPIPE, the left side of the pipeline exits non-zero, and `pipefail` fails the step — a timing race that only bites occasionally.

## Fix

The output is already captured in a shell variable, so test it directly with `[[ ]]` substring/regex matches — no pipe, no race. Applied to all five affected checks across `ci.yml` and `pr.yml`. The remaining `echo … | grep -q` pipes in the workflows carry single-line strings that fit in the pipe buffer, so they cannot hit this race and are left alone.

## Validation

- Replacement `[[ ]]` checks verified locally: they match the expected patterns and correctly fail the step under `set -e` when the pattern is absent.
- `actionlint` reports no findings for the edited steps (only pre-existing infos in an unrelated step).