### PR TITLE
fix(bytecode): run compiled class constructors when instantiated from evaluator paths

### DIFF
--- a/docs/bytecode-vm.md
+++ b/docs/bytecode-vm.md
@@ -5,7 +5,7 @@
 ## Executive Summary
 
 - **Two execution modes** — tree-walk interpreter (default) and bytecode VM (`--mode=bytecode`), sharing the same source pipeline, runtime objects, and GC
-- **Executor abstraction** — `TGocciaBytecodeExecutor` implements `TGocciaExecutor` and drives only the compiler and VM; the one residual coupling is direct `eval`, which the VM still delegates to the tree-walk evaluator
+- **Executor abstraction** — `TGocciaBytecodeExecutor` implements `TGocciaExecutor` and drives only the compiler and VM; two residual couplings remain — direct `eval`, and a module's top-level function declarations, which are created and run by the tree-walk evaluator
 - **Goccia-owned VM** — executes directly on `TGocciaValue` with tagged `TGocciaRegister` values; not a generic VM layer
 - **Opcode space** — core instructions (0-127) for hot paths, non-core generic ops (128-166), and semantic/helper instructions (167-255) for colder operations like imports/exports
 - **Binary format** — `.gbc` files with little-endian encoding, `GBC\0` magic, and version constant
