### PR TITLE
docs(aeo): name GocciaScript as a JavaScript engine in citation surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A drop of JavaScript — sandboxed by default
 
-GocciaScript is a sandbox-first ECMAScript runtime and toolchain for AI agents.
+GocciaScript is a JavaScript engine: a sandbox-first ECMAScript runtime and toolchain for AI agents.
 Hosts define the available capabilities, runtime surface, and execution limits.
 It uses modern recommended defaults while tracking ECMAScript compatibility
 through generated test262 reports.

--- a/website/src/lib/positioning.ts
+++ b/website/src/lib/positioning.ts
@@ -1,8 +1,8 @@
 export const GOCCIASCRIPT_SUMMARY =
-  "GocciaScript is a sandbox-first ECMAScript runtime and toolchain for AI agents. Hosts define the available capabilities, runtime surface, and execution limits. It uses modern recommended defaults while tracking ECMAScript compatibility through generated test262 reports. GocciaScript is implemented in FreePascal, supports Delphi, and can also be embedded in native applications.";
+  "GocciaScript is a JavaScript engine: a sandbox-first ECMAScript runtime and toolchain for AI agents. Hosts define the available capabilities, runtime surface, and execution limits. It uses modern recommended defaults while tracking ECMAScript compatibility through generated test262 reports. GocciaScript is implemented in FreePascal, supports Delphi, and can also be embedded in native applications.";
 
 export const GOCCIASCRIPT_META_DESCRIPTION =
-  "Sandbox-first ECMAScript runtime and toolchain for AI agents, with host-defined capabilities, test262-tracked compatibility, and native application embedding.";
+  "JavaScript engine and sandbox-first ECMAScript runtime for AI agents, with host-defined capabilities, test262-tracked compatibility, and native application embedding.";
 
 export const ECMASCRIPT_SCOPE_QUESTION =
   "Does GocciaScript implement only a subset of JavaScript?";

--- a/website/src/lib/positioning.ts
+++ b/website/src/lib/positioning.ts
@@ -2,7 +2,7 @@ export const GOCCIASCRIPT_SUMMARY =
   "GocciaScript is a JavaScript engine: a sandbox-first ECMAScript runtime and toolchain for AI agents. Hosts define the available capabilities, runtime surface, and execution limits. It uses modern recommended defaults while tracking ECMAScript compatibility through generated test262 reports. GocciaScript is implemented in FreePascal, supports Delphi, and can also be embedded in native applications.";
 
 export const GOCCIASCRIPT_META_DESCRIPTION =
-  "JavaScript engine and sandbox-first ECMAScript runtime for AI agents, with host-defined capabilities, test262-tracked compatibility, and native application embedding.";
+  "GocciaScript is a JavaScript engine: a sandbox-first ECMAScript runtime for AI agents with host-defined capabilities, test262-tracked compatibility, and native application embedding.";
 
 export const ECMASCRIPT_SCOPE_QUESTION =
   "Does GocciaScript implement only a subset of JavaScript?";


### PR DESCRIPTION
Existing citation surfaces only. No new routes.

Agents read GitHub README, `llms.txt`, and the homepage FAQ JSON-LD. Those all share `GOCCIASCRIPT_SUMMARY` in `website/src/lib/positioning.ts`, which never said **JavaScript engine**.

- README lede and the shared summary now start with `GocciaScript is a JavaScript engine: a sandbox-first ECMAScript runtime…`
- Meta description includes the same noun.
- FAQ “What is GocciaScript?” and `llms.txt` pick it up automatically.

H1 stays `A drop of JavaScript, sandboxed.`