@@ -18,6 +18,8 @@ GocciaScript has two execution modes:
 - **Bytecode mode**: AST compilation to Goccia bytecode, then execution on `TGocciaVM` via `TGocciaBytecodeExecutor`
 
 Both execution modes are implementations of `TGocciaExecutor` (see [Architecture](architecture.md#executor-architecture)). The single `TGocciaEngine` class bootstraps the core language environment (global scope, core built-ins, shims) and delegates execution to whichever executor is configured. Optional runtime globals are attached through runtime extensions. The `TGocciaBytecodeExecutor` unit itself depends only on the compiler and VM; the VM it drives, however, still calls the tree-walk evaluator for direct `eval` (`TGocciaVM.ExecuteDirectEval` → `EvaluateEvalProgram`), so the bytecode path is not yet fully independent of the evaluator.
+
+An imported module adds a second such coupling. Its environment is initialized while linking (ES2026 §16.2.1.7.3.1 InitializeEnvironment), and the module loader creates the top-level function declarations there with the tree-walk evaluator (`HoistFunctionDeclarations`). Bytecode compilation of that module therefore reuses those preinitialized bindings for exported declarations instead of compiling them (`PreinitializedTopLevelFunctions`), and their bodies keep running under the evaluator in bytecode mode. Everything an evaluator path can be handed from such a body — including a compiled `TGocciaVMClassValue` reached by `new`, `super()`, or a bound wrapper — must therefore work in both directions; `TGocciaClassValue.UsesOwnInstantiation` and `TryConstructOnReceiver` are what route construction of a compiled class back to the VM. `scripts/differential/l-modulefndecl.test.js` gates this split.
 
 ## Pipeline
 

--- a/scripts/differential/l-modulefndecl.test.js
+++ b/scripts/differential/l-modulefndecl.test.js
@@ -7,12 +7,14 @@
 // different machinery. The entry file has no such split, which is why every
 // probe is run on both sides of the import.
 import {
+  Counted,
   Factory,
   Point,
   Tagged,
   arrowClosureRead,
   arrowConstruct,
   arrowFieldRead,
+  derivedTickCount,
   fnDeclArrowConstruct,
   fnDeclBoundConstruct,
   fnDeclClosureRead,
@@ -21,6 +23,7 @@ import {
   fnDeclFieldRead,
   fnDeclLocalImplicitSubclassConstruct,
   fnDeclLocalSubclassConstruct,
+  fnDeclLocalSubclassOfDerivedConstruct,
   fnDeclNestedConstruct,
   fnDeclSpreadConstruct,
 } from "./mods/fndecl.js";
@@ -157,5 +160,45 @@ describe("construction from module function declarations", () => {
     expect(implicitSuper.x).toBe(15);
     expect(implicitSuper.y).toBe(16);
     expect(implicitSuper.label).toBe("point");
+  });
+
+  // The base of this local class is itself derived, so the base's own super()
+  // is what initializes its fields. Constructing twice through the one helper
+  // is deliberate: initializing a second time would advance `seq` by two, and a
+  // super()-called flag left set by the first construction only becomes visible
+  // on the second.
+  test("a subclass of a derived module class initializes each field once", () => {
+    const ticksBefore = derivedTickCount();
+    const first = fnDeclLocalSubclassOfDerivedConstruct();
+    const second = fnDeclLocalSubclassOfDerivedConstruct();
+
+    for (const instance of [first, second]) {
+      expect(instance instanceof Counted).toBe(true);
+      expect(instance instanceof Point).toBe(true);
+      // Sorted: the three runtimes disagree on own-property *order* for a
+      // derived class's field initializers, which is a separate question from
+      // whether each field is initialized exactly once.
+      expect(Object.keys(instance).sort()).toEqual([
+        "label",
+        "local",
+        "owner",
+        "seq",
+        "stamp",
+        "x",
+        "y",
+      ]);
+      expect(instance.label).toBe("point");
+      expect(instance.x).toBe(20);
+      expect(instance.y).toBe(21);
+      expect(instance.sum).toBe(41);
+      expect(instance.owner).toBe("counted");
+      expect(instance.stamp).toBe("local");
+      expect(instance.local).toBe(true);
+      expect(instance.brand()).toBe("id-counted");
+      expect(instance.localBrand()).toBe("id-local");
+    }
+
+    expect(second.seq - first.seq).toBe(1);
+    expect(derivedTickCount() - ticksBefore).toBe(2);
   });
 });

--- a/scripts/differential/l-modulefndecl.test.js
+++ b/scripts/differential/l-modulefndecl.test.js
@@ -1,0 +1,161 @@
+// Differential suite L — construction and closure reads from the three callable
+// forms, in an imported module and in the entry file.
+//
+// A module's top-level function declarations are created while the module is
+// linked, not compiled with the rest of the module body, so in bytecode mode a
+// declaration body and an arrow body next to it reach the same class through
+// different machinery. The entry file has no such split, which is why every
+// probe is run on both sides of the import.
+import {
+  Factory,
+  Point,
+  Tagged,
+  arrowClosureRead,
+  arrowConstruct,
+  arrowFieldRead,
+  fnDeclArrowConstruct,
+  fnDeclBoundConstruct,
+  fnDeclClosureRead,
+  fnDeclConstruct,
+  fnDeclDerivedConstruct,
+  fnDeclFieldRead,
+  fnDeclLocalImplicitSubclassConstruct,
+  fnDeclLocalSubclassConstruct,
+  fnDeclNestedConstruct,
+  fnDeclSpreadConstruct,
+} from "./mods/fndecl.js";
+
+const ENTRY_PREFIX = "entry-";
+
+class EntryPoint {
+  label = "entry-point";
+
+  constructor(x, y) {
+    this.x = x;
+    this.y = y;
+  }
+
+  get sum() {
+    return this.x + this.y;
+  }
+}
+
+function entryFnDeclConstruct() {
+  return new EntryPoint(1, 2);
+}
+
+function entryFnDeclImportedConstruct() {
+  return new Point(1, 2);
+}
+
+function entryFnDeclClosureRead() {
+  return ENTRY_PREFIX + "closure";
+}
+
+const entryArrowConstruct = () => new EntryPoint(1, 2);
+const entryArrowImportedConstruct = () => new Point(1, 2);
+const entryArrowClosureRead = () => ENTRY_PREFIX + "closure";
+
+class EntryFactory {
+  methodConstruct() {
+    return new EntryPoint(1, 2);
+  }
+
+  methodImportedConstruct() {
+    return new Point(1, 2);
+  }
+
+  methodClosureRead() {
+    return ENTRY_PREFIX + "closure";
+  }
+}
+
+describe("construction from module function declarations", () => {
+  test("imported module: every callable form runs the constructor body", () => {
+    for (const instance of [
+      fnDeclConstruct(),
+      arrowConstruct(),
+      new Factory().methodConstruct(),
+    ]) {
+      expect(instance instanceof Point).toBe(true);
+      expect(Object.keys(instance)).toEqual(["label", "x", "y"]);
+      expect(instance.x).toBe(1);
+      expect(instance.y).toBe(2);
+      expect(instance.sum).toBe(3);
+    }
+  });
+
+  test("imported module: every callable form reads instance fields", () => {
+    expect(fnDeclFieldRead()).toBe("point:id-tagged");
+    expect(arrowFieldRead()).toBe("point:id-tagged");
+    expect(new Factory().methodFieldRead()).toBe("point:id-tagged");
+  });
+
+  test("imported module: every callable form reads module bindings", () => {
+    expect(fnDeclClosureRead()).toBe("id-0");
+    expect(arrowClosureRead()).toBe("id-0");
+    expect(new Factory().methodClosureRead()).toBe("id-0");
+  });
+
+  test("entry file: every callable form runs the constructor body", () => {
+    for (const instance of [
+      entryFnDeclConstruct(),
+      entryArrowConstruct(),
+      new EntryFactory().methodConstruct(),
+    ]) {
+      expect(instance instanceof EntryPoint).toBe(true);
+      expect(Object.keys(instance)).toEqual(["label", "x", "y"]);
+      expect(instance.label).toBe("entry-point");
+      expect(instance.sum).toBe(3);
+    }
+  });
+
+  test("entry file: every callable form constructs an imported class", () => {
+    for (const instance of [
+      entryFnDeclImportedConstruct(),
+      entryArrowImportedConstruct(),
+      new EntryFactory().methodImportedConstruct(),
+      new Point(1, 2),
+    ]) {
+      expect(instance instanceof Point).toBe(true);
+      expect(Object.keys(instance)).toEqual(["label", "x", "y"]);
+      expect(instance.sum).toBe(3);
+    }
+  });
+
+  test("entry file: every callable form reads entry bindings", () => {
+    expect(entryFnDeclClosureRead()).toBe("entry-closure");
+    expect(entryArrowClosureRead()).toBe("entry-closure");
+    expect(new EntryFactory().methodClosureRead()).toBe("entry-closure");
+  });
+
+  test("a module function declaration constructs a derived module class", () => {
+    const tagged = fnDeclDerivedConstruct();
+    expect(tagged instanceof Tagged).toBe(true);
+    expect(tagged instanceof Point).toBe(true);
+    expect(Object.keys(tagged)).toEqual(["label", "x", "y", "tag"]);
+    expect(tagged.x).toBe(4);
+    expect(tagged.y).toBe(5);
+    expect(tagged.tag).toBe("id-tagged");
+  });
+
+  test("spread, bound, nested and arrow call sites all construct", () => {
+    expect(fnDeclSpreadConstruct().sum).toBe(11);
+    expect(fnDeclBoundConstruct().sum).toBe(23);
+    expect(fnDeclNestedConstruct().sum).toBe(15);
+    expect(fnDeclArrowConstruct().sum).toBe(19);
+  });
+
+  test("a subclass declared inside a module function runs the imported base", () => {
+    const explicitSuper = fnDeclLocalSubclassConstruct();
+    expect(explicitSuper.x).toBe(13);
+    expect(explicitSuper.y).toBe(14);
+    expect(explicitSuper.label).toBe("point");
+    expect(explicitSuper.local).toBe("id-local");
+
+    const implicitSuper = fnDeclLocalImplicitSubclassConstruct();
+    expect(implicitSuper.x).toBe(15);
+    expect(implicitSuper.y).toBe(16);
+    expect(implicitSuper.label).toBe("point");
+  });
+});

--- a/scripts/differential/mods/fndecl.js
+++ b/scripts/differential/mods/fndecl.js
@@ -1,0 +1,102 @@
+// Support module for differential suite L. Every callable form below — hoisted
+// function declaration, arrow, class method — performs the same three probes:
+// it constructs a module class, reads a field off the instance, and reads a
+// module-level binding through its closure. A module's top-level function
+// declarations are created while linking rather than compiled with the rest of
+// the module, so the declaration forms and the arrow/method forms take
+// genuinely different paths to the same class.
+const PREFIX = "id-";
+const ORIGIN = { x: 0, y: 0 };
+
+export class Point {
+  label = "point";
+
+  constructor(x, y) {
+    this.x = x;
+    this.y = y;
+  }
+
+  get sum() {
+    return this.x + this.y;
+  }
+}
+
+export class Tagged extends Point {
+  constructor(x) {
+    super(x, x + 1);
+    this.tag = PREFIX + "tagged";
+  }
+}
+
+export function fnDeclConstruct() {
+  return new Point(1, 2);
+}
+
+export function fnDeclFieldRead() {
+  return new Point(1, 2).label + ":" + new Tagged(4).tag;
+}
+
+export function fnDeclClosureRead() {
+  return PREFIX + ORIGIN.x;
+}
+
+export function fnDeclDerivedConstruct() {
+  return new Tagged(4);
+}
+
+export function fnDeclSpreadConstruct() {
+  return new Point(...[5, 6]);
+}
+
+export function fnDeclBoundConstruct() {
+  const Bound = Point.bind(null, 11);
+  return new Bound(12);
+}
+
+export function fnDeclNestedConstruct() {
+  function inner() {
+    return new Point(7, 8);
+  }
+
+  return inner();
+}
+
+export function fnDeclArrowConstruct() {
+  const make = () => new Point(9, 10);
+  return make();
+}
+
+export function fnDeclLocalSubclassConstruct() {
+  class Local extends Point {
+    constructor() {
+      super(13, 14);
+      this.local = PREFIX + "local";
+    }
+  }
+
+  return new Local();
+}
+
+export function fnDeclLocalImplicitSubclassConstruct() {
+  class Local extends Point {}
+
+  return new Local(15, 16);
+}
+
+export const arrowConstruct = () => new Point(1, 2);
+export const arrowFieldRead = () => new Point(1, 2).label + ":" + new Tagged(4).tag;
+export const arrowClosureRead = () => PREFIX + ORIGIN.x;
+
+export class Factory {
+  methodConstruct() {
+    return new Point(1, 2);
+  }
+
+  methodFieldRead() {
+    return new Point(1, 2).label + ":" + new Tagged(4).tag;
+  }
+
+  methodClosureRead() {
+    return PREFIX + ORIGIN.x;
+  }
+}

--- a/scripts/differential/mods/fndecl.js
+++ b/scripts/differential/mods/fndecl.js
@@ -28,6 +28,32 @@ export class Tagged extends Point {
   }
 }
 
+// A *derived* module class — it calls super(), and it owns both an instance
+// field with an observable side effect and a private field. Extending this one
+// rather than the base Point is what exercises the ordering rule that a derived
+// class initializes its fields when its own super() returns: running them a
+// second time would advance the tick twice and stamp the private brand twice.
+let derivedTicks = 0;
+
+export function derivedTickCount() {
+  return derivedTicks;
+}
+
+export class Counted extends Point {
+  seq = ++derivedTicks;
+
+  #brand = PREFIX + "counted";
+
+  constructor(x) {
+    super(x, x + 1);
+    this.owner = "counted";
+  }
+
+  brand() {
+    return this.#brand;
+  }
+}
+
 export function fnDeclConstruct() {
   return new Point(1, 2);
 }
@@ -81,6 +107,27 @@ export function fnDeclLocalImplicitSubclassConstruct() {
   class Local extends Point {}
 
   return new Local(15, 16);
+}
+
+// Called more than once on purpose: the constructor being entered owns the
+// super()-called flag, so a leak only shows on the second call.
+export function fnDeclLocalSubclassOfDerivedConstruct() {
+  class Local extends Counted {
+    stamp = "local";
+
+    #localBrand = PREFIX + "local";
+
+    constructor() {
+      super(20);
+      this.local = true;
+    }
+
+    localBrand() {
+      return this.#localBrand;
+    }
+  }
+
+  return new Local();
 }
 
 export const arrowConstruct = () => new Point(1, 2);

--- a/scripts/test-cli-differential.ts
+++ b/scripts/test-cli-differential.ts
@@ -122,6 +122,14 @@ const CLASSIFICATION: Record<string, Classification> = {
   // ambiguity for the toolchain this runner replaces. Vitest is skipped —
   // nothing here is testing-API semantics.
   "k-callgenerics.test.ts": { kind: "language", bun: "gate", vitest: "skip" },
+  // Construction and closure reads from a module's top-level function
+  // declarations, which are created while linking rather than compiled with the
+  // module body — the split that produced three bytecode-only bugs (the 0.11.0
+  // TDZ break, its 0.12.0 fix, and the 0.13.0 break where `new X()` inside such
+  // a declaration silently skipped the constructor body). Bun gates: this is
+  // ECMAScript class and module semantics, and the testing API is incidental.
+  // Vitest is skipped for the same reason as the other language suites.
+  "l-modulefndecl.test.js": { kind: "language", bun: "gate", vitest: "skip" },
 };
 
 type Verdict = {

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -263,11 +263,14 @@ function HasAsyncDisposals(const ATracker: TGocciaDisposalTracker): Boolean; for
 function CollectDeclaredPrivateNames(
   const AContext: TGocciaEvaluationContext): TStringList; forward;
 
+// A class value that carries its own [[Construct]] implementation — a typed
+// array, or a bytecode-compiled class whose constructor is a closure rather
+// than an AST method — cannot be built by InstantiateClass, which drives
+// construction from the AST constructor method and field tables.
 function ShouldUseNativeClassInstantiation(
   const AClassValue: TGocciaClassValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
-  Result := (AClassValue is TGocciaTypedArrayClassValue) or
-    (AClassValue is TGocciaTypedArrayIntrinsicClassValue);
+  Result := AClassValue.UsesOwnInstantiation;
 end;
 
 const
@@ -3813,7 +3816,12 @@ begin
   else if AConstructor is TGocciaClassValue then
   begin
     ClassConstructor := TGocciaClassValue(AConstructor);
-    if Assigned(ClassConstructor.ConstructorMethod) then
+    // A compiled class runs its own field initializers and constructor body;
+    // the AST tables this branch otherwise drives are empty for it.
+    if ClassConstructor.TryConstructOnReceiver(AArguments, AReceiver,
+       EffectiveNewTarget, SuperResult) then
+      ValidateClassConstructorReturn(ClassConstructor, SuperResult)
+    else if Assigned(ClassConstructor.ConstructorMethod) then
     begin
       if AReceiver is TGocciaObjectValue then
         RunClassInstanceInitializers(ClassConstructor,
@@ -4165,7 +4173,25 @@ begin
         end;
       end;
 
-      if Assigned(SuperClass) and Assigned(SuperClass.ConstructorMethod) then
+      // A compiled superclass runs its own field initializers and constructor
+      // body against the receiver; ConstructorMethod is nil for it, so without
+      // this the base initialization would be skipped silently.
+      if Assigned(SuperClass) and
+         SuperClass.TryConstructOnReceiver(Arguments, AContext.Scope.ThisValue,
+           AContext.Scope.FindNewTarget, SuperResult) then
+      begin
+        if SuperResult is TGocciaObjectValue then
+        begin
+          InitializeReplacementThis(TGocciaObjectValue(SuperResult),
+            AContext.Scope.ThisValue);
+          AContext.Scope.ThisValue := TGocciaObjectValue(SuperResult);
+          ThisScope := AContext.Scope.FindFunctionOrModuleScope;
+          if Assigned(ThisScope) then
+            ThisScope.ThisValue := AContext.Scope.ThisValue;
+        end;
+        Result := AContext.Scope.ThisValue;
+      end
+      else if Assigned(SuperClass) and Assigned(SuperClass.ConstructorMethod) then
       begin
         SuperResult := SuperClass.ConstructorMethod.CallWithThisValue(
           Arguments, AContext.Scope.ThisValue, ConstructorThisValue,
@@ -11338,7 +11364,16 @@ begin
       if AClassValue.GetConstructorPrototype is TGocciaClassValue then
         ImplicitSuperClass := TGocciaClassValue(AClassValue.GetConstructorPrototype);
 
+      // A compiled superclass has no AST ConstructorMethod; it runs its own
+      // field initializers and constructor body against the instance.
       if Assigned(ImplicitSuperClass) and
+         ImplicitSuperClass.TryConstructOnReceiver(AArguments, Instance,
+           EffectiveNewTarget, ConstructedValue) then
+      begin
+        ValidateClassConstructorReturn(ImplicitSuperClass, ConstructedValue);
+        ApplyReplacementResult(ConstructedValue);
+      end
+      else if Assigned(ImplicitSuperClass) and
          Assigned(ImplicitSuperClass.ConstructorMethod) then
       begin
         ConstructedValue := ImplicitSuperClass.ConstructorMethod.CallWithThisValue(

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -2788,6 +2788,11 @@ type
       const ANewTarget: TGocciaValue = nil): TGocciaValue; override;
     function InstantiateRegisters(
       const AArguments: TGocciaRegisterArray): TGocciaRegister;
+    function UsesOwnInstantiation: Boolean; override;
+    function TryConstructOnReceiver(
+      const AArguments: TGocciaArgumentsCollection;
+      const AReceiver: TGocciaValue; const ANewTarget: TGocciaValue;
+      out AResult: TGocciaValue): Boolean; override;
     function GetProperty(const AName: string): TGocciaValue; override;
     procedure SetProperty(const AName: string; const AValue: TGocciaValue); override;
     procedure SetVMConstructor(const AValue: TGocciaValue);
@@ -6492,6 +6497,63 @@ destructor TGocciaBytecodeFunctionValue.Destroy;
 begin
   FClosure.Free;
   inherited;
+end;
+
+// A compiled class holds its constructor as a bytecode closure, not as the AST
+// TGocciaMethodValue the tree-walk instantiation path drives, so construction
+// must run through Instantiate / InstantiateRegisters. This matters outside the
+// VM because a module's top-level function declarations are created by the
+// tree-walk evaluator while linking (ES2026 §16.2.1.7.3.1 InitializeEnvironment)
+// and keep running there even in bytecode mode.
+function TGocciaVMClassValue.UsesOwnInstantiation: Boolean;
+begin
+  Result := True;
+end;
+
+// Mirrors the compiled-class branch of TGocciaVM.InvokeConstructableWithReceiver
+// so that a tree-walk `super()` or bound `new` reaching a compiled class runs
+// the same steps the VM would.
+function TGocciaVMClassValue.TryConstructOnReceiver(
+  const AArguments: TGocciaArgumentsCollection;
+  const AReceiver: TGocciaValue; const ANewTarget: TGocciaValue;
+  out AResult: TGocciaValue): Boolean;
+var
+  ConstructorThisValue: TGocciaValue;
+begin
+  Result := True;
+
+  if not Assigned(FConstructorValue) then
+  begin
+    AResult := FVM.InvokeImplicitSuperInitialization(Self, AReceiver,
+      AArguments);
+    if not Assigned(AResult) then
+      AResult := AReceiver;
+    Exit;
+  end;
+
+  FVM.FPendingNewTarget := ANewTarget;
+  FVM.RunClassInitializers(Self, AReceiver);
+  AResult := FVM.InvokeFunctionValue(FConstructorValue, AArguments, AReceiver);
+
+  // ES2026 §10.2.2 step 13.b: a derived constructor may only return an Object
+  // or undefined.
+  if (Assigned(SuperClass) or Assigned(NativeSuperConstructor)) and
+     Assigned(AResult) and
+     not (AResult is TGocciaObjectValue) and
+     not (AResult is TGocciaUndefinedLiteralValue) then
+    ThrowTypeError('Derived constructor returned non-object',
+      SSuggestNotConstructorType);
+
+  if FConstructorValue is TGocciaBytecodeFunctionValue then
+    ConstructorThisValue := RegisterToValue(FVM.FLastClosureThisValue)
+  else
+    ConstructorThisValue := nil;
+  if not (AResult is TGocciaObjectValue) and
+     (ConstructorThisValue is TGocciaObjectValue) then
+    AResult := ConstructorThisValue;
+  if (AResult is TGocciaObjectValue) and (AResult <> AReceiver) and
+     (AResult = ConstructorThisValue) then
+    FVM.RunClassInitializers(Self, AResult);
 end;
 
 // ES2026 §10.2.2 [[Construct]](argumentsList, newTarget)

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -6519,6 +6519,11 @@ function TGocciaVMClassValue.TryConstructOnReceiver(
   out AResult: TGocciaValue): Boolean;
 var
   ConstructorThisValue: TGocciaValue;
+  PreviousConstructorSuperCalled: Boolean;
+  function HasDerivedConstructorReturnRestriction: Boolean;
+  begin
+    Result := Assigned(SuperClass) or Assigned(NativeSuperConstructor);
+  end;
 begin
   Result := True;
 
@@ -6531,13 +6536,31 @@ begin
     Exit;
   end;
 
+  // A derived class initializes its fields when its own super() returns, not
+  // before its constructor runs; doing both would evaluate every initializer
+  // twice and stamp the private brand twice, which the second stamp reports as
+  // a repeated super() call.
+  if not HasDerivedConstructorReturnRestriction then
+    FVM.RunClassInitializers(Self, AReceiver);
   FVM.FPendingNewTarget := ANewTarget;
-  FVM.RunClassInitializers(Self, AReceiver);
-  AResult := FVM.InvokeFunctionValue(FConstructorValue, AArguments, AReceiver);
+  if not Assigned(FVM.FPendingNewTarget) then
+    FVM.FPendingNewTarget := Self;
+
+  // The super()-called flag belongs to the constructor being entered. Leaving
+  // it set on the way out makes the next constructor to run believe it has
+  // already called super().
+  PreviousConstructorSuperCalled := FVM.FCurrentConstructorSuperCalled;
+  FVM.FCurrentConstructorSuperCalled := False;
+  try
+    AResult := FVM.InvokeFunctionValue(FConstructorValue, AArguments,
+      AReceiver);
+  finally
+    FVM.FCurrentConstructorSuperCalled := PreviousConstructorSuperCalled;
+  end;
 
   // ES2026 §10.2.2 step 13.b: a derived constructor may only return an Object
   // or undefined.
-  if (Assigned(SuperClass) or Assigned(NativeSuperConstructor)) and
+  if HasDerivedConstructorReturnRestriction and
      Assigned(AResult) and
      not (AResult is TGocciaObjectValue) and
      not (AResult is TGocciaUndefinedLiteralValue) then
@@ -6552,8 +6575,12 @@ begin
      (ConstructorThisValue is TGocciaObjectValue) then
     AResult := ConstructorThisValue;
   if (AResult is TGocciaObjectValue) and (AResult <> AReceiver) and
-     (AResult = ConstructorThisValue) then
-    FVM.RunClassInitializers(Self, AResult);
+     (AResult = ConstructorThisValue) and
+     not HasBytecodePrivateInitializersApplied(AResult, Self) then
+  begin
+    FVM.RunClassInitializers(Self, AResult, False);
+    StampBytecodePrivateInitializersApplied(AResult, Self);
+  end;
 end;
 
 // ES2026 §10.2.2 [[Construct]](argumentsList, newTarget)

--- a/source/units/Goccia.Values.ClassValue.pas
+++ b/source/units/Goccia.Values.ClassValue.pas
@@ -125,6 +125,26 @@ type
       const ARealm: TGocciaRealm): TGocciaObjectValue; virtual;
     function Instantiate(const AArguments: TGocciaArgumentsCollection;
       const ANewTarget: TGocciaValue = nil): TGocciaValue; virtual;
+    // True when this class value carries its own [[Construct]] implementation
+    // instead of the AST constructor method and field tables that the
+    // tree-walk instantiation path drives. Typed arrays allocate an exotic
+    // receiver, and a bytecode-compiled class holds its constructor as a
+    // closure rather than a TGocciaMethodValue; for both, `new` must go
+    // through Instantiate. The tree-walk evaluator is handed such classes in
+    // bytecode mode, because a module's top-level function declarations are
+    // created by the evaluator while linking (ES2026 §16.2.1.7.3.1
+    // InitializeEnvironment) and keep running there.
+    function UsesOwnInstantiation: Boolean; virtual;
+    // Runs this class's own [[Construct]] steps — field initializers and
+    // constructor body — against an already-allocated receiver, and reports
+    // whether it did. This is what `super()` from a tree-walk subclass and
+    // `new` through a bound wrapper need: they own the receiver, so they
+    // cannot call Instantiate. Returns False for class values whose
+    // construction the tree-walk path drives from the AST constructor method.
+    function TryConstructOnReceiver(
+      const AArguments: TGocciaArgumentsCollection;
+      const AReceiver: TGocciaValue; const ANewTarget: TGocciaValue;
+      out AResult: TGocciaValue): Boolean; virtual;
     function EstimatedInstancePropertyCapacity: Integer;
     function HasInstanceInitializerWork: Boolean;
     // ECMAScript: number of expected constructor parameters before the first
@@ -1602,6 +1622,20 @@ begin
     if not FDecoratorFieldInitializers[I].IsStatic then
       Exit(True);
 
+  Result := False;
+end;
+
+function TGocciaClassValue.UsesOwnInstantiation: Boolean;
+begin
+  Result := False;
+end;
+
+function TGocciaClassValue.TryConstructOnReceiver(
+  const AArguments: TGocciaArgumentsCollection;
+  const AReceiver: TGocciaValue; const ANewTarget: TGocciaValue;
+  out AResult: TGocciaValue): Boolean;
+begin
+  AResult := nil;
   Result := False;
 end;
 

--- a/source/units/Goccia.Values.TypedArrayValue.pas
+++ b/source/units/Goccia.Values.TypedArrayValue.pas
@@ -165,6 +165,7 @@ type
     function DefaultPrototypeForNewTarget(const ANewTarget: TGocciaValue;
       const ACurrentRealmDefault: TGocciaObjectValue): TGocciaObjectValue;
     function GetClassLength: Integer; override;
+    function UsesOwnInstantiation: Boolean; override;
     property Kind: TGocciaTypedArrayKind read FKind;
   end;
 
@@ -174,6 +175,7 @@ type
       const AThisValue: TGocciaValue): TGocciaValue; override;
     function Instantiate(const AArguments: TGocciaArgumentsCollection;
       const ANewTarget: TGocciaValue = nil): TGocciaValue; override;
+    function UsesOwnInstantiation: Boolean; override;
   end;
 
   TGocciaTypedArrayStaticFrom = class
@@ -3019,6 +3021,14 @@ begin
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
 
+// ES2026 §23.2.5.1: %TypedArray% is abstract and rejects direct construction,
+// so the tree-walk instantiation path must not build an ordinary instance for
+// it either.
+function TGocciaTypedArrayIntrinsicClassValue.UsesOwnInstantiation: Boolean;
+begin
+  Result := True;
+end;
+
 constructor TGocciaTypedArrayClassValue.Create(const AName: string; const ASuperClass: TGocciaClassValue; const AKind: TGocciaTypedArrayKind);
 begin
   inherited Create(AName, ASuperClass);
@@ -3069,6 +3079,14 @@ end;
 function TGocciaTypedArrayClassValue.GetClassLength: Integer;
 begin
   Result := 3;
+end;
+
+// ES2026 §23.2.5.1 TypedArray(...): the constructor allocates an exotic
+// integer-indexed receiver from newTarget, which the tree-walk instantiation
+// path cannot produce.
+function TGocciaTypedArrayClassValue.UsesOwnInstantiation: Boolean;
+begin
+  Result := True;
 end;
 
 function TGocciaTypedArrayClassValue.CreateNativeInstance(const AArguments: TGocciaArgumentsCollection): TGocciaObjectValue;

--- a/tests/language/modules/hoisted-function-import-capture/class-construction.js
+++ b/tests/language/modules/hoisted-function-import-capture/class-construction.js
@@ -1,0 +1,78 @@
+/*---
+description: Hoisted function declarations in imported modules construct module classes
+features: [modules, compat-function, class]
+---*/
+
+import {
+  Factory,
+  Point,
+  Tagged,
+  arrowConstruct,
+  fnDeclArrowConstruct,
+  fnDeclBoundConstruct,
+  fnDeclClosureRead,
+  fnDeclConstruct,
+  fnDeclDerivedConstruct,
+  fnDeclLocalImplicitSubclassConstruct,
+  fnDeclLocalSubclassConstruct,
+  fnDeclNestedConstruct,
+  fnDeclSpreadConstruct,
+} from "./helpers/module-classes.js";
+
+describe("imported module functions construct module classes", () => {
+  test("a hoisted function declaration runs the constructor body", () => {
+    const point = fnDeclConstruct();
+    expect(point instanceof Point).toBe(true);
+    expect(Object.keys(point)).toEqual(["label", "x", "y"]);
+    expect(point.x).toBe(1);
+    expect(point.y).toBe(2);
+    expect(point.label).toBe("point");
+    expect(point.sum).toBe(3);
+  });
+
+  test("arrow and method forms construct the same way", () => {
+    expect(Object.keys(arrowConstruct())).toEqual(["label", "x", "y"]);
+    expect(new Factory().methodConstruct().sum).toBe(3);
+  });
+
+  test("nested and arrow call sites inside a declaration construct", () => {
+    expect(fnDeclNestedConstruct().sum).toBe(15);
+    expect(fnDeclArrowConstruct().sum).toBe(19);
+  });
+
+  test("spread and bound construction run the constructor body", () => {
+    expect(fnDeclSpreadConstruct().sum).toBe(11);
+    expect(fnDeclBoundConstruct().sum).toBe(23);
+  });
+
+  test("a derived module class runs its base constructor", () => {
+    const tagged = fnDeclDerivedConstruct();
+    expect(tagged instanceof Tagged).toBe(true);
+    expect(tagged instanceof Point).toBe(true);
+    expect(tagged.x).toBe(4);
+    expect(tagged.y).toBe(5);
+    expect(tagged.tag).toBe("id-tagged");
+  });
+
+  test("a subclass declared inside the function runs the imported base", () => {
+    const explicitSuper = fnDeclLocalSubclassConstruct();
+    expect(explicitSuper.x).toBe(13);
+    expect(explicitSuper.y).toBe(14);
+    expect(explicitSuper.label).toBe("point");
+    expect(explicitSuper.local).toBe("id-local");
+
+    const implicitSuper = fnDeclLocalImplicitSubclassConstruct();
+    expect(implicitSuper.x).toBe(15);
+    expect(implicitSuper.y).toBe(16);
+    expect(implicitSuper.label).toBe("point");
+  });
+
+  test("a hoisted function declaration still reads module closure bindings", () => {
+    expect(fnDeclClosureRead()).toBe("id-closure");
+  });
+
+  test("constructing an imported class from the entry file is unchanged", () => {
+    expect(Object.keys(new Point(1, 2))).toEqual(["label", "x", "y"]);
+    expect(new Tagged(4).tag).toBe("id-tagged");
+  });
+});

--- a/tests/language/modules/hoisted-function-import-capture/class-construction.js
+++ b/tests/language/modules/hoisted-function-import-capture/class-construction.js
@@ -4,10 +4,12 @@ features: [modules, compat-function, class]
 ---*/
 
 import {
+  Counted,
   Factory,
   Point,
   Tagged,
   arrowConstruct,
+  derivedTickCount,
   fnDeclArrowConstruct,
   fnDeclBoundConstruct,
   fnDeclClosureRead,
@@ -15,6 +17,7 @@ import {
   fnDeclDerivedConstruct,
   fnDeclLocalImplicitSubclassConstruct,
   fnDeclLocalSubclassConstruct,
+  fnDeclLocalSubclassOfDerivedConstruct,
   fnDeclNestedConstruct,
   fnDeclSpreadConstruct,
 } from "./helpers/module-classes.js";
@@ -65,6 +68,45 @@ describe("imported module functions construct module classes", () => {
     expect(implicitSuper.x).toBe(15);
     expect(implicitSuper.y).toBe(16);
     expect(implicitSuper.label).toBe("point");
+  });
+
+  // The base here is itself derived, so its own super() is what initializes its
+  // fields. Constructing twice through the one helper is deliberate: a repeated
+  // initializer run would advance `seq` by two, and a super()-called flag left
+  // set by the first construction only becomes visible on the second.
+  test("a subclass of a derived module class initializes each field once", () => {
+    const ticksBefore = derivedTickCount();
+    const first = fnDeclLocalSubclassOfDerivedConstruct();
+    const second = fnDeclLocalSubclassOfDerivedConstruct();
+
+    for (const instance of [first, second]) {
+      expect(instance instanceof Counted).toBe(true);
+      expect(instance instanceof Point).toBe(true);
+      // Sorted because the two modes disagree on own-property *order* for a
+      // derived class's field initializers, which is a separate question from
+      // whether each field is initialized exactly once.
+      expect(Object.keys(instance).sort()).toEqual([
+        "label",
+        "local",
+        "owner",
+        "seq",
+        "stamp",
+        "x",
+        "y",
+      ]);
+      expect(instance.label).toBe("point");
+      expect(instance.x).toBe(20);
+      expect(instance.y).toBe(21);
+      expect(instance.sum).toBe(41);
+      expect(instance.owner).toBe("counted");
+      expect(instance.stamp).toBe("local");
+      expect(instance.local).toBe(true);
+      expect(instance.brand()).toBe("id-counted");
+      expect(instance.localBrand()).toBe("id-local");
+    }
+
+    expect(second.seq - first.seq).toBe(1);
+    expect(derivedTickCount() - ticksBefore).toBe(2);
   });
 
   test("a hoisted function declaration still reads module closure bindings", () => {

--- a/tests/language/modules/hoisted-function-import-capture/helpers/module-classes.js
+++ b/tests/language/modules/hoisted-function-import-capture/helpers/module-classes.js
@@ -20,6 +20,30 @@ export class Tagged extends Point {
   }
 }
 
+let derivedTicks = 0;
+
+export function derivedTickCount() {
+  return derivedTicks;
+}
+
+// A derived module class that calls super() and owns both a side-effecting
+// instance field and a private field, so a repeated initializer run is
+// observable as a doubled tick or a twice-stamped private brand.
+export class Counted extends Point {
+  seq = ++derivedTicks;
+
+  #brand = PREFIX + "counted";
+
+  constructor(x) {
+    super(x, x + 1);
+    this.owner = "counted";
+  }
+
+  brand() {
+    return this.#brand;
+  }
+}
+
 export function fnDeclConstruct() {
   return new Point(1, 2);
 }
@@ -65,6 +89,25 @@ export function fnDeclLocalImplicitSubclassConstruct() {
   class Local extends Point {}
 
   return new Local(15, 16);
+}
+
+export function fnDeclLocalSubclassOfDerivedConstruct() {
+  class Local extends Counted {
+    stamp = "local";
+
+    #localBrand = PREFIX + "local";
+
+    constructor() {
+      super(20);
+      this.local = true;
+    }
+
+    localBrand() {
+      return this.#localBrand;
+    }
+  }
+
+  return new Local();
 }
 
 export function fnDeclClosureRead() {

--- a/tests/language/modules/hoisted-function-import-capture/helpers/module-classes.js
+++ b/tests/language/modules/hoisted-function-import-capture/helpers/module-classes.js
@@ -1,0 +1,80 @@
+const PREFIX = "id-";
+
+export class Point {
+  label = "point";
+
+  constructor(x, y) {
+    this.x = x;
+    this.y = y;
+  }
+
+  get sum() {
+    return this.x + this.y;
+  }
+}
+
+export class Tagged extends Point {
+  constructor(x) {
+    super(x, x + 1);
+    this.tag = PREFIX + "tagged";
+  }
+}
+
+export function fnDeclConstruct() {
+  return new Point(1, 2);
+}
+
+export function fnDeclDerivedConstruct() {
+  return new Tagged(4);
+}
+
+export function fnDeclSpreadConstruct() {
+  return new Point(...[5, 6]);
+}
+
+export function fnDeclBoundConstruct() {
+  const Bound = Point.bind(null, 11);
+  return new Bound(12);
+}
+
+export function fnDeclNestedConstruct() {
+  function inner() {
+    return new Point(7, 8);
+  }
+
+  return inner();
+}
+
+export function fnDeclArrowConstruct() {
+  const make = () => new Point(9, 10);
+  return make();
+}
+
+export function fnDeclLocalSubclassConstruct() {
+  class Local extends Point {
+    constructor() {
+      super(13, 14);
+      this.local = PREFIX + "local";
+    }
+  }
+
+  return new Local();
+}
+
+export function fnDeclLocalImplicitSubclassConstruct() {
+  class Local extends Point {}
+
+  return new Local(15, 16);
+}
+
+export function fnDeclClosureRead() {
+  return PREFIX + "closure";
+}
+
+export const arrowConstruct = () => new Point(1, 2);
+
+export class Factory {
+  methodConstruct() {
+    return new Point(1, 2);
+  }
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Fixes the first bytecode/interpreter parity break since 0.11.0: constructing a class via `new`, `super()`, or a bound wrapper from inside an imported module's top-level `function` declaration silently skipped the compiled constructor and every field initializer in `--mode=bytecode`. The instance kept its prototype (`instanceof` true) but had zero own properties.
- Root cause is architectural, not a compiler bug: a module's top-level function declarations are created by the tree-walk evaluator during linking (ES2026 §16.2.1.7.3.1) and keep running under it even in bytecode mode, but the evaluator's instantiation path drove construction from AST constructor tables that a compiled `TGocciaVMClassValue` does not have. Construction of self-constructing class values (compiled classes, typed arrays) now routes through their own `[[Construct]]` via two new virtuals — `UsesOwnInstantiation` and `TryConstructOnReceiver` — the latter mirroring the VM's `Instantiate` reference step for step (derived-initializer gating, `FCurrentConstructorSuperCalled` bracketing, newTarget defaulting, private-brand-guarded replay).
- This is the third bytecode bug specific to fn-decls in imported modules (0.11.0 TDZ, its 0.12.0 fix, now this), so the compilation split now has a dedicated differential suite: `scripts/differential/l-modulefndecl.test.js` crosses {fn-decl, arrow, class method} × {imported module} × {construction, field reads, closure reads}, including a derived compiled base constructed twice through the same helper. Each new guard is independently mutation-checked (removing it makes the suite fail with a mode-parity divergence).
- `docs/bytecode-vm.md` no longer claims direct `eval` is the only residual evaluator coupling; the module-linking coupling is documented.
- Known pre-existing gaps deliberately not fixed here (both modes agree today): §10.2.2 step 13.a (derived constructor never calling `super()` should throw) and own-key insertion order for derived-class fields (interp runs first-pass initializers before the constructor). The new suites use sorted-key assertions for the one affected shape, with a comment saying why.

## Testing

- [x] Verified no regressions and confirmed the bugfix in end-to-end JavaScript/TypeScript tests — full suite 12322/12322 in both modes; `l-modulefndecl` 10p/0f in both modes with zero divergence (bun-gated); original repro passes in both modes; regression tests under `tests/language/modules/hoisted-function-import-capture/`
- [x] Updated documentation (`docs/bytecode-vm.md`, `docs/differential-testing.md` classification row lands with the next layer's table edit)
- [x] Native Pascal surface unchanged beyond the class-value virtuals; `./format.pas --check` clean
- [x] No benchmark-relevant hot paths changed (virtual dispatch replaces a type test on the evaluator instantiation path only)

Review: fresh-context high-effort pass found 2 blocking findings (derived-class double initialization; super-called flag leak); both fixed against the `Instantiate` reference and mutation-checked.
