### PR TITLE
feat(runtime): node:async_hooks with engine-propagated async context

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ Core built-ins include `Math`, `JSON`, `Object`, `Function`, `Array`, `Boolean`,
 
 Non-standard data-format APIs and SemVer are import-only Goccia runtime modules, not auto-installed globals: `goccia:csv`, `goccia:json5`, `goccia:jsonl`, `goccia:toml`, `goccia:tsv`, `goccia:yaml`, and `goccia:semver`. They expose named exports only; use `import * as CSV from "goccia:csv"` when you want the namespace-object shape. There is no default export.
 
+`node:async_hooks` is an import-only module too, at Node's own address and with Node's exports: `AsyncLocalStorage` and `AsyncResource`, named and on the default export. The engine propagates the async context, so a store bound with `run` survives `await` and every promise-reaction continuation. See the [Async Context reference](docs/built-ins-async-context.md) and [ADR 0112](docs/adr/0112-native-async-local-storage.md).
+
 Native FFI is an explicit unsafe runtime opt-in (`--unsafe-ffi` or the matching configuration key). It provides native-layout structures, unions, fixed-length arrays, callbacks, and guarded library lifetimes through GocciaScript's custom bidirectional ABI machinery. See the [FFI reference](docs/built-ins-ffi.md) and [ADR 0095](docs/adr/0095-custom-bidirectional-ffi-abi-engine.md).
 
 See [Built-in Objects](docs/built-ins.md) for the complete API reference.
@@ -379,6 +381,7 @@ See [Core patterns](docs/core-patterns.md) and [Interpreter](docs/interpreter.md
 | [FFI Built-ins](docs/built-ins-ffi.md) | Native libraries, aggregate types, callbacks, lifetimes, and safety limits |
 | [Temporal Built-ins](docs/built-ins-temporal.md) | Temporal API: dates, times, durations, time zones |
 | [Binary Data Built-ins](docs/built-ins-binary-data.md) | ArrayBuffer, SharedArrayBuffer, TypedArray API |
+| [Async Context](docs/built-ins-async-context.md) | `node:async_hooks`: `AsyncLocalStorage`, `AsyncResource`, and what propagates |
 | [Errors](docs/errors.md) | Error types, parser/runtime display, JSON output, `Error.cause`, `try`/`catch`/`finally` |
 | [Architecture](docs/architecture.md) | Pipelines, main layers, design direction, duplication boundaries |
 | [Interpreter](docs/interpreter.md) · [Bytecode VM](docs/bytecode-vm.md) | Tree-walk and bytecode execution modes |

--- a/docs/adr/0112-native-async-local-storage.md
+++ b/docs/adr/0112-native-async-local-storage.md
@@ -49,12 +49,19 @@ maintained:
   enqueue path captures the current snapshot unless it passes one explicitly,
   so no call site can forget.
 
-`await` needs no seam of its own. GocciaScript drains awaits synchronously
-inside the awaiting call, so the awaiting frame never leaves the Pascal stack;
-the jobs drained during the await restore the snapshot they found, which leaves
-the awaiting frame's own snapshot in place across the await. The restore is also
-what keeps a foreign continuation, drained by an unrelated `await`, from leaking
-its bindings into the frame that drained it.
+`await` needs no seam of its own, but not because nothing suspends. An async
+function does suspend at each `await` — `EGocciaAsyncAwaitSuspend` in the
+interpreter, `EGocciaBytecodeAsyncSuspend` in the bytecode VM — and its
+resumption is attached with `InvokeThen` on the awaited promise. That lands the
+continuation on the registration seam above, which records the snapshot in
+effect at the point of the `await`, so the resumed body sees exactly the
+bindings the suspending frame had. What GocciaScript does not do is *park*:
+the awaited promise is driven to settlement by draining the microtask queue on
+the same Pascal stack, so the resumption is reached from inside the awaiting
+call rather than from a later turn of an event loop. Either way the snapshot
+travels with the reaction, not with the stack. The restore in the execution
+seam is what additionally keeps a foreign continuation, drained by an unrelated
+`await`, from leaking its bindings into the frame that drained it.
 
 The current snapshot is a garbage-collection root through a `TGCRootSource`, and
 queued snapshots are rooted with the microtask they belong to. `nil` is the
@@ -98,18 +105,64 @@ Deliberately out of scope:
   have — awaits do not suspend, so there are no resources to report. The
   per-resource ids `AsyncResource` exposes are unique and stable but relate to
   nothing else, and `triggerAsyncId` reports the resource's own id.
-- **Cross-realm propagation.** A ShadowRealm child gets its own snapshot state,
-  as it gets its own module records and intrinsics.
+- **Cross-realm propagation.** Snapshot state is thread-local, not
+  realm-local: a ShadowRealm child shares the thread's current snapshot rather
+  than getting one of its own. Nothing can observe that, because a child realm
+  has no way to import `node:async_hooks` and therefore no way to read or bind
+  a store. If a child ever gains access to the module, whether the state should
+  be partitioned per realm becomes a real question; today it is unobservable
+  rather than isolated.
 
-`disable()` is implemented as a per-instance flag that `run` and `enterWith`
-clear, which is what Node's observable behaviour requires. It is not a retroactive
-erasure of bindings from snapshots that were already captured: a continuation
-created before the `disable`, resumed after a later `run` re-enabled the
-instance, can still see the store it captured. Reaching that state requires
-disabling an instance and then re-enabling it while an older continuation is
-still pending, and no other behaviour depends on it.
+`disable()` deletes the binding from the current frame and does nothing else,
+matching Node v24's AsyncContextFrame model. Every observable consequence
+follows from that one edit rather than from a rule of its own: `getStore()`
+reports the default value afterwards because no binding is left in this frame;
+a later `run` or `enterWith` re-binds; and a continuation captured *before* the
+disable still reports the store it captured, because the disable never reached
+that frame.
+
+An earlier draft used a per-instance `disabled` flag instead. It reproduced the
+first two consequences and got the third wrong in both directions, which is why
+the model rather than the flag is the mechanism: the flag masked bindings in
+already-captured continuations where Node keeps them, and it made `exit()` on a
+disabled instance report the default value where Node reports `undefined`. Both
+were probed against Node v24.0.1, along with the cases that agreed either way
+(disable-then-getStore with a default value; disable followed by a re-binding
+`run` straddling a pending continuation).
+
+## Async generators
+
+Each executor drives async generators through its own request queue
+(`TGocciaAsyncGeneratorObjectValue` in `Goccia.Values.GeneratorValue`,
+`TGocciaBytecodeAsyncGeneratorObjectValue` in `Goccia.VM`), and neither queue
+records an async context of its own. That is deliberate and was checked rather
+than assumed: every resumption reaches the generator body through a promise
+reaction, which already carries the snapshot captured where it was registered,
+so the body observes the context of whichever call resumed it — which is what
+Node does.
+
+Four shapes were probed against Node v24.0.1 and match in both executors: a
+`for await` inside a `run`; a generator created under one store and resumed
+with none; a generator started with no store and resumed inside a `run`; and
+two overlapping `next()` calls from two different stores, where the second is
+queued behind the first. `tests/built-ins/AsyncHooks/async-generators.js` locks
+all four in, and the differential suite gates the first two against bun. The two
+queues are duplicated machinery, so each carries a comment pointing at the
+other.
 
 ## Consequences
+
+Installing a snapshot has to go through a saved-context stack that the
+collector marks, not through a Pascal local. The current-snapshot slot is a
+snapshot's only root, so a scope that displaced one and held it in a local
+across guest code let a collection inside that code free it, and the restore
+then wrote a dangling pointer — `run` nested in `run` with a `Goccia.gc()` in
+the inner callback crashed both executors. `EnterAsyncContext` /
+`LeaveAsyncContext` in `Goccia.AsyncContext` push the displaced snapshot onto a
+per-thread stack that the async-context root source also marks, and all three
+scoped-installation sites use them. The token they exchange is the stack depth
+at entry, so a frame restores to its own depth and cannot unwind past an
+enclosing frame's entry.
 
 A latent bytecode-VM bug had to be fixed to ship this. `OP_CALL_METHOD`
 recognised `Function.prototype.bind` by the callee's *name*, so any own static

--- a/docs/adr/0112-native-async-local-storage.md
+++ b/docs/adr/0112-native-async-local-storage.md
@@ -1,0 +1,120 @@
+# Native AsyncLocalStorage over continuation snapshots
+
+**Date:** 2026-08-20
+**Area:** `runtime`
+
+GocciaScript implements `node:async_hooks` natively — `AsyncLocalStorage` and
+`AsyncResource` — and the engine, not the JavaScript layer, propagates the
+async context. The propagation mechanism is general: one immutable snapshot per
+continuation, holding the bindings of every `AsyncLocalStorage` instance at
+once, rather than a per-instance stack.
+
+## Why the engine has to do it
+
+A userland shim cannot express these semantics, and the reason is structural
+rather than a matter of effort. `storage.run(store, callback)` returns as soon
+as an `async` callback reaches its first `await`. A shim's `finally` therefore
+pops the store at that moment, and the resumed continuation — the part of the
+callback that actually does the work — reads nothing. The context has to travel
+with each continuation, and only the code that creates continuations can attach
+it. The acceptance target is `convex-test`, which is built on three concurrent
+`AsyncLocalStorage` instances; a mechanism that handles one instance, or that
+handles `run` but not interleaving, does not run it.
+
+Declining the feature was the alternative. It was rejected for the same reason:
+`AsyncLocalStorage` is the last engine-level wall in front of npm-shaped test
+suites, and there is no workaround a suite author can apply.
+
+## The mechanism
+
+A snapshot is an immutable association list from `AsyncLocalStorage` instance to
+store. `run` derives a new snapshot from the current one, installs it, calls the
+callback, and restores the previous snapshot when the callback's synchronous
+part returns. Deriving copies the entries once, so every continuation that
+already captured a snapshot keeps seeing exactly the bindings that were in
+effect when it was created.
+
+Two seams carry snapshots into continuations, and both sit in machinery the
+interpreter and the bytecode VM share, so mode parity is structural rather than
+maintained:
+
+- **Registration** — a promise reaction records the current snapshot when it is
+  registered on a still-pending promise (`TGocciaPromiseReaction.Context` in
+  `Goccia.Values.PromiseValue`). Recording it at settlement instead would be
+  wrong: `run(store, () => pending.then(handler))` must reach `handler` with
+  the store even though whatever resolves `pending` runs outside the `run`.
+- **Execution** — the microtask queue installs a job's snapshot before running
+  it and restores the previous one afterwards
+  (`TGocciaMicrotaskQueue.ExecuteTask` in `Goccia.MicrotaskQueue`). Every
+  enqueue path captures the current snapshot unless it passes one explicitly,
+  so no call site can forget.
+
+`await` needs no seam of its own. GocciaScript drains awaits synchronously
+inside the awaiting call, so the awaiting frame never leaves the Pascal stack;
+the jobs drained during the await restore the snapshot they found, which leaves
+the awaiting frame's own snapshot in place across the await. The restore is also
+what keeps a foreign continuation, drained by an unrelated `await`, from leaking
+its bindings into the frame that drained it.
+
+The current snapshot is a garbage-collection root through a `TGCRootSource`, and
+queued snapshots are rooted with the microtask they belong to. `nil` is the
+empty snapshot rather than a missing one, so a program that never touches
+`AsyncLocalStorage` allocates nothing and pays one null check per enqueue.
+
+## Availability
+
+`node:async_hooks` is registered by the loader runtime profile, which means it
+is present in `GocciaScriptLoader`, `GocciaTestRunner`, `GocciaREPL`, and
+`GocciaBenchmarkRunner` without an opt-in. It carries no capability: no I/O, no
+clock, no ambient authority, no way to observe anything the running program did
+not already have. It is context bookkeeping over values the program itself
+supplies, so gating it would add a switch that protects nothing. The address is
+Node's own — there is no `goccia:` spelling — because the surface is Node's
+rather than one GocciaScript invented.
+
+## Semantics and scope
+
+The implemented surface was probed against Node v24.0.1 rather than read off the
+documentation, and matches it on every probe: `run`, `getStore`, `enterWith`,
+`exit`, `disable`, the `defaultValue` and `name` constructor options, the
+`AsyncLocalStorage.bind` and `AsyncLocalStorage.snapshot` statics, and
+`AsyncResource` with `runInAsyncScope`, `bind` (instance and static), `asyncId`,
+`triggerAsyncId`, and `emitDestroy`. Two behaviours are worth recording because
+they are not obvious from the prose: `exit` binds `undefined` rather than
+dropping the binding, so `getStore` inside it reports `undefined` even when the
+instance has a `defaultValue`; and `disable` leaves the default value reachable,
+so `getStore` reports it rather than `undefined`.
+
+Deliberately out of scope:
+
+- **Host-scheduled callbacks.** GocciaScript has no timer task queue and no
+  general event loop, so there is no `setTimeout` continuation for a context to
+  travel into. When a host-scheduled callback surface is added, its scheduling
+  point becomes a third seam; nothing about the snapshot representation has to
+  change for that.
+- **The `async_hooks` observer API.** `createHook`, `executionAsyncId`,
+  `triggerAsyncId`, and the `init`/`before`/`after`/`destroy` callbacks are not
+  provided. They describe an async-resource lifecycle GocciaScript does not
+  have — awaits do not suspend, so there are no resources to report. The
+  per-resource ids `AsyncResource` exposes are unique and stable but relate to
+  nothing else, and `triggerAsyncId` reports the resource's own id.
+- **Cross-realm propagation.** A ShadowRealm child gets its own snapshot state,
+  as it gets its own module records and intrinsics.
+
+`disable()` is implemented as a per-instance flag that `run` and `enterWith`
+clear, which is what Node's observable behaviour requires. It is not a retroactive
+erasure of bindings from snapshots that were already captured: a continuation
+created before the `disable`, resumed after a later `run` re-enabled the
+instance, can still see the store it captured. Reaching that state requires
+disabling an instance and then re-enabling it while an older continuation is
+still pending, and no other behaviour depends on it.
+
+## Consequences
+
+A latent bytecode-VM bug had to be fixed to ship this. `OP_CALL_METHOD`
+recognised `Function.prototype.bind` by the callee's *name*, so any own static
+named `bind` on a function object was silently redirected into
+`TGocciaBoundFunctionValue` — which is exactly what `AsyncLocalStorage.bind` and
+`AsyncResource.bind` are. The check now matches the intrinsic by identity
+(`nikFunctionBind`). The sibling `call` and `apply` fast paths carry the same
+name-based hazard behind a narrower guard and are untouched here.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -121,3 +121,4 @@ Durable architecture and implementation decisions for GocciaScript. New ADRs use
 - [0109 — Engine-integrity faults are never guest-catchable](0109-engine-integrity-faults-are-uncatchable.md)
 - [0110 — The growth gate collects before refusing, and store paths root their temporaries](0110-growth-gate-collects-before-refusing.md)
 - [0111 — Opt-in node_modules resolution](0111-opt-in-node-modules-resolution.md)
+- [0112 — Native AsyncLocalStorage over continuation snapshots](0112-native-async-local-storage.md)

--- a/docs/built-ins-async-context.md
+++ b/docs/built-ins-async-context.md
@@ -38,12 +38,15 @@ const handle = async (request) =>
 | `getStore()` | The bound store, or the instance's `defaultValue` when nothing is bound. A store bound as `undefined` wins over the default value. |
 | `enterWith(store)` | Binds `store` for the rest of the current execution and for continuations created from it. There is no scope to leave, so the binding lasts until whatever installed the surrounding context restores it. Re-enables a disabled instance. |
 | `exit(callback, ...args)` | Calls `callback(...args)` with `undefined` bound — not with the default value — and restores the previous binding afterwards. |
-| `disable()` | `getStore()` reports the `defaultValue` until `run` or `enterWith` is called again. |
+| `disable()` | Deletes the binding from the current context. `getStore()` then reports the `defaultValue` until `run` or `enterWith` binds again. A continuation captured *before* the `disable` still carries the store it captured. |
 
 | Static | Behavior |
 |--------|----------|
-| `AsyncLocalStorage.bind(fn)` | Returns `fn` pinned to the context current at the `bind` call. |
-| `AsyncLocalStorage.snapshot()` | Returns `(fn, ...args) => fn(...args)`, run under the context current at the `snapshot` call. |
+| `AsyncLocalStorage.bind(fn)` | Returns `fn` pinned to the context current at the `bind` call. Throws `TypeError` at the `bind` call if `fn` is not callable. |
+| `AsyncLocalStorage.snapshot()` | Returns `(fn, ...args) => fn(...args)`, run under the context current at the `snapshot` call. It has no callback to validate, so a non-callable is a `TypeError` at the runner's call instead. |
+
+Every function these return is named `bound` and reports its target's `length`,
+as Node's do.
 
 ## AsyncResource
 
@@ -61,9 +64,9 @@ const later = resource.bind(() => requestContext.getStore());
 | Member | Behavior |
 |--------|----------|
 | `new AsyncResource(type, options?)` | Captures the current context. `type` and `options` are accepted and unused. |
-| `runInAsyncScope(fn, thisArg, ...args)` | Calls `fn` under the captured context and returns its result. |
-| `bind(fn, thisArg?)` | Returns `fn` pinned to the captured context. |
-| `AsyncResource.bind(fn, type?, thisArg?)` | Returns `fn` pinned to the context current at the `bind` call. |
+| `runInAsyncScope(fn, thisArg, ...args)` | Calls `fn` under the captured context and returns its result. Unlike `bind`, an omitted `thisArg` means `this` is `undefined` rather than the call site's receiver. |
+| `bind(fn, thisArg?)` | Returns `fn` pinned to the captured context. An undefined `thisArg` leaves the call site's own receiver in place, so a bound function installed as an object method still sees that object as `this`. Throws `TypeError` at the `bind` call if `fn` is not callable. |
+| `AsyncResource.bind(fn, type?, thisArg?)` | Returns `fn` pinned to the context current at the `bind` call, with the same receiver and validation rules. |
 | `asyncId()` / `triggerAsyncId()` | A number unique to the resource. Nothing else in the engine relates to it, and `triggerAsyncId` reports the resource's own id. |
 | `emitDestroy()` | Returns the resource. There are no destroy hooks to emit to. |
 
@@ -80,6 +83,10 @@ storage.run("registered", () => pending.then(handler));
 
 reaches `handler` with `"registered"` bound however `pending` is eventually
 settled.
+
+An async generator body observes the context of whichever call resumed it, in
+both executors and as in Node — a `for await` inside a `run` sees that run's
+store, and a generator resumed outside one sees no store.
 
 It does not travel into host-scheduled callbacks, because there are none:
 GocciaScript has no timer task queue and no general event loop, so there is no

--- a/docs/built-ins-async-context.md
+++ b/docs/built-ins-async-context.md
@@ -1,0 +1,99 @@
+# Async Context
+
+*The `node:async_hooks` surface: stores that travel with a continuation instead of with a call.*
+
+## Executive Summary
+
+- **Node's module, Node's address** — `import { AsyncLocalStorage, AsyncResource } from "node:async_hooks"`, with a default export carrying both, exactly as Node spells it.
+- **The engine propagates the context** — a snapshot of every bound store is captured when a continuation is created and installed when it runs, so a store survives `await`, `.then`, `.catch`, and `.finally`.
+- **Concurrent chains stay separate** — the snapshot holds all instances at once, so interleaved chains and several `AsyncLocalStorage` instances never see each other's stores.
+- **Available everywhere the loader profile is** — it carries no capability, so there is no opt-in flag.
+- **No observer API** — `createHook`, `executionAsyncId`, and the resource lifecycle callbacks are not provided; see [ADR 0112](adr/0112-native-async-local-storage.md).
+
+## AsyncLocalStorage
+
+```javascript
+import { AsyncLocalStorage } from "node:async_hooks";
+
+const requestContext = new AsyncLocalStorage();
+
+const handle = async (request) =>
+  requestContext.run({ id: request.id }, async () => {
+    await loadUser();
+    // Still the same store, on the other side of the await.
+    return requestContext.getStore().id;
+  });
+```
+
+`new AsyncLocalStorage(options?)` accepts an options object with two members:
+
+| Option | Effect |
+|--------|--------|
+| `defaultValue` | What `getStore()` reports when no store is bound. Defaults to `undefined`. |
+| `name` | Read back through the `name` property. Defaults to the empty string. |
+
+| Method | Behavior |
+|--------|----------|
+| `run(store, callback, ...args)` | Binds `store`, calls `callback(...args)`, and restores the previous binding when the synchronous part of `callback` returns. Returns the callback's result. Continuations created while it runs keep the store. Re-enables a disabled instance. |
+| `getStore()` | The bound store, or the instance's `defaultValue` when nothing is bound. A store bound as `undefined` wins over the default value. |
+| `enterWith(store)` | Binds `store` for the rest of the current execution and for continuations created from it. There is no scope to leave, so the binding lasts until whatever installed the surrounding context restores it. Re-enables a disabled instance. |
+| `exit(callback, ...args)` | Calls `callback(...args)` with `undefined` bound — not with the default value — and restores the previous binding afterwards. |
+| `disable()` | `getStore()` reports the `defaultValue` until `run` or `enterWith` is called again. |
+
+| Static | Behavior |
+|--------|----------|
+| `AsyncLocalStorage.bind(fn)` | Returns `fn` pinned to the context current at the `bind` call. |
+| `AsyncLocalStorage.snapshot()` | Returns `(fn, ...args) => fn(...args)`, run under the context current at the `snapshot` call. |
+
+## AsyncResource
+
+An `AsyncResource` captures the async context once, at construction, and replays
+it on demand. It is the mechanism a library uses to run a stored callback under
+the context it was registered in.
+
+```javascript
+import { AsyncResource } from "node:async_hooks";
+
+const resource = new AsyncResource("db-query");
+const later = resource.bind(() => requestContext.getStore());
+```
+
+| Member | Behavior |
+|--------|----------|
+| `new AsyncResource(type, options?)` | Captures the current context. `type` and `options` are accepted and unused. |
+| `runInAsyncScope(fn, thisArg, ...args)` | Calls `fn` under the captured context and returns its result. |
+| `bind(fn, thisArg?)` | Returns `fn` pinned to the captured context. |
+| `AsyncResource.bind(fn, type?, thisArg?)` | Returns `fn` pinned to the context current at the `bind` call. |
+| `asyncId()` / `triggerAsyncId()` | A number unique to the resource. Nothing else in the engine relates to it, and `triggerAsyncId` reports the resource's own id. |
+| `emitDestroy()` | Returns the resource. There are no destroy hooks to emit to. |
+
+## What propagates, and what does not
+
+The context travels with every continuation the engine creates: `await`
+resumptions, `.then` / `.catch` / `.finally` handlers, callbacks passed to
+`queueMicrotask`, and promise reactions registered inside a scope but settled
+outside it. A reaction records the context where it was *registered*, so
+
+```javascript
+storage.run("registered", () => pending.then(handler));
+```
+
+reaches `handler` with `"registered"` bound however `pending` is eventually
+settled.
+
+It does not travel into host-scheduled callbacks, because there are none:
+GocciaScript has no timer task queue and no general event loop, so there is no
+`setTimeout` continuation for a context to reach. The `async_hooks` observer API
+(`createHook`, `executionAsyncId`, and the `init` / `before` / `after` /
+`destroy` callbacks) is not provided either — it describes an async-resource
+lifecycle this engine does not have. [ADR
+0112](adr/0112-native-async-local-storage.md) records both cuts and the
+snapshot mechanism behind the propagation.
+
+## Availability
+
+`node:async_hooks` is installed by the loader runtime profile, so it resolves in
+`GocciaScriptLoader`, `GocciaTestRunner`, `GocciaREPL`, and
+`GocciaBenchmarkRunner` without a flag. It grants no capability — no I/O, no
+clock, no ambient authority — so nothing about it is gated. `GocciaScriptLoaderBare`
+attaches no runtime and therefore does not resolve it.

--- a/docs/built-ins.md
+++ b/docs/built-ins.md
@@ -9,6 +9,7 @@
 - **Core vs runtime registration** — `TGocciaEngine` always registers core language built-ins (Math, Object, Array, String, Number, RegExp, JSON, Symbol, Set, Map, Promise, Temporal, Intl, ArrayBuffer, SharedArrayBuffer, Atomics, TypedArrays, Proxy, Reflect, Iterator, DisposableStack, etc.); `Goccia.Runtime` provides optional runtime globals (Console, Performance, TextEncoder/TextDecoder, URL, fetch, Headers, Response, AbortController/AbortSignal, EventTarget/Event) and import-only `goccia:` runtime modules
 - **Runtime opt-ins** — Testing, benchmarking, FFI, data-format APIs, and SemVer extend the runtime surface through concrete runtime extension classes
 - **Goccia runtime modules** — Non-standard data-format APIs and SemVer are named-export-only modules (`goccia:csv`, `goccia:json5`, `goccia:jsonl`, `goccia:toml`, `goccia:tsv`, `goccia:yaml`, `goccia:semver`); use namespace imports for `CSV.parse(...)`-style call sites
+- **Node-addressed modules** — `node:async_hooks` provides `AsyncLocalStorage` and `AsyncResource` at Node's own address, with engine-level async-context propagation; see [Async Context](built-ins-async-context.md)
 - **Sandbox modules** — `GocciaSandboxRunner` installs import-only `"fs"` and `"goccia"` modules for sandbox filesystem and shell/nested-execution access; they are not globals
 - **ECMAScript shims** — Legacy standard names such as global `parseInt`, `parseFloat`, `isNaN`, `isFinite`, `Date`, `__proto__`, and legacy getter/setter helpers are installed through Goccia.shims
 - **Adding new built-ins** — See [Adding Built-in Types](adding-built-in-types.md) for the step-by-step recipe
@@ -945,6 +946,10 @@ Implements the [WHATWG URLSearchParams](https://developer.mozilla.org/en-US/docs
 ### Fetch runtime APIs
 
 The focused WHATWG `fetch`, `Headers`, `Response`, `AbortController`, `AbortSignal`, `EventTarget`, and `Event` surface is documented in [Fetch Runtime APIs](built-ins-fetch.md). `AbortSignal` inherits from `EventTarget`, so `addEventListener`, `onabort`, and the one-shot `abort` event are available; see [ADR 0104](adr/0104-whatwg-eventtarget-base.md).
+
+### Async context (`node:async_hooks`)
+
+`AsyncLocalStorage` and `AsyncResource` are provided by the loader runtime profile as the import-only module `node:async_hooks`, at Node's own address and with Node's named plus default exports. The engine propagates the async context, so a store survives `await` and every promise-reaction continuation. See [Async Context](built-ins-async-context.md) for the full surface and [ADR 0112](adr/0112-native-async-local-storage.md) for the mechanism and the scope cuts.
 
 ### DisposableStack / AsyncDisposableStack (`Goccia.Builtins.DisposableStack.pas`)
 

--- a/docs/differential-testing.md
+++ b/docs/differential-testing.md
@@ -66,6 +66,18 @@ oracle instead of inheriting a default.
 | `l-modulefndecl.test.js` | language | skip | gate |
 | `m-nodemods.test.js` | language | skip | gate |
 | `n-nodemods.goccia.test.js` | language | skip | skip |
+| `o-asynccontext.test.js` | language | skip | gate |
+
+`o-asynccontext.test.js` covers `node:async_hooks` propagation only, and stops
+there on purpose. Bun 1.3.14 does not honour the `defaultValue` or `name`
+constructor options, leaks the store bound by a `run` that follows a `disable`,
+and returns `undefined` rather than the resource from `emitDestroy`. Gating on
+bun for those four would report bun's gaps as GocciaScript divergences, so they
+are covered against Node's behaviour in `tests/built-ins/AsyncHooks` instead,
+where bun is not the oracle. Everything the suite does check — stores surviving
+`await`, interleaved chains, several instances at once, `.then` / `.catch` /
+`.finally` continuations, `exit`, `enterWith`, and `AsyncResource` — bun and
+Node agree on.
 
 `h-modulemock.test.js` and `i-modulemock-isolation.test.js` are a pair: the
 first mocks `./mods/mockable.js` with a `vi.mock` factory, the second mocks

--- a/docs/differential-testing.md
+++ b/docs/differential-testing.md
@@ -71,15 +71,18 @@ oracle instead of inheriting a default.
 `o-asynccontext.test.js` covers `node:async_hooks` propagation only, and stops
 there on purpose. Bun 1.3.14 does not honour the `defaultValue` or `name`
 constructor options, returns `undefined` rather than the resource from
-`emitDestroy`, and still models `disable()` as an instance-wide flag instead of
-Node's edit of the current context frame — so under bun a continuation captured
-before a `disable` loses its store, and a `run` after one leaks. Gating on bun
-for any of that would report bun's gaps as GocciaScript divergences, so it is
-covered against Node's behaviour in `tests/built-ins/AsyncHooks` instead, where
-bun is not the oracle. Everything the suite does check — stores surviving
-`await`, interleaved chains, several instances at once, `.then` / `.catch` /
-`.finally` continuations, `exit`, `enterWith`, `AsyncResource` receiver and
-validation semantics, and async-generator resumptions — bun and Node agree on.
+`emitDestroy`, models `disable()` as an instance-wide flag instead of Node's
+edit of the current context frame, and substitutes `undefined` where Node
+forwards `bind`'s call-site receiver — and because bun 1.4.0 fixes the last
+two, any assertion in that territory makes the verdict depend on which bun the
+harness happens to run under. Gating on bun for any of it would report the
+oracle's own gaps or version as GocciaScript divergences, so all of it is
+covered against Node's behaviour in `tests/built-ins/AsyncHooks` instead,
+where bun is not the oracle. Everything the suite does check — stores
+surviving `await`, interleaved chains, several instances at once, `.then` /
+`.catch` / `.finally` continuations, `exit`, `enterWith`, bind-time callable
+validation, and async-generator resumptions — every bun since 1.3.14 and Node
+agree on.
 
 `h-modulemock.test.js` and `i-modulemock-isolation.test.js` are a pair: the
 first mocks `./mods/mockable.js` with a `vi.mock` factory, the second mocks

--- a/docs/differential-testing.md
+++ b/docs/differential-testing.md
@@ -70,14 +70,16 @@ oracle instead of inheriting a default.
 
 `o-asynccontext.test.js` covers `node:async_hooks` propagation only, and stops
 there on purpose. Bun 1.3.14 does not honour the `defaultValue` or `name`
-constructor options, leaks the store bound by a `run` that follows a `disable`,
-and returns `undefined` rather than the resource from `emitDestroy`. Gating on
-bun for those four would report bun's gaps as GocciaScript divergences, so they
-are covered against Node's behaviour in `tests/built-ins/AsyncHooks` instead,
-where bun is not the oracle. Everything the suite does check — stores surviving
+constructor options, returns `undefined` rather than the resource from
+`emitDestroy`, and still models `disable()` as an instance-wide flag instead of
+Node's edit of the current context frame — so under bun a continuation captured
+before a `disable` loses its store, and a `run` after one leaks. Gating on bun
+for any of that would report bun's gaps as GocciaScript divergences, so it is
+covered against Node's behaviour in `tests/built-ins/AsyncHooks` instead, where
+bun is not the oracle. Everything the suite does check — stores surviving
 `await`, interleaved chains, several instances at once, `.then` / `.catch` /
-`.finally` continuations, `exit`, `enterWith`, and `AsyncResource` — bun and
-Node agree on.
+`.finally` continuations, `exit`, `enterWith`, `AsyncResource` receiver and
+validation semantics, and async-generator resumptions — bun and Node agree on.
 
 `h-modulemock.test.js` and `i-modulemock-isolation.test.js` are a pair: the
 first mocks `./mods/mockable.js` with a `vi.mock` factory, the second mocks

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -10,7 +10,7 @@
 - **Module resolution** — Pluggable resolver with extensionless imports, import maps, custom content providers, virtual modules, and host modules
 - **Transparent GC** — Mark-and-sweep GC initializes automatically; FPU exceptions are masked for IEEE 754 semantics
 
-Native application embedding is an important secondary GocciaScript goal. `TGocciaRuntime` is the shared Pascal embedding entry point for the runtime layer: filesystem module content loading, runtime module dispatch, and extension installation. Runtime globals such as `console`, `fetch`, and `URL`, plus import-only modules such as `goccia:json5`, `goccia:toml`, `goccia:yaml`, `goccia:csv`, `goccia:tsv`, `goccia:jsonl`, `goccia:semver`, and `goccia:test`, usually come from `ApplyLoaderRuntimeProfile`. `TGocciaEngine` remains available through `Runtime.Engine` and as a core-language-only API for embedders that intentionally do not want runtime globals or runtime modules.
+Native application embedding is an important secondary GocciaScript goal. `TGocciaRuntime` is the shared Pascal embedding entry point for the runtime layer: filesystem module content loading, runtime module dispatch, and extension installation. Runtime globals such as `console`, `fetch`, and `URL`, plus import-only modules such as `goccia:json5`, `goccia:toml`, `goccia:yaml`, `goccia:csv`, `goccia:tsv`, `goccia:jsonl`, `goccia:semver`, `goccia:test`, and `node:async_hooks`, usually come from `ApplyLoaderRuntimeProfile`. `TGocciaEngine` remains available through `Runtime.Engine` and as a core-language-only API for embedders that intentionally do not want runtime globals or runtime modules.
 
 ## Quick Start
 
@@ -35,7 +35,7 @@ For files, load `app.js` into the `Source` list, pass the real filename to `TGoc
 
 ### Class Methods (One-Shot Execution)
 
-These helpers create, execute, and clean up in a single call. The `TGocciaEngine` methods create a core-language-only engine. The `TGocciaRuntime` methods attach the runtime layer for file loading, but they do not apply a runtime profile; install runtime extensions explicitly when scripts need runtime globals such as `console`, `fetch`, and `URL`, or import-only modules such as `goccia:json5`, `goccia:toml`, `goccia:yaml`, `goccia:csv`, `goccia:tsv`, `goccia:jsonl`, or `goccia:semver`.
+These helpers create, execute, and clean up in a single call. The `TGocciaEngine` methods create a core-language-only engine. The `TGocciaRuntime` methods attach the runtime layer for file loading, but they do not apply a runtime profile; install runtime extensions explicitly when scripts need runtime globals such as `console`, `fetch`, and `URL`, or import-only modules such as `goccia:json5`, `goccia:toml`, `goccia:yaml`, `goccia:csv`, `goccia:tsv`, `goccia:jsonl`, `goccia:semver`, or `node:async_hooks`.
 
 | Method | Description |
 |--------|-------------|
@@ -465,7 +465,7 @@ The CLI hosts based on `TGocciaCLIApplication` (ScriptLoader, TestRunner, Benchm
 
 ## Built-in Registration
 
-Core language built-ins (Math, Object, Array, JSON, Promise, Temporal, typed arrays, etc.) are registered by `TGocciaEngine`. Runtime globals that are not part of the language core (Console, TextEncoder/TextDecoder, URL, fetch, performance, etc.) and import-only runtime modules (`goccia:csv`, `goccia:json5`, `goccia:jsonl`, `goccia:toml`, `goccia:tsv`, `goccia:yaml`, `goccia:semver`, `goccia:test`) are provided by concrete runtime units. Hosts can call `ApplyLoaderRuntimeProfile` for the ordinary CLI runtime surface or install only the extension classes they need for a smaller runtime surface. `ApplyLoaderRuntimeProfile(ARuntime, False)` suppresses the `goccia:test` registration for a host that installs `TGocciaTestingLibraryRuntimeExtension` itself — the testing globals are opt-in through that extension and are never part of the profile. The `goccia:` modules expose named exports only; callers can use namespace imports such as `import * as CSV from "goccia:csv"` when they want namespace-style access.
+Core language built-ins (Math, Object, Array, JSON, Promise, Temporal, typed arrays, etc.) are registered by `TGocciaEngine`. Runtime globals that are not part of the language core (Console, TextEncoder/TextDecoder, URL, fetch, performance, etc.) and import-only runtime modules (`goccia:csv`, `goccia:json5`, `goccia:jsonl`, `goccia:toml`, `goccia:tsv`, `goccia:yaml`, `goccia:semver`, `goccia:test`, `node:async_hooks`) are provided by concrete runtime units. Hosts can call `ApplyLoaderRuntimeProfile` for the ordinary CLI runtime surface or install only the extension classes they need for a smaller runtime surface. `ApplyLoaderRuntimeProfile(ARuntime, False)` suppresses the `goccia:test` registration for a host that installs `TGocciaTestingLibraryRuntimeExtension` itself — the testing globals are opt-in through that extension and are never part of the profile. The `goccia:` modules expose named exports only; callers can use namespace imports such as `import * as CSV from "goccia:csv"` when they want namespace-style access.
 
 When you already have an engine, pass it to the runtime constructor:
 

--- a/docs/testing-api.md
+++ b/docs/testing-api.md
@@ -671,6 +671,8 @@ expect(set).toEqual(new Set([2, 1]));
 
 **GocciaScript-specific behaviors** --- Some tests exercise GocciaScript extensions or intentional divergences from the spec (e.g., `Math.clamp`, emoji identifiers, arrow function `this` binding in object methods). These will fail in Vitest since standard JS doesn't support them. This is expected.
 
+**Async context** --- A suite whose library keeps per-request state in `AsyncLocalStorage` runs unchanged: `node:async_hooks` is present in `GocciaTestRunner`, and the engine propagates the context across `await` and every promise-reaction continuation. See [Async Context](built-ins-async-context.md) for the surface and the two things that are out of scope (host-scheduled callbacks and the `async_hooks` observer API).
+
 ### Known Vitest Divergences
 
 | Category | GocciaScript | Standard JS |
@@ -694,3 +696,4 @@ One of those rows is worth expanding, because it cost a debugging session before
 
 - [Testing](testing.md) --- test organization, directory layout, running tests, and test principles
 - [Built-ins](built-ins.md) --- test assertion built-in reference
+- [Async Context](built-ins-async-context.md) --- `node:async_hooks` for suites whose code under test carries per-request state

--- a/scripts/differential/o-asynccontext.test.js
+++ b/scripts/differential/o-asynccontext.test.js
@@ -241,18 +241,10 @@ describe("async context propagation", () => {
     expect(read()).toEqual(["target", 1]);
   });
 
-  test("bind forwards the call-site receiver when thisArg is undefined", () => {
-    const als = new AsyncLocalStorage();
-    const read = ({ read() { return this.tag; } }).read;
-    let bound;
-    let explicit;
-    als.run("ctx", () => {
-      bound = AsyncResource.bind(read);
-      explicit = new AsyncResource("probe").bind(read, { tag: "explicit" });
-    });
-    expect(({ tag: "holder", method: bound }).method()).toBe("holder");
-    expect(({ tag: "holder", method: explicit }).method()).toBe("explicit");
-  });
+  // Receiver forwarding for an undefined thisArg is NOT asserted here: bun
+  // 1.3.14 substitutes undefined where Node forwards the call-site receiver
+  // (fixed in bun 1.4.0), so gating on it makes the verdict depend on the
+  // oracle's version. Covered against Node in tests/built-ins/AsyncHooks.
 
   test("bind rejects a non-callable at bind time", () => {
     expect(() => AsyncResource.bind(42)).toThrow(TypeError);
@@ -260,18 +252,10 @@ describe("async context propagation", () => {
     expect(() => AsyncLocalStorage.bind(42)).toThrow(TypeError);
   });
 
-  test("disabling inside an inner run leaves the outer store intact", () => {
-    const als = new AsyncLocalStorage();
-    const seen = [];
-    als.run("outer", () => {
-      als.run("inner", () => {
-        als.disable();
-        seen.push(als.getStore());
-      });
-      seen.push(als.getStore());
-    });
-    expect(seen).toEqual([undefined, "outer"]);
-  });
+  // disable() semantics are NOT asserted here at all: bun 1.3.14 models
+  // disable as an instance-wide flag where Node edits the current context
+  // frame (bun 1.4.0 matches Node), so any disable-shaped assertion gates on
+  // the oracle's version. Covered against Node in tests/built-ins/AsyncHooks.
 
   test("an async generator body observes the resuming call's store", async () => {
     const als = new AsyncLocalStorage();

--- a/scripts/differential/o-asynccontext.test.js
+++ b/scripts/differential/o-asynccontext.test.js
@@ -1,0 +1,241 @@
+// Async-context propagation through node:async_hooks.
+//
+// Scope is deliberately the propagation core — the part bun, Node and
+// GocciaScript agree on. The constructor options (`defaultValue`, `name`),
+// `disable()` re-enablement and `emitDestroy()`'s return value are covered by
+// tests/built-ins/AsyncHooks instead: bun 1.3.14 diverges from Node on all
+// four, so gating on bun there would report bun's gaps as GocciaScript
+// divergences. See the CLASSIFICATION entry in scripts/test-cli-differential.ts.
+
+import { AsyncLocalStorage, AsyncResource } from "node:async_hooks";
+
+describe("async context propagation", () => {
+  test("the store survives an await", async () => {
+    const als = new AsyncLocalStorage();
+    await als.run("ctx-1", async () => {
+      expect(als.getStore()).toBe("ctx-1");
+      await Promise.resolve();
+      expect(als.getStore()).toBe("ctx-1");
+    });
+    expect(als.getStore()).toBe(undefined);
+  });
+
+  test("interleaved chains keep separate stores", async () => {
+    const als = new AsyncLocalStorage();
+    const seen = [];
+    await Promise.all([
+      als.run("a", async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+        seen.push(als.getStore());
+      }),
+      als.run("b", async () => {
+        await Promise.resolve();
+        seen.push(als.getStore());
+      }),
+    ]);
+    expect(seen.sort()).toEqual(["a", "b"]);
+  });
+
+  test("many concurrent chains each keep their own store", async () => {
+    const als = new AsyncLocalStorage();
+    const observed = [];
+    const chain = (tag) =>
+      als.run(tag, async () => {
+        for (const step of [0, 1, 2]) {
+          await Promise.resolve();
+          observed.push(tag === als.getStore());
+        }
+      });
+    await Promise.all([chain(1), chain(2), chain(3)]);
+    expect(observed).toEqual([true, true, true, true, true, true, true, true, true]);
+  });
+
+  test("nested runs restore the enclosing store", () => {
+    const als = new AsyncLocalStorage();
+    const seen = [];
+    als.run("outer", () => {
+      als.run("inner", () => seen.push(als.getStore()));
+      seen.push(als.getStore());
+    });
+    expect(seen).toEqual(["inner", "outer"]);
+  });
+
+  test("three instances stay independent across awaits", async () => {
+    const first = new AsyncLocalStorage();
+    const second = new AsyncLocalStorage();
+    const third = new AsyncLocalStorage();
+    const seen = [];
+    await first.run("X", async () => {
+      await second.run("Y", async () => {
+        await third.run("Z", async () => {
+          await Promise.resolve();
+          seen.push([first.getStore(), second.getStore(), third.getStore()]);
+        });
+        seen.push([first.getStore(), second.getStore(), third.getStore()]);
+      });
+    });
+    seen.push([first.getStore(), second.getStore(), third.getStore()]);
+    expect(seen).toEqual([
+      ["X", "Y", "Z"],
+      ["X", "Y", undefined],
+      [undefined, undefined, undefined],
+    ]);
+  });
+
+  test("exit clears the store for its callback only", () => {
+    const als = new AsyncLocalStorage();
+    const seen = [];
+    als.run("with-store", () => {
+      als.exit(() => seen.push(als.getStore()));
+      seen.push(als.getStore());
+    });
+    expect(seen).toEqual([undefined, "with-store"]);
+  });
+
+  test("enterWith binds for the rest of the execution, including after an await", async () => {
+    const als = new AsyncLocalStorage();
+    const seen = [];
+    await als.run("start", async () => {
+      await Promise.resolve();
+      als.enterWith("entered");
+      seen.push(als.getStore());
+      await Promise.resolve();
+      seen.push(als.getStore());
+    });
+    seen.push(als.getStore());
+    expect(seen).toEqual(["entered", "entered", undefined]);
+  });
+
+  test("a then registered inside run sees the store when settled outside", async () => {
+    const als = new AsyncLocalStorage();
+    let settle;
+    const pending = new Promise((resolve) => {
+      settle = resolve;
+    });
+    const chained = als.run("registered", () =>
+      pending.then(() => als.getStore()));
+    settle(1);
+    expect(await chained).toBe("registered");
+    expect(als.getStore()).toBe(undefined);
+  });
+
+  test("catch and finally continuations carry the store", async () => {
+    const als = new AsyncLocalStorage();
+    const seen = [];
+    await als.run("handled", () =>
+      Promise.reject(new Error("rejected"))
+        .catch(() => seen.push(als.getStore()))
+        .finally(() => seen.push(als.getStore())));
+    expect(seen).toEqual(["handled", "handled"]);
+  });
+
+  test("a foreign continuation does not leak into the frame that drained it", async () => {
+    const als = new AsyncLocalStorage();
+    const seen = [];
+    let settle;
+    const pending = new Promise((resolve) => {
+      settle = resolve;
+    });
+    als.run("foreign", () => {
+      pending.then(() => seen.push(als.getStore()));
+    });
+
+    await als.run("own", async () => {
+      settle(1);
+      await pending;
+      seen.push(als.getStore());
+    });
+    seen.push(als.getStore());
+    expect(seen).toEqual(["foreign", "own", undefined]);
+  });
+
+  test("a callback that throws after an await still restores the store", async () => {
+    const als = new AsyncLocalStorage();
+    const seen = [];
+    let message = null;
+    try {
+      await als.run("rejecting", async () => {
+        await Promise.resolve();
+        seen.push(als.getStore());
+        throw new Error("boom");
+      });
+    } catch (error) {
+      message = error.message;
+    }
+    seen.push(message);
+    seen.push(als.getStore());
+    expect(seen).toEqual(["rejecting", "boom", undefined]);
+  });
+
+  test("a rejection awaited inside the callback keeps the store", async () => {
+    const als = new AsyncLocalStorage();
+    const seen = [];
+    await als.run("kept", async () => {
+      try {
+        await Promise.reject(new Error("inner"));
+      } catch {
+        seen.push("caught");
+      }
+      seen.push(als.getStore());
+    });
+    seen.push(als.getStore());
+    expect(seen).toEqual(["caught", "kept", undefined]);
+  });
+
+  test("a queued microtask sees the store of the scope that queued it", async () => {
+    const als = new AsyncLocalStorage();
+    let seen = "unset";
+    als.run("queued", () => {
+      queueMicrotask(() => {
+        seen = als.getStore();
+      });
+    });
+    await Promise.resolve();
+    expect(seen).toBe("queued");
+  });
+
+  test("run returns the callback result and forwards extra arguments", () => {
+    const als = new AsyncLocalStorage();
+    expect(als.run("ctx", () => 42)).toBe(42);
+    expect(als.run("ctx", (first, second) => [first, second, als.getStore()], 1, 2))
+      .toEqual([1, 2, "ctx"]);
+  });
+
+  test("AsyncResource replays the context it captured", async () => {
+    const als = new AsyncLocalStorage();
+    let resource;
+    let bound;
+    let staticBound;
+    als.run("captured", () => {
+      resource = new AsyncResource("probe");
+      bound = resource.bind(() => als.getStore());
+      staticBound = AsyncResource.bind(() => als.getStore());
+    });
+    expect(resource.runInAsyncScope(() => als.getStore())).toBe("captured");
+    expect(bound()).toBe("captured");
+    expect(staticBound()).toBe("captured");
+    expect(await resource.runInAsyncScope(async () => {
+      await Promise.resolve();
+      return als.getStore();
+    })).toBe("captured");
+    expect(als.getStore()).toBe(undefined);
+  });
+
+  test("AsyncLocalStorage.bind and .snapshot pin to the calling context", () => {
+    const als = new AsyncLocalStorage();
+    let bound;
+    let snapshot;
+    als.run("pinned", () => {
+      bound = AsyncLocalStorage.bind(() => als.getStore());
+      snapshot = AsyncLocalStorage.snapshot();
+    });
+    expect(bound()).toBe("pinned");
+    expect(snapshot(() => als.getStore())).toBe("pinned");
+  });
+
+  test("a static named bind does not shadow Function.prototype.bind", () => {
+    const read = ((value) => ["target", value]).bind(null, 1);
+    expect(read()).toEqual(["target", 1]);
+  });
+});

--- a/scripts/differential/o-asynccontext.test.js
+++ b/scripts/differential/o-asynccontext.test.js
@@ -1,11 +1,13 @@
 // Async-context propagation through node:async_hooks.
 //
 // Scope is deliberately the propagation core — the part bun, Node and
-// GocciaScript agree on. The constructor options (`defaultValue`, `name`),
-// `disable()` re-enablement and `emitDestroy()`'s return value are covered by
-// tests/built-ins/AsyncHooks instead: bun 1.3.14 diverges from Node on all
-// four, so gating on bun there would report bun's gaps as GocciaScript
-// divergences. See the CLASSIFICATION entry in scripts/test-cli-differential.ts.
+// GocciaScript agree on. Everything about `disable()` and the constructor
+// options (`defaultValue`, `name`), plus `emitDestroy()`'s return value, is
+// covered by tests/built-ins/AsyncHooks instead: bun 1.3.14 diverges from Node
+// on all of them — it still models `disable()` as an instance-wide flag, so a
+// continuation captured before the disable loses its store — and gating on bun
+// there would report bun's gaps as GocciaScript divergences. See the
+// CLASSIFICATION entry in scripts/test-cli-differential.ts.
 
 import { AsyncLocalStorage, AsyncResource } from "node:async_hooks";
 
@@ -237,5 +239,69 @@ describe("async context propagation", () => {
   test("a static named bind does not shadow Function.prototype.bind", () => {
     const read = ((value) => ["target", value]).bind(null, 1);
     expect(read()).toEqual(["target", 1]);
+  });
+
+  test("bind forwards the call-site receiver when thisArg is undefined", () => {
+    const als = new AsyncLocalStorage();
+    const read = ({ read() { return this.tag; } }).read;
+    let bound;
+    let explicit;
+    als.run("ctx", () => {
+      bound = AsyncResource.bind(read);
+      explicit = new AsyncResource("probe").bind(read, { tag: "explicit" });
+    });
+    expect(({ tag: "holder", method: bound }).method()).toBe("holder");
+    expect(({ tag: "holder", method: explicit }).method()).toBe("explicit");
+  });
+
+  test("bind rejects a non-callable at bind time", () => {
+    expect(() => AsyncResource.bind(42)).toThrow(TypeError);
+    expect(() => new AsyncResource("probe").bind(42)).toThrow(TypeError);
+    expect(() => AsyncLocalStorage.bind(42)).toThrow(TypeError);
+  });
+
+  test("disabling inside an inner run leaves the outer store intact", () => {
+    const als = new AsyncLocalStorage();
+    const seen = [];
+    als.run("outer", () => {
+      als.run("inner", () => {
+        als.disable();
+        seen.push(als.getStore());
+      });
+      seen.push(als.getStore());
+    });
+    expect(seen).toEqual([undefined, "outer"]);
+  });
+
+  test("an async generator body observes the resuming call's store", async () => {
+    const als = new AsyncLocalStorage();
+    const seen = [];
+    const source = {
+      async *values() {
+        seen.push(als.getStore());
+        yield 1;
+        seen.push(als.getStore());
+        await Promise.resolve();
+        seen.push(als.getStore());
+        yield 2;
+      },
+    };
+
+    await als.run("GEN", async () => {
+      for await (const value of source.values()) {
+        seen.push(als.getStore() + ":" + value);
+      }
+    });
+
+    const iterator = source.values();
+    await iterator.next();
+    await als.run("RESUMER", async () => {
+      await iterator.next();
+    });
+
+    expect(seen).toEqual([
+      "GEN", "GEN:1", "GEN", "GEN", "GEN:2",
+      undefined, "RESUMER", "RESUMER",
+    ]);
   });
 });

--- a/scripts/test-cli-differential.ts
+++ b/scripts/test-cli-differential.ts
@@ -165,6 +165,17 @@ const CLASSIFICATION: Record<string, Classification> = {
     vitest: "skip",
     gocciaFlags: ["--allow-node-modules"],
   },
+  // node:async_hooks context propagation. Bun gates: async-context propagation
+  // is runtime semantics, not testing-API semantics, and bun implements
+  // node:async_hooks. Vitest is skipped for the same reason — nothing here is
+  // a matcher or a hook.
+  //
+  // The suite deliberately covers propagation only. Bun 1.3.14 does not honour
+  // the `defaultValue` or `name` constructor options, leaks the store bound by
+  // a `run` that follows a `disable`, and returns undefined rather than the
+  // resource from `emitDestroy`; all four are covered against Node's behaviour
+  // in tests/built-ins/AsyncHooks, where bun is not the oracle.
+  "o-asynccontext.test.js": { kind: "language", bun: "gate", vitest: "skip" },
 };
 
 type Verdict = {

--- a/scripts/test-cli-differential.ts
+++ b/scripts/test-cli-differential.ts
@@ -171,10 +171,12 @@ const CLASSIFICATION: Record<string, Classification> = {
   // a matcher or a hook.
   //
   // The suite deliberately covers propagation only. Bun 1.3.14 does not honour
-  // the `defaultValue` or `name` constructor options, leaks the store bound by
-  // a `run` that follows a `disable`, and returns undefined rather than the
-  // resource from `emitDestroy`; all four are covered against Node's behaviour
-  // in tests/built-ins/AsyncHooks, where bun is not the oracle.
+  // the `defaultValue` or `name` constructor options, returns undefined rather
+  // than the resource from `emitDestroy`, and still models `disable()` as an
+  // instance-wide flag rather than Node's edit of the current context frame —
+  // so under bun a continuation captured before a `disable` loses its store,
+  // and a `run` after one leaks. All of that is covered against Node's
+  // behaviour in tests/built-ins/AsyncHooks, where bun is not the oracle.
   "o-asynccontext.test.js": { kind: "language", bun: "gate", vitest: "skip" },
 };
 

--- a/source/units/Goccia.AsyncContext.pas
+++ b/source/units/Goccia.AsyncContext.pas
@@ -55,8 +55,41 @@ type
   nil is the empty snapshot rather than a missing one, so a program that never
   touches AsyncLocalStorage allocates nothing. }
 function CurrentAsyncContext: TGocciaAsyncContextSnapshot;
+
+{ Replaces the current snapshot without saving the old one. For the operations
+  that deliberately mutate the ambient context and never restore it —
+  `enterWith` and `disable`. Every scoped installation must use
+  EnterAsyncContext/LeaveAsyncContext instead. }
 procedure SetCurrentAsyncContext(
   const ASnapshot: TGocciaAsyncContextSnapshot);
+
+{ Installs ASnapshot and saves the outgoing one on a stack the collector also
+  marks, returning the token LeaveAsyncContext needs.
+
+  The stack is what makes the save safe. A displaced snapshot is reachable from
+  nothing else — the current-context slot is its only root — so holding it in a
+  bare Pascal local across a guest call let a collection inside that call free
+  it and left the restore writing a dangling pointer. Guest code reaches a
+  collection safe point trivially (`Goccia.gc()`, or any allocation once the
+  threshold is met), so this was a crash in practice, not in theory.
+
+  The token is the stack depth at entry rather than a pop count, so a frame
+  restores to the depth it was entered at and cannot unwind past an enclosing
+  frame's entry even if the stack is left unbalanced beneath it. }
+function EnterAsyncContext(
+  const ASnapshot: TGocciaAsyncContextSnapshot): Integer;
+procedure LeaveAsyncContext(const AToken: Integer);
+
+{ Drops every snapshot this thread is holding. Called when an engine is torn
+  down, because snapshots reference that engine's objects and the next engine
+  on the same thread must not inherit them.
+
+  `enterWith` is why this is not merely tidy: it installs a context with no
+  scope to leave, so a program that calls it outside a `run` deliberately
+  leaves one in effect when it ends. Without this reset the next engine on the
+  worker thread started with the previous engine's snapshot still current, and
+  marking it walked objects belonging to a realm that no longer exists. }
+procedure ResetAsyncContextState;
 
 { Both derivations tolerate a nil source snapshot and return nil when the
   result would be empty, so the nil-is-empty representation is closed. }
@@ -85,16 +118,29 @@ type
     property Collector: TGarbageCollector read FCollector write FCollector;
   end;
 
+const
+  SAVED_SNAPSHOT_INITIAL_CAPACITY = 8;
+
 threadvar
   GCurrentSnapshot: TGocciaAsyncContextSnapshot;
   GSnapshotRoots: TGocciaAsyncContextRoots;
+  { Snapshots displaced by an active EnterAsyncContext, innermost last. Held
+    here rather than only in the entering frame's local so that they stay
+    reachable for the collector while guest code runs. }
+  GSavedSnapshots: TArray<TGocciaAsyncContextSnapshot>;
+  GSavedSnapshotCount: Integer;
 
 { TGocciaAsyncContextRoots }
 
 procedure TGocciaAsyncContextRoots.MarkRootReferences;
+var
+  I: Integer;
 begin
   if Assigned(GCurrentSnapshot) then
     GCurrentSnapshot.MarkReferences;
+  for I := 0 to GSavedSnapshotCount - 1 do
+    if Assigned(GSavedSnapshots[I]) then
+      GSavedSnapshots[I].MarkReferences;
 end;
 
 { TGocciaAsyncContextSnapshot }
@@ -177,6 +223,39 @@ begin
     EnsureSnapshotRoots;
 end;
 
+function EnterAsyncContext(
+  const ASnapshot: TGocciaAsyncContextSnapshot): Integer;
+begin
+  if GSavedSnapshotCount >= Length(GSavedSnapshots) then
+    SetLength(GSavedSnapshots,
+      GSavedSnapshotCount * 2 + SAVED_SNAPSHOT_INITIAL_CAPACITY);
+
+  Result := GSavedSnapshotCount;
+  GSavedSnapshots[Result] := GCurrentSnapshot;
+  Inc(GSavedSnapshotCount);
+  GCurrentSnapshot := ASnapshot;
+
+  { The root source has to exist before the first collection that could see
+    either slot, and either slot may be the only reference to a snapshot. }
+  if Assigned(ASnapshot) or Assigned(GSavedSnapshots[Result]) then
+    EnsureSnapshotRoots;
+end;
+
+procedure LeaveAsyncContext(const AToken: Integer);
+var
+  I: Integer;
+begin
+  if (AToken < 0) or (AToken >= GSavedSnapshotCount) then
+    Exit;
+
+  GCurrentSnapshot := GSavedSnapshots[AToken];
+  { Drop the released entries so a snapshot that is no longer reachable is not
+    kept alive by a stale slot above the new top. }
+  for I := AToken to GSavedSnapshotCount - 1 do
+    GSavedSnapshots[I] := nil;
+  GSavedSnapshotCount := AToken;
+end;
+
 function DeriveAsyncContext(const ASnapshot: TGocciaAsyncContextSnapshot;
   const AKey, AStore: TGocciaValue): TGocciaAsyncContextSnapshot;
 var
@@ -252,10 +331,23 @@ begin
   Result := Derived;
 end;
 
-procedure CleanupAsyncContextThreadState;
+procedure ResetAsyncContextState;
+var
+  I: Integer;
 begin
   GCurrentSnapshot := nil;
+  for I := 0 to High(GSavedSnapshots) do
+    GSavedSnapshots[I] := nil;
+  GSavedSnapshotCount := 0;
+  { The root source is dropped too: it registered with the collector this
+    engine used, and the next engine gets a fresh registration on demand. }
   FreeAndNil(GSnapshotRoots);
+end;
+
+procedure CleanupAsyncContextThreadState;
+begin
+  ResetAsyncContextState;
+  SetLength(GSavedSnapshots, 0);
 end;
 
 initialization

--- a/source/units/Goccia.AsyncContext.pas
+++ b/source/units/Goccia.AsyncContext.pas
@@ -1,0 +1,264 @@
+{ Continuation-scoped async context.
+
+  One snapshot holds every AsyncLocalStorage binding that is in effect for a
+  continuation: a small association list from the storage instance to the store
+  it carries. Snapshots are immutable — deriving a binding copies the entries
+  once — so a continuation that captured a snapshot keeps seeing exactly the
+  bindings that were in effect when it was created, no matter what the code
+  that created it does afterwards.
+
+  Two seams keep the current snapshot travelling with continuations, and both
+  live in the machinery both executors share:
+
+    - a promise reaction records the snapshot in effect when it is registered
+      (Goccia.Values.PromiseValue), and
+    - the microtask queue installs a job's snapshot while the job runs and
+      restores the previous one afterwards (Goccia.MicrotaskQueue).
+
+  `await` needs no seam of its own. GocciaScript drains awaits synchronously
+  inside the awaiting call, so the awaiting frame never leaves the Pascal
+  stack; the drained jobs restore the snapshot they found, which leaves the
+  awaiting frame's own snapshot in place across the await.
+
+  The current snapshot is a garbage-collection root: it is reachable from
+  nothing else while a `run` callback executes, and the stores it holds are
+  ordinary JavaScript values. }
+
+unit Goccia.AsyncContext;
+
+{$I Goccia.inc}
+
+interface
+
+uses
+  Goccia.Values.ObjectValue,
+  Goccia.Values.Primitives;
+
+type
+  { An immutable set of AsyncLocalStorage bindings. Never exposed to
+    JavaScript; it descends from TGocciaObjectValue only so the collector
+    traces the stores it holds through the ordinary MarkReferences path. }
+  TGocciaAsyncContextSnapshot = class(TGocciaObjectValue)
+  private
+    FKeys: TArray<TGocciaValue>;
+    FStores: TArray<TGocciaValue>;
+    FCount: Integer;
+    function IndexOfKey(const AKey: TGocciaValue): Integer;
+  public
+    constructor Create;
+    function TryGetStore(const AKey: TGocciaValue;
+      out AStore: TGocciaValue): Boolean;
+    procedure MarkReferences; override;
+  end;
+
+{ The snapshot in effect on this thread, or nil when no binding is in effect.
+  nil is the empty snapshot rather than a missing one, so a program that never
+  touches AsyncLocalStorage allocates nothing. }
+function CurrentAsyncContext: TGocciaAsyncContextSnapshot;
+procedure SetCurrentAsyncContext(
+  const ASnapshot: TGocciaAsyncContextSnapshot);
+
+{ Both derivations tolerate a nil source snapshot and return nil when the
+  result would be empty, so the nil-is-empty representation is closed. }
+function DeriveAsyncContext(const ASnapshot: TGocciaAsyncContextSnapshot;
+  const AKey, AStore: TGocciaValue): TGocciaAsyncContextSnapshot;
+function DeriveAsyncContextWithout(
+  const ASnapshot: TGocciaAsyncContextSnapshot;
+  const AKey: TGocciaValue): TGocciaAsyncContextSnapshot;
+
+implementation
+
+uses
+  SysUtils,
+
+  Goccia.GarbageCollector,
+  Goccia.ThreadCleanupRegistry;
+
+type
+  { Publishes the current snapshot to the collector. One instance per thread,
+    created the first time a binding takes effect on that thread. }
+  TGocciaAsyncContextRoots = class(TGCRootSource)
+  private
+    FCollector: TGarbageCollector;
+  public
+    procedure MarkRootReferences; override;
+    property Collector: TGarbageCollector read FCollector write FCollector;
+  end;
+
+threadvar
+  GCurrentSnapshot: TGocciaAsyncContextSnapshot;
+  GSnapshotRoots: TGocciaAsyncContextRoots;
+
+{ TGocciaAsyncContextRoots }
+
+procedure TGocciaAsyncContextRoots.MarkRootReferences;
+begin
+  if Assigned(GCurrentSnapshot) then
+    GCurrentSnapshot.MarkReferences;
+end;
+
+{ TGocciaAsyncContextSnapshot }
+
+constructor TGocciaAsyncContextSnapshot.Create;
+begin
+  inherited Create(nil);
+  FCount := 0;
+end;
+
+function TGocciaAsyncContextSnapshot.IndexOfKey(
+  const AKey: TGocciaValue): Integer;
+var
+  I: Integer;
+begin
+  for I := 0 to FCount - 1 do
+    if FKeys[I] = AKey then
+      Exit(I);
+  Result := -1;
+end;
+
+function TGocciaAsyncContextSnapshot.TryGetStore(const AKey: TGocciaValue;
+  out AStore: TGocciaValue): Boolean;
+var
+  Index: Integer;
+begin
+  AStore := nil;
+  Index := IndexOfKey(AKey);
+  Result := Index >= 0;
+  if Result then
+    AStore := FStores[Index];
+end;
+
+procedure TGocciaAsyncContextSnapshot.MarkReferences;
+var
+  I: Integer;
+begin
+  if GCMarked then Exit;
+  inherited;
+
+  for I := 0 to FCount - 1 do
+  begin
+    if Assigned(FKeys[I]) then
+      FKeys[I].MarkReferences;
+    if Assigned(FStores[I]) then
+      FStores[I].MarkReferences;
+  end;
+end;
+
+{ Current snapshot }
+
+function CurrentAsyncContext: TGocciaAsyncContextSnapshot;
+begin
+  Result := GCurrentSnapshot;
+end;
+
+{ The root source registers with whichever collector is current when it is
+  built, so a thread whose collector was replaced needs a fresh one. }
+procedure EnsureSnapshotRoots;
+var
+  Collector: TGarbageCollector;
+begin
+  Collector := TGarbageCollector.Instance;
+  if Assigned(GSnapshotRoots) and (GSnapshotRoots.Collector = Collector) then
+    Exit;
+
+  FreeAndNil(GSnapshotRoots);
+  if not Assigned(Collector) then
+    Exit;
+
+  GSnapshotRoots := TGocciaAsyncContextRoots.Create;
+  GSnapshotRoots.Collector := Collector;
+end;
+
+procedure SetCurrentAsyncContext(
+  const ASnapshot: TGocciaAsyncContextSnapshot);
+begin
+  GCurrentSnapshot := ASnapshot;
+  if Assigned(ASnapshot) then
+    EnsureSnapshotRoots;
+end;
+
+function DeriveAsyncContext(const ASnapshot: TGocciaAsyncContextSnapshot;
+  const AKey, AStore: TGocciaValue): TGocciaAsyncContextSnapshot;
+var
+  Derived: TGocciaAsyncContextSnapshot;
+  Existing, I: Integer;
+begin
+  Derived := TGocciaAsyncContextSnapshot.Create;
+
+  if not Assigned(ASnapshot) then
+  begin
+    SetLength(Derived.FKeys, 1);
+    SetLength(Derived.FStores, 1);
+    Derived.FKeys[0] := AKey;
+    Derived.FStores[0] := AStore;
+    Derived.FCount := 1;
+    Exit(Derived);
+  end;
+
+  Existing := ASnapshot.IndexOfKey(AKey);
+  if Existing >= 0 then
+    Derived.FCount := ASnapshot.FCount
+  else
+    Derived.FCount := ASnapshot.FCount + 1;
+  SetLength(Derived.FKeys, Derived.FCount);
+  SetLength(Derived.FStores, Derived.FCount);
+
+  for I := 0 to ASnapshot.FCount - 1 do
+  begin
+    Derived.FKeys[I] := ASnapshot.FKeys[I];
+    Derived.FStores[I] := ASnapshot.FStores[I];
+  end;
+
+  if Existing >= 0 then
+    Derived.FStores[Existing] := AStore
+  else
+  begin
+    Derived.FKeys[Derived.FCount - 1] := AKey;
+    Derived.FStores[Derived.FCount - 1] := AStore;
+  end;
+
+  Result := Derived;
+end;
+
+function DeriveAsyncContextWithout(
+  const ASnapshot: TGocciaAsyncContextSnapshot;
+  const AKey: TGocciaValue): TGocciaAsyncContextSnapshot;
+var
+  Derived: TGocciaAsyncContextSnapshot;
+  I, Target: Integer;
+begin
+  if not Assigned(ASnapshot) then
+    Exit(nil);
+  if ASnapshot.IndexOfKey(AKey) < 0 then
+    Exit(ASnapshot);
+  if ASnapshot.FCount = 1 then
+    Exit(nil);
+
+  Derived := TGocciaAsyncContextSnapshot.Create;
+  Derived.FCount := ASnapshot.FCount - 1;
+  SetLength(Derived.FKeys, Derived.FCount);
+  SetLength(Derived.FStores, Derived.FCount);
+
+  Target := 0;
+  for I := 0 to ASnapshot.FCount - 1 do
+  begin
+    if ASnapshot.FKeys[I] = AKey then
+      Continue;
+    Derived.FKeys[Target] := ASnapshot.FKeys[I];
+    Derived.FStores[Target] := ASnapshot.FStores[I];
+    Inc(Target);
+  end;
+
+  Result := Derived;
+end;
+
+procedure CleanupAsyncContextThreadState;
+begin
+  GCurrentSnapshot := nil;
+  FreeAndNil(GSnapshotRoots);
+end;
+
+initialization
+  RegisterThreadvarCleanup(CleanupAsyncContextThreadState);
+
+end.

--- a/source/units/Goccia.Builtins.AsyncHooks.pas
+++ b/source/units/Goccia.Builtins.AsyncHooks.pas
@@ -1,0 +1,685 @@
+{ The `node:async_hooks` namespace: AsyncLocalStorage and AsyncResource.
+
+  Both are thin wrappers over Goccia.AsyncContext, which owns the snapshot
+  mechanism and the propagation seams. Nothing here knows how a continuation
+  is created; it only derives snapshots and installs them around a call.
+
+  See docs/adr/0112-native-async-local-storage.md for the decision and the
+  scope cuts. }
+
+unit Goccia.Builtins.AsyncHooks;
+
+{$I Goccia.inc}
+
+interface
+
+uses
+  Goccia.Values.ObjectValue;
+
+function CreateAsyncHooksNamespace: TGocciaObjectValue;
+procedure ClearAsyncHooksHosts;
+
+implementation
+
+uses
+  Generics.Collections,
+  SysUtils,
+
+  Goccia.Arguments.Collection,
+  Goccia.AsyncContext,
+  Goccia.Constants.PropertyNames,
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions,
+  Goccia.GarbageCollector,
+  Goccia.Keywords.Reserved,
+  Goccia.ObjectModel,
+  Goccia.ThreadCleanupRegistry,
+  Goccia.Values.ErrorHelper,
+  Goccia.Values.FunctionBase,
+  Goccia.Values.NativeFunction,
+  Goccia.Values.ObjectPropertyDescriptor,
+  Goccia.Values.Primitives;
+
+const
+  ASYNC_LOCAL_STORAGE_NAME = 'AsyncLocalStorage';
+  ASYNC_RESOURCE_NAME = 'AsyncResource';
+  PROP_DEFAULT_VALUE = 'defaultValue';
+  { Node reports an unnamed AsyncLocalStorage as the empty string, not as
+    undefined; probed against Node v24.0.1. }
+  UNNAMED_STORAGE = '';
+  { AsyncResource ids exist so that code written for Node can read them. They
+    are unique per resource and never recycled; nothing in GocciaScript acts
+    on them, and there is no async-hooks callback surface to relate them to. }
+  FIRST_ASYNC_ID = 1;
+
+type
+  TGocciaAsyncHooksHostList = TObjectList<TObject>;
+
+  { One AsyncLocalStorage instance. Identity is the snapshot key, so the
+    instance object itself is what a snapshot binds a store to. }
+  TGocciaAsyncLocalStorageValue = class(TGocciaObjectValue)
+  private
+    FDefaultValue: TGocciaValue;
+    FDisabled: Boolean;
+    FStorageName: string;
+  public
+    procedure MarkReferences; override;
+    property DefaultValue: TGocciaValue read FDefaultValue write FDefaultValue;
+    property Disabled: Boolean read FDisabled write FDisabled;
+    property StorageName: string read FStorageName write FStorageName;
+  end;
+
+  { An AsyncResource captures the async context once, at construction, and
+    replays it on demand. }
+  TGocciaAsyncResourceValue = class(TGocciaObjectValue)
+  private
+    FContext: TGocciaAsyncContextSnapshot;
+    FAsyncId: Double;
+  public
+    procedure MarkReferences; override;
+    property Context: TGocciaAsyncContextSnapshot read FContext write FContext;
+    property AsyncId: Double read FAsyncId write FAsyncId;
+  end;
+
+  { A callable bound to one snapshot. Backs AsyncResource.prototype.bind,
+    AsyncResource.bind, AsyncLocalStorage.bind and the function returned by
+    AsyncLocalStorage.snapshot. }
+  TGocciaAsyncBoundFunction = class(TGocciaObjectValue)
+  private
+    FTarget: TGocciaValue;
+    FBoundThis: TGocciaValue;
+    FContext: TGocciaAsyncContextSnapshot;
+    FUsesCallerTarget: Boolean;
+  public
+    constructor Create(const ATarget, ABoundThis: TGocciaValue;
+      const AContext: TGocciaAsyncContextSnapshot;
+      const AUsesCallerTarget: Boolean);
+    function Invoke(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    procedure MarkReferences; override;
+  end;
+
+  TGocciaAsyncHooksNamespaceHost = class
+  private
+    FAsyncLocalStoragePrototype: TGocciaObjectValue;
+    FAsyncResourcePrototype: TGocciaObjectValue;
+    FNextAsyncId: Double;
+
+    function RequireStorage(
+      const AThisValue: TGocciaValue): TGocciaAsyncLocalStorageValue;
+    function RequireResource(
+      const AThisValue: TGocciaValue): TGocciaAsyncResourceValue;
+    function CallInContext(const ACallback, AThisValue: TGocciaValue;
+      const AArgs: TGocciaArgumentsCollection; const AFirstArgument: Integer;
+      const AContext: TGocciaAsyncContextSnapshot): TGocciaValue;
+    function CreateBoundFunction(const ATarget, ABoundThis: TGocciaValue;
+      const AContext: TGocciaAsyncContextSnapshot;
+      const AUsesCallerTarget: Boolean): TGocciaValue;
+  public
+    constructor Create;
+
+    function StorageConstructor(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function StorageRun(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function StorageGetStore(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function StorageEnterWith(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function StorageExit(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function StorageDisable(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function StorageGetName(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function StorageStaticBind(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function StorageStaticSnapshot(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+
+    function ResourceConstructor(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function ResourceRunInAsyncScope(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function ResourceBind(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function ResourceStaticBind(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function ResourceAsyncId(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function ResourceTriggerAsyncId(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+    function ResourceEmitDestroy(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+  end;
+
+threadvar
+  GAsyncHooksHosts: TGocciaAsyncHooksHostList;
+
+{ TGocciaAsyncLocalStorageValue }
+
+procedure TGocciaAsyncLocalStorageValue.MarkReferences;
+begin
+  if GCMarked then Exit;
+  inherited;
+  if Assigned(FDefaultValue) then
+    FDefaultValue.MarkReferences;
+end;
+
+{ TGocciaAsyncResourceValue }
+
+procedure TGocciaAsyncResourceValue.MarkReferences;
+begin
+  if GCMarked then Exit;
+  inherited;
+  if Assigned(FContext) then
+    FContext.MarkReferences;
+end;
+
+{ TGocciaAsyncBoundFunction }
+
+constructor TGocciaAsyncBoundFunction.Create(
+  const ATarget, ABoundThis: TGocciaValue;
+  const AContext: TGocciaAsyncContextSnapshot;
+  const AUsesCallerTarget: Boolean);
+begin
+  inherited Create(nil);
+  FTarget := ATarget;
+  FBoundThis := ABoundThis;
+  FContext := AContext;
+  FUsesCallerTarget := AUsesCallerTarget;
+end;
+
+function TGocciaAsyncBoundFunction.Invoke(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  CallArgs: TGocciaArgumentsCollection;
+  I: Integer;
+  PreviousContext: TGocciaAsyncContextSnapshot;
+  Receiver, Target: TGocciaValue;
+begin
+  { AsyncLocalStorage.snapshot() returns a function that takes the callback to
+    run as its first argument; every other bound form closes over its target
+    and forwards all arguments. }
+  if FUsesCallerTarget then
+    Target := AArgs.GetElement(0)
+  else
+    Target := FTarget;
+
+  if not (Assigned(Target) and Target.IsCallable) then
+    ThrowTypeError(SErrorAsyncHooksCallbackRequired, SSuggestCallbackRequired);
+
+  Receiver := FBoundThis;
+  if not Assigned(Receiver) then
+    Receiver := AThisValue;
+
+  CallArgs := TGocciaArgumentsCollection.Create;
+  try
+    if FUsesCallerTarget then
+      for I := 1 to AArgs.Length - 1 do
+        CallArgs.Add(AArgs.GetElement(I))
+    else
+      for I := 0 to AArgs.Length - 1 do
+        CallArgs.Add(AArgs.GetElement(I));
+
+    PreviousContext := CurrentAsyncContext;
+    SetCurrentAsyncContext(FContext);
+    try
+      Result := DispatchCall(Target, CallArgs, Receiver);
+    finally
+      SetCurrentAsyncContext(PreviousContext);
+    end;
+  finally
+    CallArgs.Free;
+  end;
+end;
+
+procedure TGocciaAsyncBoundFunction.MarkReferences;
+begin
+  if GCMarked then Exit;
+  inherited;
+  if Assigned(FTarget) then
+    FTarget.MarkReferences;
+  if Assigned(FBoundThis) then
+    FBoundThis.MarkReferences;
+  if Assigned(FContext) then
+    FContext.MarkReferences;
+end;
+
+{ TGocciaAsyncHooksNamespaceHost }
+
+constructor TGocciaAsyncHooksNamespaceHost.Create;
+begin
+  inherited Create;
+  FNextAsyncId := FIRST_ASYNC_ID;
+end;
+
+function TGocciaAsyncHooksNamespaceHost.RequireStorage(
+  const AThisValue: TGocciaValue): TGocciaAsyncLocalStorageValue;
+begin
+  if not (AThisValue is TGocciaAsyncLocalStorageValue) then
+    ThrowTypeError(SErrorAsyncLocalStorageReceiver,
+      SSuggestAsyncLocalStorageReceiver);
+  Result := TGocciaAsyncLocalStorageValue(AThisValue);
+end;
+
+function TGocciaAsyncHooksNamespaceHost.RequireResource(
+  const AThisValue: TGocciaValue): TGocciaAsyncResourceValue;
+begin
+  if not (AThisValue is TGocciaAsyncResourceValue) then
+    ThrowTypeError(SErrorAsyncResourceReceiver, SSuggestAsyncResourceReceiver);
+  Result := TGocciaAsyncResourceValue(AThisValue);
+end;
+
+{ Calls ACallback with AArgs[AFirstArgument..] under AContext, and restores the
+  enclosing context on every exit path — including the throwing one, which is
+  what keeps a rejected async callback from leaving its bindings behind. }
+function TGocciaAsyncHooksNamespaceHost.CallInContext(
+  const ACallback, AThisValue: TGocciaValue;
+  const AArgs: TGocciaArgumentsCollection; const AFirstArgument: Integer;
+  const AContext: TGocciaAsyncContextSnapshot): TGocciaValue;
+var
+  CallArgs: TGocciaArgumentsCollection;
+  I: Integer;
+  PreviousContext: TGocciaAsyncContextSnapshot;
+begin
+  { Install before anything else runs. AContext was derived by the caller and
+    is reachable from nothing until it is the current context, so any
+    allocation in between — building the argument collection, or the error
+    object on the non-callable path — could collect it at a safe point. }
+  PreviousContext := CurrentAsyncContext;
+  SetCurrentAsyncContext(AContext);
+  try
+    if not (Assigned(ACallback) and ACallback.IsCallable) then
+      ThrowTypeError(SErrorAsyncHooksCallbackRequired,
+        SSuggestCallbackRequired);
+
+    CallArgs := TGocciaArgumentsCollection.Create;
+    try
+      for I := AFirstArgument to AArgs.Length - 1 do
+        CallArgs.Add(AArgs.GetElement(I));
+      Result := DispatchCall(ACallback, CallArgs, AThisValue);
+    finally
+      CallArgs.Free;
+    end;
+  finally
+    SetCurrentAsyncContext(PreviousContext);
+  end;
+end;
+
+function TGocciaAsyncHooksNamespaceHost.CreateBoundFunction(
+  const ATarget, ABoundThis: TGocciaValue;
+  const AContext: TGocciaAsyncContextSnapshot;
+  const AUsesCallerTarget: Boolean): TGocciaValue;
+var
+  Bound: TGocciaAsyncBoundFunction;
+  BoundFunction: TGocciaNativeFunctionValue;
+  BoundRoot: TGocciaTempRoot;
+begin
+  Bound := TGocciaAsyncBoundFunction.Create(ATarget, ABoundThis, AContext,
+    AUsesCallerTarget);
+  { Nothing refers to Bound until CapturedRoot does, and allocating the
+    wrapper is a collection safe point. }
+  InitializeTempRoot(BoundRoot);
+  AddTempRootIfNeeded(BoundRoot, Bound);
+  try
+    BoundFunction := TGocciaNativeFunctionValue.CreateWithoutPrototype(
+      Bound.Invoke, '', 0);
+    BoundFunction.CapturedRoot := Bound;
+    Result := BoundFunction;
+  finally
+    RemoveTempRootIfNeeded(BoundRoot);
+  end;
+end;
+
+function TGocciaAsyncHooksNamespaceHost.StorageConstructor(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  NameValue: TGocciaValue;
+  Options: TGocciaObjectValue;
+  Storage: TGocciaAsyncLocalStorageValue;
+  StorageRoot: TGocciaTempRoot;
+begin
+  Storage := TGocciaAsyncLocalStorageValue.Create(FAsyncLocalStoragePrototype);
+  Storage.DefaultValue := TGocciaUndefinedLiteralValue.UndefinedValue;
+  Storage.StorageName := UNNAMED_STORAGE;
+
+  { Reading the options runs guest code when a member is an accessor, so the
+    instance has to be rooted for the duration. }
+  InitializeTempRoot(StorageRoot);
+  AddTempRootIfNeeded(StorageRoot, Storage);
+  try
+    if AArgs.GetElement(0) is TGocciaObjectValue then
+    begin
+      Options := TGocciaObjectValue(AArgs.GetElement(0));
+      if Options.HasProperty(PROP_DEFAULT_VALUE) then
+        Storage.DefaultValue := Options.GetProperty(PROP_DEFAULT_VALUE);
+      if Options.HasProperty(PROP_NAME) then
+      begin
+        NameValue := Options.GetProperty(PROP_NAME);
+        if Assigned(NameValue) and
+           not (NameValue is TGocciaUndefinedLiteralValue) then
+          Storage.StorageName := NameValue.ToStringLiteral.Value;
+      end;
+    end;
+  finally
+    RemoveTempRootIfNeeded(StorageRoot);
+  end;
+
+  Result := Storage;
+end;
+
+{ Node: AsyncLocalStorage.prototype.run(store, callback[, ...args]).
+
+  The store is bound for the synchronous part of the callback, and for every
+  continuation created while it runs — those capture the derived snapshot at
+  the point they are created and carry it themselves. }
+function TGocciaAsyncHooksNamespaceHost.StorageRun(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+const
+  RUN_FIRST_EXTRA_ARGUMENT = 2;
+var
+  Storage: TGocciaAsyncLocalStorageValue;
+begin
+  Storage := RequireStorage(AThisValue);
+  { Node re-enables a disabled instance on run and on enterWith. }
+  Storage.Disabled := False;
+  Result := CallInContext(AArgs.GetElement(1),
+    TGocciaUndefinedLiteralValue.UndefinedValue, AArgs,
+    RUN_FIRST_EXTRA_ARGUMENT,
+    DeriveAsyncContext(CurrentAsyncContext, Storage, AArgs.GetElement(0)));
+end;
+
+{ Node: AsyncLocalStorage.prototype.getStore(). A bound store wins even when it
+  is undefined — `run(undefined, ...)` reports undefined, not the default. }
+function TGocciaAsyncHooksNamespaceHost.StorageGetStore(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Snapshot: TGocciaAsyncContextSnapshot;
+  Storage: TGocciaAsyncLocalStorageValue;
+  Store: TGocciaValue;
+begin
+  Storage := RequireStorage(AThisValue);
+  if Storage.Disabled then
+    Exit(Storage.DefaultValue);
+
+  Snapshot := CurrentAsyncContext;
+  if Assigned(Snapshot) and Snapshot.TryGetStore(Storage, Store) then
+    Result := Store
+  else
+    Result := Storage.DefaultValue;
+end;
+
+{ Node: AsyncLocalStorage.prototype.enterWith(store). Unlike run there is no
+  scope to leave, so the binding survives until whatever installed the current
+  context restores it — the enclosing run, the enclosing microtask, or nothing
+  at all at the top level. }
+function TGocciaAsyncHooksNamespaceHost.StorageEnterWith(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Storage: TGocciaAsyncLocalStorageValue;
+begin
+  Storage := RequireStorage(AThisValue);
+  Storage.Disabled := False;
+  SetCurrentAsyncContext(DeriveAsyncContext(CurrentAsyncContext, Storage,
+    AArgs.GetElement(0)));
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+end;
+
+{ Node: AsyncLocalStorage.prototype.exit(callback[, ...args]). Probed against
+  Node v24.0.1: exit binds undefined rather than dropping the binding, so
+  getStore reports undefined inside the callback even when the instance was
+  constructed with a defaultValue. }
+function TGocciaAsyncHooksNamespaceHost.StorageExit(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+const
+  EXIT_FIRST_EXTRA_ARGUMENT = 1;
+var
+  Storage: TGocciaAsyncLocalStorageValue;
+begin
+  Storage := RequireStorage(AThisValue);
+  Result := CallInContext(AArgs.GetElement(0),
+    TGocciaUndefinedLiteralValue.UndefinedValue, AArgs,
+    EXIT_FIRST_EXTRA_ARGUMENT,
+    DeriveAsyncContext(CurrentAsyncContext, Storage,
+      TGocciaUndefinedLiteralValue.UndefinedValue));
+end;
+
+{ Node: AsyncLocalStorage.prototype.disable(). getStore reports the default
+  value until run or enterWith re-enables the instance. }
+function TGocciaAsyncHooksNamespaceHost.StorageDisable(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Storage: TGocciaAsyncLocalStorageValue;
+begin
+  Storage := RequireStorage(AThisValue);
+  Storage.Disabled := True;
+  SetCurrentAsyncContext(
+    DeriveAsyncContextWithout(CurrentAsyncContext, Storage));
+  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+end;
+
+function TGocciaAsyncHooksNamespaceHost.StorageGetName(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := TGocciaStringLiteralValue.Create(
+    RequireStorage(AThisValue).StorageName);
+end;
+
+{ Node: AsyncLocalStorage.bind(fn) — binds fn to the current context. }
+function TGocciaAsyncHooksNamespaceHost.StorageStaticBind(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := CreateBoundFunction(AArgs.GetElement(0), nil,
+    CurrentAsyncContext, False);
+end;
+
+{ Node: AsyncLocalStorage.snapshot() — returns (fn, ...args) => fn(...args)
+  run under the context current at the time of the snapshot call. }
+function TGocciaAsyncHooksNamespaceHost.StorageStaticSnapshot(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := CreateBoundFunction(nil, nil, CurrentAsyncContext, True);
+end;
+
+function TGocciaAsyncHooksNamespaceHost.ResourceConstructor(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+var
+  Resource: TGocciaAsyncResourceValue;
+begin
+  Resource := TGocciaAsyncResourceValue.Create(FAsyncResourcePrototype);
+  Resource.Context := CurrentAsyncContext;
+  Resource.AsyncId := FNextAsyncId;
+  FNextAsyncId := FNextAsyncId + 1;
+  Result := Resource;
+end;
+
+{ Node: asyncResource.runInAsyncScope(fn[, thisArg, ...args]). }
+function TGocciaAsyncHooksNamespaceHost.ResourceRunInAsyncScope(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+const
+  RUN_IN_SCOPE_FIRST_EXTRA_ARGUMENT = 2;
+var
+  Receiver: TGocciaValue;
+  Resource: TGocciaAsyncResourceValue;
+begin
+  Resource := RequireResource(AThisValue);
+  Receiver := AArgs.GetElement(1);
+  if not Assigned(Receiver) then
+    Receiver := TGocciaUndefinedLiteralValue.UndefinedValue;
+  Result := CallInContext(AArgs.GetElement(0), Receiver, AArgs,
+    RUN_IN_SCOPE_FIRST_EXTRA_ARGUMENT, Resource.Context);
+end;
+
+{ Node: asyncResource.bind(fn[, thisArg]) — the resource's captured context. }
+function TGocciaAsyncHooksNamespaceHost.ResourceBind(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := CreateBoundFunction(AArgs.GetElement(0), AArgs.GetElement(1),
+    RequireResource(AThisValue).Context, False);
+end;
+
+{ Node: AsyncResource.bind(fn[, type, thisArg]) — the context current at the
+  call, which is what constructing a resource here and binding to it would
+  capture anyway. }
+function TGocciaAsyncHooksNamespaceHost.ResourceStaticBind(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+const
+  STATIC_BIND_THIS_ARGUMENT = 2;
+begin
+  Result := CreateBoundFunction(AArgs.GetElement(0),
+    AArgs.GetElement(STATIC_BIND_THIS_ARGUMENT), CurrentAsyncContext, False);
+end;
+
+function TGocciaAsyncHooksNamespaceHost.ResourceAsyncId(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := TGocciaNumberLiteralValue.Create(
+    RequireResource(AThisValue).AsyncId);
+end;
+
+{ GocciaScript has no async-hooks callback surface and therefore no notion of
+  the resource that triggered another, so a resource reports itself. }
+function TGocciaAsyncHooksNamespaceHost.ResourceTriggerAsyncId(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := TGocciaNumberLiteralValue.Create(
+    RequireResource(AThisValue).AsyncId);
+end;
+
+{ There are no destroy hooks to emit to; Node returns the resource so the call
+  chains, and so does this. }
+function TGocciaAsyncHooksNamespaceHost.ResourceEmitDestroy(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  Result := RequireResource(AThisValue);
+end;
+
+function CreateAsyncHooksNamespace: TGocciaObjectValue;
+var
+  DefaultExport, NamespaceObject: TGocciaObjectValue;
+  Host: TGocciaAsyncHooksNamespaceHost;
+  Members: TGocciaMemberCollection;
+  MemberDefinitions: TArray<TGocciaMemberDefinition>;
+  StorageConstructorValue, ResourceConstructorValue: TGocciaNativeFunctionValue;
+begin
+  Host := TGocciaAsyncHooksNamespaceHost.Create;
+  if not Assigned(GAsyncHooksHosts) then
+    GAsyncHooksHosts := TGocciaAsyncHooksHostList.Create(True);
+  GAsyncHooksHosts.Add(Host);
+
+  Host.FAsyncLocalStoragePrototype := TGocciaObjectValue.Create(
+    TGocciaObjectValue.SharedObjectPrototype);
+  Members := TGocciaMemberCollection.Create;
+  try
+    Members.AddNamedMethod('run', Host.StorageRun, 2);
+    Members.AddNamedMethod('getStore', Host.StorageGetStore, 0);
+    Members.AddNamedMethod('enterWith', Host.StorageEnterWith, 1);
+    Members.AddNamedMethod('exit', Host.StorageExit, 1);
+    Members.AddNamedMethod('disable', Host.StorageDisable, 0);
+    Members.AddAccessor(PROP_NAME, Host.StorageGetName, nil,
+      [pfConfigurable]);
+    MemberDefinitions := Members.ToDefinitions;
+  finally
+    Members.Free;
+  end;
+  RegisterMemberDefinitions(Host.FAsyncLocalStoragePrototype,
+    MemberDefinitions);
+
+  Host.FAsyncResourcePrototype := TGocciaObjectValue.Create(
+    TGocciaObjectValue.SharedObjectPrototype);
+  Members := TGocciaMemberCollection.Create;
+  try
+    Members.AddNamedMethod('runInAsyncScope', Host.ResourceRunInAsyncScope, 1);
+    Members.AddNamedMethod('bind', Host.ResourceBind, 1);
+    Members.AddNamedMethod('asyncId', Host.ResourceAsyncId, 0);
+    Members.AddNamedMethod('triggerAsyncId', Host.ResourceTriggerAsyncId, 0);
+    Members.AddNamedMethod('emitDestroy', Host.ResourceEmitDestroy, 0);
+    MemberDefinitions := Members.ToDefinitions;
+  finally
+    Members.Free;
+  end;
+  RegisterMemberDefinitions(Host.FAsyncResourcePrototype, MemberDefinitions);
+
+  StorageConstructorValue := TGocciaNativeFunctionValue.Create(
+    Host.StorageConstructor, ASYNC_LOCAL_STORAGE_NAME, 0);
+  StorageConstructorValue.AssignProperty(PROP_PROTOTYPE,
+    Host.FAsyncLocalStoragePrototype);
+  Host.FAsyncLocalStoragePrototype.AssignProperty(PROP_CONSTRUCTOR,
+    StorageConstructorValue);
+
+  ResourceConstructorValue := TGocciaNativeFunctionValue.Create(
+    Host.ResourceConstructor, ASYNC_RESOURCE_NAME, 1);
+  ResourceConstructorValue.AssignProperty(PROP_PROTOTYPE,
+    Host.FAsyncResourcePrototype);
+  Host.FAsyncResourcePrototype.AssignProperty(PROP_CONSTRUCTOR,
+    ResourceConstructorValue);
+
+  Members := TGocciaMemberCollection.Create;
+  try
+    Members.AddNamedMethod('bind', Host.StorageStaticBind, 1,
+      gmkStaticMethod);
+    Members.AddNamedMethod('snapshot', Host.StorageStaticSnapshot, 0,
+      gmkStaticMethod);
+    MemberDefinitions := Members.ToDefinitions;
+  finally
+    Members.Free;
+  end;
+  RegisterMemberDefinitions(StorageConstructorValue, MemberDefinitions);
+
+  Members := TGocciaMemberCollection.Create;
+  try
+    Members.AddNamedMethod('bind', Host.ResourceStaticBind, 1,
+      gmkStaticMethod);
+    MemberDefinitions := Members.ToDefinitions;
+  finally
+    Members.Free;
+  end;
+  RegisterMemberDefinitions(ResourceConstructorValue, MemberDefinitions);
+
+  NamespaceObject := TGocciaObjectValue.Create(
+    TGocciaObjectValue.SharedObjectPrototype);
+  NamespaceObject.AssignProperty(ASYNC_LOCAL_STORAGE_NAME,
+    StorageConstructorValue);
+  NamespaceObject.AssignProperty(ASYNC_RESOURCE_NAME,
+    ResourceConstructorValue);
+
+  { Node's CommonJS module object is the default export of `node:async_hooks`
+    under ESM, so `import async_hooks from "node:async_hooks"` reaches the same
+    two constructors as the named imports. }
+  DefaultExport := TGocciaObjectValue.Create(
+    TGocciaObjectValue.SharedObjectPrototype);
+  DefaultExport.AssignProperty(ASYNC_LOCAL_STORAGE_NAME,
+    StorageConstructorValue);
+  DefaultExport.AssignProperty(ASYNC_RESOURCE_NAME, ResourceConstructorValue);
+  NamespaceObject.AssignProperty(KEYWORD_DEFAULT, DefaultExport);
+
+  Result := NamespaceObject;
+end;
+
+procedure ClearAsyncHooksHosts;
+begin
+  FreeAndNil(GAsyncHooksHosts);
+end;
+
+initialization
+  RegisterThreadvarCleanup(ClearAsyncHooksHosts);
+
+end.

--- a/source/units/Goccia.Builtins.AsyncHooks.pas
+++ b/source/units/Goccia.Builtins.AsyncHooks.pas
@@ -16,7 +16,11 @@ interface
 uses
   Goccia.Values.ObjectValue;
 
-function CreateAsyncHooksNamespace: TGocciaObjectValue;
+{ Returns the namespace object. AHostToken receives an opaque handle for the
+  per-namespace host state; pass it to ReleaseAsyncHooksHost when the module
+  registration that owns this namespace goes away. }
+function CreateAsyncHooksNamespace(out AHostToken: TObject): TGocciaObjectValue;
+procedure ReleaseAsyncHooksHost(const AHostToken: TObject);
 procedure ClearAsyncHooksHosts;
 
 implementation
@@ -51,6 +55,11 @@ const
     are unique per resource and never recycled; nothing in GocciaScript acts
     on them, and there is no async-hooks callback surface to relate them to. }
   FIRST_ASYNC_ID = 1;
+  { Every bind-family member returns a function Node calls `bound`, with the
+    target's own length. The snapshot runner takes (callback, ...args), so its
+    length is one however long the callback is. }
+  BOUND_FUNCTION_NAME = 'bound';
+  SNAPSHOT_RUNNER_LENGTH = 1;
 
 type
   TGocciaAsyncHooksHostList = TObjectList<TObject>;
@@ -60,12 +69,10 @@ type
   TGocciaAsyncLocalStorageValue = class(TGocciaObjectValue)
   private
     FDefaultValue: TGocciaValue;
-    FDisabled: Boolean;
     FStorageName: string;
   public
     procedure MarkReferences; override;
     property DefaultValue: TGocciaValue read FDefaultValue write FDefaultValue;
-    property Disabled: Boolean read FDisabled write FDisabled;
     property StorageName: string read FStorageName write FStorageName;
   end;
 
@@ -115,6 +122,8 @@ type
     function CreateBoundFunction(const ATarget, ABoundThis: TGocciaValue;
       const AContext: TGocciaAsyncContextSnapshot;
       const AUsesCallerTarget: Boolean): TGocciaValue;
+    function ReceiverArgument(const AArgs: TGocciaArgumentsCollection;
+      const AIndex: Integer): TGocciaValue;
   public
     constructor Create;
 
@@ -156,6 +165,39 @@ type
 threadvar
   GAsyncHooksHosts: TGocciaAsyncHooksHostList;
 
+{ Node's bind family runs validateFunction(fn) before it builds anything, so a
+  non-callable is a TypeError at the bind call rather than a surprise at the
+  first invocation. }
+procedure RequireCallable(const AValue: TGocciaValue);
+begin
+  if not (Assigned(AValue) and AValue.IsCallable) then
+    ThrowTypeError(SErrorAsyncHooksCallbackRequired, SSuggestCallbackRequired);
+end;
+
+{ The `length` a bound wrapper should report: the target's own, read through
+  the ordinary property lookup so a bound or native target answers too. A
+  snapshot runner has no target to ask. }
+function CallableLength(const ATarget: TGocciaValue;
+  const AUsesCallerTarget: Boolean): Integer;
+var
+  LengthValue: TGocciaValue;
+  Reported: Double;
+begin
+  if AUsesCallerTarget then
+    Exit(SNAPSHOT_RUNNER_LENGTH);
+  if not (ATarget is TGocciaObjectValue) then
+    Exit(0);
+
+  LengthValue := TGocciaObjectValue(ATarget).GetProperty(PROP_LENGTH);
+  if not (LengthValue is TGocciaNumberLiteralValue) then
+    Exit(0);
+
+  Reported := TGocciaNumberLiteralValue(LengthValue).Value;
+  if (Reported <> Reported) or (Reported < 0) or (Reported > MaxInt) then
+    Exit(0);
+  Result := Trunc(Reported);
+end;
+
 { TGocciaAsyncLocalStorageValue }
 
 procedure TGocciaAsyncLocalStorageValue.MarkReferences;
@@ -195,8 +237,7 @@ function TGocciaAsyncBoundFunction.Invoke(
   const AThisValue: TGocciaValue): TGocciaValue;
 var
   CallArgs: TGocciaArgumentsCollection;
-  I: Integer;
-  PreviousContext: TGocciaAsyncContextSnapshot;
+  ContextToken, I: Integer;
   Receiver, Target: TGocciaValue;
 begin
   { AsyncLocalStorage.snapshot() returns a function that takes the callback to
@@ -210,6 +251,12 @@ begin
   if not (Assigned(Target) and Target.IsCallable) then
     ThrowTypeError(SErrorAsyncHooksCallbackRequired, SSuggestCallbackRequired);
 
+  (* Node forwards the call-site receiver whenever thisArg is undefined,
+     whether it was omitted or written out — `bind` splits on
+     `thisArg === undefined`, not on the argument count. So a bound function
+     installed as an object method, `{ tag, run: resource.bind(fn) }`, sees the
+     holder as `this`, and only an explicitly non-undefined thisArg displaces
+     it. Probed against Node v24.0.1. *)
   Receiver := FBoundThis;
   if not Assigned(Receiver) then
     Receiver := AThisValue;
@@ -223,12 +270,11 @@ begin
       for I := 0 to AArgs.Length - 1 do
         CallArgs.Add(AArgs.GetElement(I));
 
-    PreviousContext := CurrentAsyncContext;
-    SetCurrentAsyncContext(FContext);
+    ContextToken := EnterAsyncContext(FContext);
     try
       Result := DispatchCall(Target, CallArgs, Receiver);
     finally
-      SetCurrentAsyncContext(PreviousContext);
+      LeaveAsyncContext(ContextToken);
     end;
   finally
     CallArgs.Free;
@@ -281,15 +327,16 @@ function TGocciaAsyncHooksNamespaceHost.CallInContext(
   const AContext: TGocciaAsyncContextSnapshot): TGocciaValue;
 var
   CallArgs: TGocciaArgumentsCollection;
-  I: Integer;
-  PreviousContext: TGocciaAsyncContextSnapshot;
+  ContextToken, I: Integer;
 begin
-  { Install before anything else runs. AContext was derived by the caller and
-    is reachable from nothing until it is the current context, so any
-    allocation in between — building the argument collection, or the error
-    object on the non-callable path — could collect it at a safe point. }
-  PreviousContext := CurrentAsyncContext;
-  SetCurrentAsyncContext(AContext);
+  { Enter before anything else runs, and through the saved-snapshot stack.
+    AContext was derived by the caller and is reachable from nothing until it
+    is the current context, so any allocation in between — the argument
+    collection, or the error object on the non-callable path — could collect
+    it; and the snapshot it displaces has no other root either, so parking it
+    in a local across the callback made a collection inside that callback free
+    it and the restore write a dangling pointer. }
+  ContextToken := EnterAsyncContext(AContext);
   try
     if not (Assigned(ACallback) and ACallback.IsCallable) then
       ThrowTypeError(SErrorAsyncHooksCallbackRequired,
@@ -304,7 +351,7 @@ begin
       CallArgs.Free;
     end;
   finally
-    SetCurrentAsyncContext(PreviousContext);
+    LeaveAsyncContext(ContextToken);
   end;
 end;
 
@@ -324,13 +371,30 @@ begin
   InitializeTempRoot(BoundRoot);
   AddTempRootIfNeeded(BoundRoot, Bound);
   try
+    { Node names every one of these `bound` — not `bound <fn>` — because the
+      wrapper it returns is a function declared under that name, and copies
+      the target's length onto it. Probed against Node v24.0.1. }
     BoundFunction := TGocciaNativeFunctionValue.CreateWithoutPrototype(
-      Bound.Invoke, '', 0);
+      Bound.Invoke, BOUND_FUNCTION_NAME,
+      CallableLength(ATarget, AUsesCallerTarget));
     BoundFunction.CapturedRoot := Bound;
     Result := BoundFunction;
   finally
     RemoveTempRootIfNeeded(BoundRoot);
   end;
+end;
+
+{ The receiver a bind-family member was given, or nil when it was omitted or
+  written as undefined — the two cases Node treats alike. GetElement answers
+  undefined for an absent index, so an Assigned check alone can never see the
+  difference and the call-site-receiver fallback would be dead. }
+function TGocciaAsyncHooksNamespaceHost.ReceiverArgument(
+  const AArgs: TGocciaArgumentsCollection;
+  const AIndex: Integer): TGocciaValue;
+begin
+  Result := AArgs.GetElement(AIndex);
+  if Result is TGocciaUndefinedLiteralValue then
+    Result := nil;
 end;
 
 function TGocciaAsyncHooksNamespaceHost.StorageConstructor(
@@ -385,16 +449,18 @@ var
   Storage: TGocciaAsyncLocalStorageValue;
 begin
   Storage := RequireStorage(AThisValue);
-  { Node re-enables a disabled instance on run and on enterWith. }
-  Storage.Disabled := False;
   Result := CallInContext(AArgs.GetElement(1),
     TGocciaUndefinedLiteralValue.UndefinedValue, AArgs,
     RUN_FIRST_EXTRA_ARGUMENT,
     DeriveAsyncContext(CurrentAsyncContext, Storage, AArgs.GetElement(0)));
 end;
 
-{ Node: AsyncLocalStorage.prototype.getStore(). A bound store wins even when it
-  is undefined — `run(undefined, ...)` reports undefined, not the default. }
+{ Node: AsyncLocalStorage.prototype.getStore().
+
+  Purely a lookup in the current frame: a binding wins even when its value is
+  undefined (`run(undefined, ...)` reports undefined, not the default), and the
+  default value stands in only when there is no binding at all. There is no
+  per-instance enabled flag to consult — see StorageDisable. }
 function TGocciaAsyncHooksNamespaceHost.StorageGetStore(
   const AArgs: TGocciaArgumentsCollection;
   const AThisValue: TGocciaValue): TGocciaValue;
@@ -404,9 +470,6 @@ var
   Store: TGocciaValue;
 begin
   Storage := RequireStorage(AThisValue);
-  if Storage.Disabled then
-    Exit(Storage.DefaultValue);
-
   Snapshot := CurrentAsyncContext;
   if Assigned(Snapshot) and Snapshot.TryGetStore(Storage, Store) then
     Result := Store
@@ -425,7 +488,6 @@ var
   Storage: TGocciaAsyncLocalStorageValue;
 begin
   Storage := RequireStorage(AThisValue);
-  Storage.Disabled := False;
   SetCurrentAsyncContext(DeriveAsyncContext(CurrentAsyncContext, Storage,
     AArgs.GetElement(0)));
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
@@ -451,8 +513,19 @@ begin
       TGocciaUndefinedLiteralValue.UndefinedValue));
 end;
 
-{ Node: AsyncLocalStorage.prototype.disable(). getStore reports the default
-  value until run or enterWith re-enables the instance. }
+{ Node: AsyncLocalStorage.prototype.disable().
+
+  Deletes the binding from the CURRENT frame and nothing more. Node v24 is the
+  AsyncContextFrame model, and every observable consequence follows from that
+  one edit: getStore reports the default value afterwards because no binding is
+  left here; a run or enterWith re-binds; and a continuation captured before
+  the disable still reports the store IT captured, because disable never
+  reached that frame.
+
+  An earlier per-instance `disabled` flag reproduced the first two and got the
+  third wrong in both directions — it masked already-captured bindings, and it
+  made exit() on a disabled instance report the default value where Node
+  reports undefined. Both were probed against Node v24.0.1. }
 function TGocciaAsyncHooksNamespaceHost.StorageDisable(
   const AArgs: TGocciaArgumentsCollection;
   const AThisValue: TGocciaValue): TGocciaValue;
@@ -460,7 +533,6 @@ var
   Storage: TGocciaAsyncLocalStorageValue;
 begin
   Storage := RequireStorage(AThisValue);
-  Storage.Disabled := True;
   SetCurrentAsyncContext(
     DeriveAsyncContextWithout(CurrentAsyncContext, Storage));
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
@@ -474,11 +546,14 @@ begin
     RequireStorage(AThisValue).StorageName);
 end;
 
-{ Node: AsyncLocalStorage.bind(fn) — binds fn to the current context. }
+{ Node: AsyncLocalStorage.bind(fn) — binds fn to the current context. Node
+  routes it through AsyncResource.bind, so the same validateFunction check
+  rejects a non-callable here rather than at the first call. }
 function TGocciaAsyncHooksNamespaceHost.StorageStaticBind(
   const AArgs: TGocciaArgumentsCollection;
   const AThisValue: TGocciaValue): TGocciaValue;
 begin
+  RequireCallable(AArgs.GetElement(0));
   Result := CreateBoundFunction(AArgs.GetElement(0), nil,
     CurrentAsyncContext, False);
 end;
@@ -505,30 +580,37 @@ begin
   Result := Resource;
 end;
 
-{ Node: asyncResource.runInAsyncScope(fn[, thisArg, ...args]). }
+{ Node: asyncResource.runInAsyncScope(fn[, thisArg, ...args]).
+
+  Unlike bind, an omitted thisArg here is NOT replaced by the call-site
+  receiver — Node applies fn with whatever was passed, so an omitted one means
+  `this` is undefined. GetElement already answers undefined for an absent
+  index, which is that value. }
 function TGocciaAsyncHooksNamespaceHost.ResourceRunInAsyncScope(
   const AArgs: TGocciaArgumentsCollection;
   const AThisValue: TGocciaValue): TGocciaValue;
 const
   RUN_IN_SCOPE_FIRST_EXTRA_ARGUMENT = 2;
 var
-  Receiver: TGocciaValue;
   Resource: TGocciaAsyncResourceValue;
 begin
   Resource := RequireResource(AThisValue);
-  Receiver := AArgs.GetElement(1);
-  if not Assigned(Receiver) then
-    Receiver := TGocciaUndefinedLiteralValue.UndefinedValue;
-  Result := CallInContext(AArgs.GetElement(0), Receiver, AArgs,
+  Result := CallInContext(AArgs.GetElement(0), AArgs.GetElement(1), AArgs,
     RUN_IN_SCOPE_FIRST_EXTRA_ARGUMENT, Resource.Context);
 end;
 
-{ Node: asyncResource.bind(fn[, thisArg]) — the resource's captured context. }
+{ Node: asyncResource.bind(fn[, thisArg]) — the resource's captured context.
+  An undefined thisArg leaves the call-site receiver in place; see
+  TGocciaAsyncBoundFunction.Invoke. }
 function TGocciaAsyncHooksNamespaceHost.ResourceBind(
   const AArgs: TGocciaArgumentsCollection;
   const AThisValue: TGocciaValue): TGocciaValue;
+const
+  BIND_THIS_ARGUMENT = 1;
 begin
-  Result := CreateBoundFunction(AArgs.GetElement(0), AArgs.GetElement(1),
+  RequireCallable(AArgs.GetElement(0));
+  Result := CreateBoundFunction(AArgs.GetElement(0),
+    ReceiverArgument(AArgs, BIND_THIS_ARGUMENT),
     RequireResource(AThisValue).Context, False);
 end;
 
@@ -541,8 +623,10 @@ function TGocciaAsyncHooksNamespaceHost.ResourceStaticBind(
 const
   STATIC_BIND_THIS_ARGUMENT = 2;
 begin
+  RequireCallable(AArgs.GetElement(0));
   Result := CreateBoundFunction(AArgs.GetElement(0),
-    AArgs.GetElement(STATIC_BIND_THIS_ARGUMENT), CurrentAsyncContext, False);
+    ReceiverArgument(AArgs, STATIC_BIND_THIS_ARGUMENT), CurrentAsyncContext,
+    False);
 end;
 
 function TGocciaAsyncHooksNamespaceHost.ResourceAsyncId(
@@ -572,7 +656,7 @@ begin
   Result := RequireResource(AThisValue);
 end;
 
-function CreateAsyncHooksNamespace: TGocciaObjectValue;
+function CreateAsyncHooksNamespace(out AHostToken: TObject): TGocciaObjectValue;
 var
   DefaultExport, NamespaceObject: TGocciaObjectValue;
   Host: TGocciaAsyncHooksNamespaceHost;
@@ -584,6 +668,7 @@ begin
   if not Assigned(GAsyncHooksHosts) then
     GAsyncHooksHosts := TGocciaAsyncHooksHostList.Create(True);
   GAsyncHooksHosts.Add(Host);
+  AHostToken := Host;
 
   Host.FAsyncLocalStoragePrototype := TGocciaObjectValue.Create(
     TGocciaObjectValue.SharedObjectPrototype);
@@ -674,6 +759,16 @@ begin
   Result := NamespaceObject;
 end;
 
+{ Drops one namespace's host. The list owns its entries, so Remove frees it;
+  an unknown or already-released token is ignored so a double detach is safe. }
+procedure ReleaseAsyncHooksHost(const AHostToken: TObject);
+begin
+  if not (Assigned(AHostToken) and Assigned(GAsyncHooksHosts)) then
+    Exit;
+  GAsyncHooksHosts.Remove(AHostToken);
+end;
+
+{ Thread teardown: releases whatever survived, for a host that never detached. }
 procedure ClearAsyncHooksHosts;
 begin
   FreeAndNil(GAsyncHooksHosts);

--- a/source/units/Goccia.Engine.pas
+++ b/source/units/Goccia.Engine.pas
@@ -395,6 +395,7 @@ uses
   TimingUtils,
   UnicodeStringList,
 
+  Goccia.AsyncContext,
   Goccia.CallStack,
   Goccia.Constants.ConstructorNames,
   Goccia.Constants.PropertyNames,
@@ -937,6 +938,11 @@ end;
 
 destructor TGocciaEngine.Destroy;
 begin
+  { Async-context snapshots hold this engine's objects, and `enterWith` can
+    leave one installed with no scope to unwind it. Drop them before anything
+    else is torn down so the next engine on this thread cannot inherit them. }
+  ResetAsyncContextState;
+
   if (TGarbageCollector.Instance <> nil) and Assigned(FInterpreter) then
     TGarbageCollector.Instance.RemoveRootObject(FInterpreter.GlobalScope);
 

--- a/source/units/Goccia.Error.Messages.pas
+++ b/source/units/Goccia.Error.Messages.pas
@@ -664,6 +664,13 @@ resourcestring
   SErrorThenNotFunction = 'then is not a function';
   SErrorPromiseChainingCycle = 'Chaining cycle detected for promise';
 
+  // node:async_hooks errors
+  SErrorAsyncLocalStorageReceiver =
+    'AsyncLocalStorage prototype method called on a non-AsyncLocalStorage object';
+  SErrorAsyncResourceReceiver =
+    'AsyncResource prototype method called on a non-AsyncResource object';
+  SErrorAsyncHooksCallbackRequired = 'callback is not a function';
+
   // Disposal method errors
   SErrorDisposePropertyNotFunction = 'Property [Symbol.%s] is not a function';
 

--- a/source/units/Goccia.Error.Suggestions.pas
+++ b/source/units/Goccia.Error.Suggestions.pas
@@ -202,6 +202,13 @@ resourcestring
   SSuggestPromiseAnyRejected = 'Promise.any() requires at least one promise to fulfill';
   SSuggestCallbackRequired = 'pass a function as the argument';
 
+  // Runtime errors — node:async_hooks
+  SSuggestAsyncLocalStorageReceiver =
+    'call run(), getStore(), enterWith(), exit() and disable() on an ' +
+    'AsyncLocalStorage instance';
+  SSuggestAsyncResourceReceiver =
+    'call runInAsyncScope() and bind() on an AsyncResource instance';
+
   // Runtime errors — ArrayBuffer
   SSuggestArrayBufferThisType = 'ArrayBuffer methods must be called on an ArrayBuffer instance';
   SSuggestArrayBufferDetached = 'the ArrayBuffer has been detached (transferred) and can no longer be used';

--- a/source/units/Goccia.MicrotaskQueue.pas
+++ b/source/units/Goccia.MicrotaskQueue.pas
@@ -8,6 +8,7 @@ uses
   Generics.Collections,
 
   Goccia.Arguments.Collection,
+  Goccia.AsyncContext,
   Goccia.Values.ObjectValue,
   Goccia.Values.Primitives;
 
@@ -27,6 +28,10 @@ type
     ResultPromise: TGocciaValue;
     Value: TGocciaValue;
     ReactionType: TPromiseReactionType;
+    { The async context this job runs under. Never set by the code that builds
+      the record — Enqueue always overwrites it — so no enqueue site can leave
+      it holding whatever the stack frame happened to contain. }
+    Context: TGocciaAsyncContextSnapshot;
   end;
 
   TGocciaMicrotaskQueue = class
@@ -49,7 +54,13 @@ type
     constructor Create;
     destructor Destroy; override;
 
+    { Enqueue captures the async context in effect right now. Use
+      EnqueueWithContext for a job whose context was captured earlier — a
+      promise reaction registered on a promise that was still pending runs
+      under the context of its registration, not of its settlement. }
     procedure Enqueue(const AMicrotask: TGocciaMicrotask);
+    procedure EnqueueWithContext(const AMicrotask: TGocciaMicrotask;
+      const AContext: TGocciaAsyncContextSnapshot);
     procedure EnqueueJob(const AJob: TGocciaMicrotaskJob);
     procedure EnqueueFinalizationCleanup(const AMicrotask: TGocciaMicrotask);
     function DrainOneJob: Boolean;
@@ -311,8 +322,19 @@ end;
 
 procedure TGocciaMicrotaskQueue.Enqueue(const AMicrotask: TGocciaMicrotask);
 begin
-  AddQueuedRoots(AMicrotask);
-  FQueue.Add(AMicrotask);
+  EnqueueWithContext(AMicrotask, CurrentAsyncContext);
+end;
+
+procedure TGocciaMicrotaskQueue.EnqueueWithContext(
+  const AMicrotask: TGocciaMicrotask;
+  const AContext: TGocciaAsyncContextSnapshot);
+var
+  Task: TGocciaMicrotask;
+begin
+  Task := AMicrotask;
+  Task.Context := AContext;
+  AddQueuedRoots(Task);
+  FQueue.Add(Task);
 end;
 
 procedure TGocciaMicrotaskQueue.EnqueueJob(const AJob: TGocciaMicrotaskJob);
@@ -357,9 +379,13 @@ end;
 
 procedure TGocciaMicrotaskQueue.EnqueueFinalizationCleanup(
   const AMicrotask: TGocciaMicrotask);
+var
+  Task: TGocciaMicrotask;
 begin
-  AddQueuedRoots(AMicrotask);
-  FFinalizationQueue.Add(AMicrotask);
+  Task := AMicrotask;
+  Task.Context := CurrentAsyncContext;
+  AddQueuedRoots(Task);
+  FFinalizationQueue.Add(Task);
 end;
 
 procedure TGocciaMicrotaskQueue.AddQueuedRoots(
@@ -376,6 +402,8 @@ begin
     GC.AddQueuedRoot(AMicrotask.Value);
   if Assigned(AMicrotask.ResultPromise) then
     GC.AddQueuedRoot(AMicrotask.ResultPromise);
+  if Assigned(AMicrotask.Context) then
+    GC.AddQueuedRoot(AMicrotask.Context);
 end;
 
 procedure TGocciaMicrotaskQueue.RemoveQueuedRoots(
@@ -393,6 +421,8 @@ begin
       GC.RemoveQueuedRoot(AMicrotask.Value);
     if Assigned(AMicrotask.ResultPromise) then
       GC.RemoveQueuedRoot(AMicrotask.ResultPromise);
+    if Assigned(AMicrotask.Context) then
+      GC.RemoveQueuedRoot(AMicrotask.Context);
   end;
   if Assigned(AMicrotask.Handler) and
      FJobs.TryGetValue(AMicrotask.Handler, Job) then
@@ -409,6 +439,7 @@ var
   Capability: TGocciaPromiseReactionCapability;
   HandlerResult: TGocciaValue;
   CallArgs: TGocciaArgumentsCollection;
+  PreviousContext: TGocciaAsyncContextSnapshot;
   procedure ResolveResult(const AValue: TGocciaValue);
   begin
     if Assigned(Capability) then
@@ -437,6 +468,15 @@ var
       RejectResult(CreateErrorObject(ERROR_NAME, AException.Message));
   end;
 begin
+  { Every job runs under the async context that was in effect where its
+    continuation was created, and leaves the enclosing context untouched. The
+    restore is what keeps a nested drain — an `await` inside a handler pumps
+    this queue re-entrantly — from leaking one continuation's bindings into
+    the frame that drained it. }
+  PreviousContext := CurrentAsyncContext;
+  SetCurrentAsyncContext(ATask.Context);
+  try
+
   Promise := nil;
   Capability := nil;
   if ATask.ResultPromise is TGocciaPromiseValue then
@@ -522,6 +562,10 @@ begin
         prtThenableResolve:;
       end;
     end;
+  end;
+
+  finally
+    SetCurrentAsyncContext(PreviousContext);
   end;
 end;
 

--- a/source/units/Goccia.MicrotaskQueue.pas
+++ b/source/units/Goccia.MicrotaskQueue.pas
@@ -439,7 +439,7 @@ var
   Capability: TGocciaPromiseReactionCapability;
   HandlerResult: TGocciaValue;
   CallArgs: TGocciaArgumentsCollection;
-  PreviousContext: TGocciaAsyncContextSnapshot;
+  ContextToken: Integer;
   procedure ResolveResult(const AValue: TGocciaValue);
   begin
     if Assigned(Capability) then
@@ -472,9 +472,14 @@ begin
     continuation was created, and leaves the enclosing context untouched. The
     restore is what keeps a nested drain — an `await` inside a handler pumps
     this queue re-entrantly — from leaking one continuation's bindings into
-    the frame that drained it. }
-  PreviousContext := CurrentAsyncContext;
-  SetCurrentAsyncContext(ATask.Context);
+    the frame that drained it.
+
+    EnterAsyncContext rather than a saved local: the displaced snapshot has to
+    stay reachable for the collector while the handler runs. It happens to be
+    reachable here anyway, through the queued root of the task that is still
+    in flight, but that is a property of the drain loop rather than of this
+    function — one reordering of RemoveQueuedRoots away from being false. }
+  ContextToken := EnterAsyncContext(ATask.Context);
   try
 
   Promise := nil;
@@ -565,7 +570,7 @@ begin
   end;
 
   finally
-    SetCurrentAsyncContext(PreviousContext);
+    LeaveAsyncContext(ContextToken);
   end;
 end;
 

--- a/source/units/Goccia.RuntimeExtensions.AsyncHooks.pas
+++ b/source/units/Goccia.RuntimeExtensions.AsyncHooks.pas
@@ -1,0 +1,55 @@
+unit Goccia.RuntimeExtensions.AsyncHooks;
+
+{$I Goccia.inc}
+
+interface
+
+uses
+  Goccia.Runtime,
+  Goccia.RuntimeExtensions.NamespaceModule,
+  Goccia.Values.Primitives;
+
+const
+  { Node's own address for the module, so a package written for Node imports it
+    unchanged. There is no `goccia:` spelling: the surface is Node's, not one
+    GocciaScript invented. }
+  ASYNC_HOOKS_MODULE_NAME = 'node:async_hooks';
+
+type
+  TGocciaAsyncHooksRuntimeExtension = class(TGocciaRuntimeExtension)
+  private
+    FAsyncHooksModule: TGocciaRuntimeNamespaceModuleRegistration;
+    function MaterializeAsyncHooks: TGocciaValue;
+  public
+    procedure Attach(const ARuntime: TGocciaRuntimeCore); override;
+    procedure Detach; override;
+  end;
+
+implementation
+
+uses
+  Goccia.Builtins.AsyncHooks;
+
+procedure TGocciaAsyncHooksRuntimeExtension.Attach(
+  const ARuntime: TGocciaRuntimeCore);
+begin
+  inherited Attach(ARuntime);
+  FAsyncHooksModule := TGocciaRuntimeNamespaceModuleRegistration.Create(Runtime,
+    ASYNC_HOOKS_MODULE_NAME,
+    MaterializeAsyncHooks,
+    True);
+end;
+
+procedure TGocciaAsyncHooksRuntimeExtension.Detach;
+begin
+  FAsyncHooksModule.Free;
+  FAsyncHooksModule := nil;
+  inherited;
+end;
+
+function TGocciaAsyncHooksRuntimeExtension.MaterializeAsyncHooks: TGocciaValue;
+begin
+  Result := CreateAsyncHooksNamespace;
+end;
+
+end.

--- a/source/units/Goccia.RuntimeExtensions.AsyncHooks.pas
+++ b/source/units/Goccia.RuntimeExtensions.AsyncHooks.pas
@@ -19,6 +19,7 @@ type
   TGocciaAsyncHooksRuntimeExtension = class(TGocciaRuntimeExtension)
   private
     FAsyncHooksModule: TGocciaRuntimeNamespaceModuleRegistration;
+    FHostToken: TObject;
     function MaterializeAsyncHooks: TGocciaValue;
   public
     procedure Attach(const ARuntime: TGocciaRuntimeCore); override;
@@ -44,12 +45,17 @@ procedure TGocciaAsyncHooksRuntimeExtension.Detach;
 begin
   FAsyncHooksModule.Free;
   FAsyncHooksModule := nil;
+  { Release this extension's own host state rather than leaving it for thread
+    teardown: several engines can live on one thread, and a detached one must
+    not keep its prototypes and namespace alive until the thread ends. }
+  ReleaseAsyncHooksHost(FHostToken);
+  FHostToken := nil;
   inherited;
 end;
 
 function TGocciaAsyncHooksRuntimeExtension.MaterializeAsyncHooks: TGocciaValue;
 begin
-  Result := CreateAsyncHooksNamespace;
+  Result := CreateAsyncHooksNamespace(FHostToken);
 end;
 
 end.

--- a/source/units/Goccia.RuntimeExtensions.NamespaceModule.pas
+++ b/source/units/Goccia.RuntimeExtensions.NamespaceModule.pas
@@ -20,9 +20,15 @@ type
     FFactory: TGocciaRuntimeNamespaceFactory;
     FNamespaceObject: TGocciaObjectValue;
     FRuntime: TGocciaRuntimeCore;
+    FExportsDefault: Boolean;
   public
+    { AExportsDefault opts a module into exporting the factory object's
+      `default` key as its default export. Off by default: a `goccia:` runtime
+      module is a namespace of named exports, and exporting one of them as
+      `default` as well would be an accident rather than a decision. }
     constructor Create(const ARuntime: TGocciaRuntimeCore;
-      const AModuleName: string; const AFactory: TGocciaRuntimeNamespaceFactory);
+      const AModuleName: string; const AFactory: TGocciaRuntimeNamespaceFactory;
+      const AExportsDefault: Boolean = False);
     destructor Destroy; override;
     function LoadModule: TGocciaModule;
   end;
@@ -37,9 +43,11 @@ uses
 
 constructor TGocciaRuntimeNamespaceModuleRegistration.Create(
   const ARuntime: TGocciaRuntimeCore; const AModuleName: string;
-  const AFactory: TGocciaRuntimeNamespaceFactory);
+  const AFactory: TGocciaRuntimeNamespaceFactory;
+  const AExportsDefault: Boolean);
 begin
   inherited Create;
+  FExportsDefault := AExportsDefault;
   if not Assigned(ARuntime) then
     raise Exception.Create('Runtime namespace module registration needs a runtime.');
   if not Assigned(AFactory) then
@@ -82,7 +90,7 @@ begin
   Module := TGocciaModule.Create(FModuleName);
   try
     for ExportName in FNamespaceObject.GetOwnPropertyKeys do
-      if ExportName <> KEYWORD_DEFAULT then
+      if (ExportName <> KEYWORD_DEFAULT) or FExportsDefault then
         Module.AddExportValue(ExportName,
           FNamespaceObject.GetProperty(ExportName));
     FModule := Module;

--- a/source/units/Goccia.RuntimeProfiles.Loader.pas
+++ b/source/units/Goccia.RuntimeProfiles.Loader.pas
@@ -18,6 +18,7 @@ procedure ApplyLoaderRuntimeProfile(const ARuntime: TGocciaRuntimeCore;
 implementation
 
 uses
+  Goccia.RuntimeExtensions.AsyncHooks,
   Goccia.RuntimeExtensions.Console,
   Goccia.RuntimeExtensions.CSV,
   Goccia.RuntimeExtensions.Fetch,
@@ -50,6 +51,10 @@ begin
   ARuntime.Install(TGocciaTextEncodingRuntimeExtension.Create);
   ARuntime.Install(TGocciaURLRuntimeExtension.Create);
   ARuntime.Install(TGocciaFetchRuntimeExtension.Create);
+  { Pure context bookkeeping — no I/O, no clock, no way to observe anything
+    the running program did not already have. It carries no capability, so it
+    is on by default wherever the loader profile is. }
+  ARuntime.Install(TGocciaAsyncHooksRuntimeExtension.Create);
   if ATestingModule then
     ARuntime.Install(TGocciaTestingLibraryRuntimeExtension.CreateModuleOnly);
 end;

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -16197,7 +16197,11 @@ begin
              (FRegisters[A].ObjectValue is TGocciaNativeFunctionValue) then
           begin
             GlobalName := TGocciaNativeFunctionValue(FRegisters[A].ObjectValue).Name;
-            if (GlobalName = 'bind') and
+            { Identity, not name: an own static named `bind` on a function
+              object is a different function, and matching on the name alone
+              silently redirected the call into Function.prototype.bind. }
+            if (TGocciaNativeFunctionValue(FRegisters[A].ObjectValue)
+                 .IntrinsicKind = nikFunctionBind) and
                (FRegisters[A - 1].ObjectValue is TGocciaFunctionBase) then
             begin
               case B of

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -2708,6 +2708,21 @@ type
   TGocciaBytecodeAsyncGeneratorObjectValue = class(TGocciaAsyncGeneratorBaseValue)
   private
     FInner: TGocciaBytecodeGeneratorObjectValue;
+    { Async-generator request queue. DUPLICATED: TGocciaAsyncGeneratorObjectValue
+      in Goccia.Values.GeneratorValue
+      carries the same queue with the same discipline for the other executor,
+      and the two must stay in step — a change to one is a bug in the other
+      until it is made there too.
+
+      Async context is deliberately NOT recorded per request. A body observes
+      the context of whichever call resumed it, and that already falls out of
+      the microtask seam: every resumption reaches the body through a promise
+      reaction, which carries the snapshot captured where it was registered.
+      Probed against Node v24.0.1 across for-await, a generator created in one
+      context and resumed in another, a queued second request overlapping a
+      running one, and nested for-await under different stores; both executors
+      match Node on all of them. See tests/built-ins/AsyncHooks/
+      async-generators.js, which locks that in, and ADR 0111. }
     FQueue: array of TGocciaBytecodeAsyncGeneratorRequest;
     FQueueHead: Integer;
     FQueueCount: Integer;

--- a/source/units/Goccia.Values.FunctionBase.pas
+++ b/source/units/Goccia.Values.FunctionBase.pas
@@ -999,6 +999,7 @@ end;
 
 constructor TGocciaFunctionSharedPrototype.Create;
 var
+  BindIntrinsic: TGocciaValue;
   Members: array[0..4] of TGocciaMemberDefinition;
   Thrower: TGocciaNativeFunctionValue;
 begin
@@ -1032,6 +1033,10 @@ begin
       1,
       []);
     RegisterMemberDefinitions(Self, Members);
+    BindIntrinsic := GetProperty('bind');
+    if BindIntrinsic is TGocciaNativeFunctionValue then
+      TGocciaNativeFunctionValue(BindIntrinsic).IntrinsicKind :=
+        nikFunctionBind;
   except
     if (CurrentRealm <> nil) and (CurrentRealm.GetSlot(GFunctionPrototypeSlot) = Self) then
       CurrentRealm.SetSlot(GFunctionPrototypeSlot, nil);

--- a/source/units/Goccia.Values.GeneratorValue.pas
+++ b/source/units/Goccia.Values.GeneratorValue.pas
@@ -72,6 +72,21 @@ type
   private
     FContinuation: TGocciaGeneratorContinuation;
     FState: TGocciaGeneratorState;
+    { Async-generator request queue. DUPLICATED: TGocciaBytecodeAsyncGeneratorObjectValue
+      in Goccia.VM
+      carries the same queue with the same discipline for the other executor,
+      and the two must stay in step — a change to one is a bug in the other
+      until it is made there too.
+
+      Async context is deliberately NOT recorded per request. A body observes
+      the context of whichever call resumed it, and that already falls out of
+      the microtask seam: every resumption reaches the body through a promise
+      reaction, which carries the snapshot captured where it was registered.
+      Probed against Node v24.0.1 across for-await, a generator created in one
+      context and resumed in another, a queued second request overlapping a
+      running one, and nested for-await under different stores; both executors
+      match Node on all of them. See tests/built-ins/AsyncHooks/
+      async-generators.js, which locks that in, and ADR 0111. }
     FQueue: array of TGocciaAsyncGeneratorRequest;
     FQueueHead: Integer;
     FQueueCount: Integer;

--- a/source/units/Goccia.Values.NativeFunction.pas
+++ b/source/units/Goccia.Values.NativeFunction.pas
@@ -17,7 +17,13 @@ type
     nikNone,
     nikDecodeURI,
     nikDecodeURIComponent,
-    nikStringFromCharCode
+    nikStringFromCharCode,
+    { Function.prototype.bind. Marked so the bytecode VM's bound-function fast
+      path can recognise the intrinsic itself rather than any callable that
+      happens to be named `bind` — an own static named `bind` on a function
+      object (node:async_hooks installs two) is a different function and must
+      not be redirected into TGocciaBoundFunctionValue. }
+    nikFunctionBind
   );
 
   TGocciaNativeFunctionValue = class(TGocciaFunctionBase)

--- a/source/units/Goccia.Values.PromiseValue.pas
+++ b/source/units/Goccia.Values.PromiseValue.pas
@@ -8,6 +8,7 @@ uses
   Generics.Collections,
 
   Goccia.Arguments.Collection,
+  Goccia.AsyncContext,
   Goccia.ObjectModel,
   Goccia.Realm,
   Goccia.SharedPrototype,
@@ -24,6 +25,11 @@ type
     OnFulfilled: TGocciaValue;
     OnRejected: TGocciaValue;
     ResultPromise: TGocciaValue;
+    { The async context in effect where the reaction was registered. A
+      reaction on a pending promise outlives the call that registered it, so
+      the context has to travel with the reaction rather than be read again
+      when the promise settles. }
+    Context: TGocciaAsyncContextSnapshot;
   end;
 
   TGocciaPromiseFinallyWrapper = class(TGocciaObjectValue)
@@ -623,6 +629,8 @@ begin
         Reaction.OnRejected.MarkReferences;
       if Assigned(Reaction.ResultPromise) then
         Reaction.ResultPromise.MarkReferences;
+      if Assigned(Reaction.Context) then
+        Reaction.Context.MarkReferences;
     end;
 end;
 
@@ -719,6 +727,7 @@ begin
       Reaction.OnFulfilled := nil;
       Reaction.OnRejected := nil;
       Reaction.ResultPromise := Self;
+      Reaction.Context := CurrentAsyncContext;
       if not Assigned(APromise.FReactions) then
         APromise.FReactions := TList<TGocciaPromiseReaction>.Create;
       APromise.FReactions.Add(Reaction);
@@ -748,7 +757,7 @@ begin
         Task.Value := FResult;
         Task.ResultPromise := Reaction.ResultPromise;
         Task.ReactionType := prtFulfill;
-        Queue.Enqueue(Task);
+        Queue.EnqueueWithContext(Task, Reaction.Context);
       end;
       gpsRejected:
       begin
@@ -756,7 +765,7 @@ begin
         Task.Value := FResult;
         Task.ResultPromise := Reaction.ResultPromise;
         Task.ReactionType := prtReject;
-        Queue.Enqueue(Task);
+        Queue.EnqueueWithContext(Task, Reaction.Context);
       end;
     end;
   end;
@@ -811,6 +820,7 @@ begin
       Reaction.OnFulfilled := AOnFulfilled;
       Reaction.OnRejected := AOnRejected;
       Reaction.ResultPromise := CapabilityHost;
+      Reaction.Context := CurrentAsyncContext;
       if not Assigned(APromise.FReactions) then
         APromise.FReactions := TList<TGocciaPromiseReaction>.Create;
       APromise.FReactions.Add(Reaction);

--- a/tests/built-ins/AsyncHooks/AsyncResource.js
+++ b/tests/built-ins/AsyncHooks/AsyncResource.js
@@ -1,0 +1,79 @@
+/*---
+description: AsyncResource captures the async context at construction and replays it on demand
+features: [AsyncResource, AsyncLocalStorage]
+---*/
+
+import { AsyncLocalStorage, AsyncResource } from "node:async_hooks";
+
+const captureIn = (als, store) => {
+  let captured;
+  als.run(store, () => {
+    captured = new AsyncResource("probe");
+  });
+  return captured;
+};
+
+describe("AsyncResource", () => {
+  test("runInAsyncScope replays the captured context", () => {
+    const als = new AsyncLocalStorage();
+    const resource = captureIn(als, "captured");
+    expect(resource.runInAsyncScope(() => als.getStore())).toBe("captured");
+    expect(als.getStore()).toBeUndefined();
+  });
+
+  test("runInAsyncScope forwards a receiver and extra arguments", () => {
+    const resource = new AsyncResource("probe");
+    const receiver = { tag: "receiver" };
+    const observed = resource.runInAsyncScope(
+      ({ tag }, first) => [tag, first],
+      undefined,
+      receiver,
+      1,
+    );
+    expect(observed).toEqual(["receiver", 1]);
+  });
+
+  test("the captured context survives an await inside the scope", async () => {
+    const als = new AsyncLocalStorage();
+    const resource = captureIn(als, "captured");
+    const observed = await resource.runInAsyncScope(async () => {
+      await Promise.resolve();
+      return als.getStore();
+    });
+    expect(observed).toBe("captured");
+  });
+
+  test("bind returns a function pinned to the captured context", () => {
+    const als = new AsyncLocalStorage();
+    const resource = captureIn(als, "captured");
+    const bound = resource.bind(() => als.getStore());
+    expect(bound()).toBe("captured");
+  });
+
+  test("the static bind pins to the context of the bind call", () => {
+    const als = new AsyncLocalStorage();
+    let bound;
+    als.run("static", () => {
+      bound = AsyncResource.bind(() => als.getStore());
+    });
+    expect(bound()).toBe("static");
+  });
+
+  test("asyncId and triggerAsyncId are numbers and emitDestroy chains", () => {
+    const resource = new AsyncResource("probe");
+    expect(typeof resource.asyncId()).toBe("number");
+    expect(typeof resource.triggerAsyncId()).toBe("number");
+    expect(resource.emitDestroy()).toBe(resource);
+  });
+
+  test("distinct resources report distinct async ids", () => {
+    const first = new AsyncResource("probe");
+    const second = new AsyncResource("probe");
+    expect(first.asyncId()).not.toBe(second.asyncId());
+  });
+
+  test("prototype methods reject a foreign receiver", () => {
+    const foreign = { asyncId: AsyncResource.prototype.asyncId };
+    expect(() => foreign.asyncId()).toThrow(TypeError);
+  });
+});

--- a/tests/built-ins/AsyncHooks/AsyncResource.js
+++ b/tests/built-ins/AsyncHooks/AsyncResource.js
@@ -72,6 +72,52 @@ describe("AsyncResource", () => {
     expect(first.asyncId()).not.toBe(second.asyncId());
   });
 
+  test("bind forwards the call-site receiver when thisArg is omitted", () => {
+    // Node splits on `thisArg === undefined`, not on the argument count, so an
+    // omitted and an explicitly undefined thisArg behave alike: both leave the
+    // call site's own receiver in place. Probed against Node v24.0.1.
+    const resource = new AsyncResource("probe");
+    const read = ({ read() { return this.tag; } }).read;
+    expect(({ tag: "holder", method: resource.bind(read) }).method()).toBe("holder");
+    expect(({ tag: "holder", method: resource.bind(read, undefined) }).method())
+      .toBe("holder");
+  });
+
+  test("bind honours an explicit receiver", () => {
+    const resource = new AsyncResource("probe");
+    const read = ({ read() { return this.tag; } }).read;
+    const bound = resource.bind(read, { tag: "explicit" });
+    expect(({ tag: "holder", method: bound }).method()).toBe("explicit");
+  });
+
+  test("the static bind forwards the call-site receiver too", () => {
+    const read = ({ read() { return this.tag; } }).read;
+    expect(({ tag: "holder", method: AsyncResource.bind(read) }).method())
+      .toBe("holder");
+  });
+
+  test("runInAsyncScope does not substitute the call-site receiver", () => {
+    // Unlike bind: an omitted thisArg here really is undefined.
+    const resource = new AsyncResource("probe");
+    const read = ({ read() { return this; } }).read;
+    expect(resource.runInAsyncScope(read)).toBeUndefined();
+  });
+
+  test("bind rejects a non-callable at bind time, not at call time", () => {
+    const resource = new AsyncResource("probe");
+    expect(() => resource.bind(42)).toThrow(TypeError);
+    expect(() => AsyncResource.bind(42)).toThrow(TypeError);
+  });
+
+  test("bound functions report Node's name and the target's length", () => {
+    const resource = new AsyncResource("probe");
+    const target = (first, second) => [first, second];
+    expect(resource.bind(target).name).toBe("bound");
+    expect(resource.bind(target).length).toBe(2);
+    expect(AsyncResource.bind(target).name).toBe("bound");
+    expect(AsyncResource.bind(target).length).toBe(2);
+  });
+
   test("prototype methods reject a foreign receiver", () => {
     const foreign = { asyncId: AsyncResource.prototype.asyncId };
     expect(() => foreign.asyncId()).toThrow(TypeError);

--- a/tests/built-ins/AsyncHooks/async-generators.js
+++ b/tests/built-ins/AsyncHooks/async-generators.js
@@ -1,0 +1,122 @@
+/*---
+description: async generator resumptions observe the same async context as Node
+features: [AsyncLocalStorage, async-generators]
+---*/
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
+// Async generators drive their bodies through per-mode request queues that the
+// async-context seams do not touch directly. Every expectation here was probed
+// against Node v24.0.1 and holds in both executors: the body observes the
+// context of whichever call resumed it, and the surrounding frames are
+// unaffected.
+const als = new AsyncLocalStorage();
+
+describe("AsyncLocalStorage across async generators", () => {
+  test("the store reaches the body and survives yields and awaits", async () => {
+    const seen = [];
+    const source = {
+      async *values() {
+        seen.push(als.getStore());
+        yield 1;
+        seen.push(als.getStore());
+        await Promise.resolve();
+        seen.push(als.getStore());
+        yield 2;
+        seen.push(als.getStore());
+      },
+    };
+
+    await als.run("GEN", async () => {
+      for await (const value of source.values()) {
+        seen.push(als.getStore() + ":" + value);
+      }
+    });
+    expect(seen).toEqual(["GEN", "GEN:1", "GEN", "GEN", "GEN:2", "GEN"]);
+    expect(als.getStore()).toBeUndefined();
+  });
+
+  test("a generator resumed outside a run sees no store", async () => {
+    const seen = [];
+    const source = {
+      async *values() {
+        seen.push(als.getStore());
+        yield 1;
+        seen.push(als.getStore());
+      },
+    };
+
+    let iterator;
+    als.run("CREATED", () => {
+      iterator = source.values();
+    });
+    await iterator.next();
+    await iterator.next();
+    expect(seen).toEqual([undefined, undefined]);
+  });
+
+  test("a generator resumed inside a run sees that run's store", async () => {
+    const seen = [];
+    const source = {
+      async *values() {
+        seen.push(als.getStore());
+        yield 1;
+        seen.push(als.getStore());
+      },
+    };
+
+    const iterator = source.values();
+    await iterator.next();
+    await als.run("RESUMER", async () => {
+      await iterator.next();
+    });
+    expect(seen).toEqual([undefined, "RESUMER"]);
+  });
+
+  test("a queued second request does not displace the running body's store", async () => {
+    const seen = [];
+    let release;
+    const gate = new Promise((resolve) => {
+      release = resolve;
+    });
+    const source = {
+      async *values() {
+        seen.push(als.getStore());
+        await gate;
+        seen.push(als.getStore());
+        yield 1;
+        seen.push(als.getStore());
+        yield 2;
+      },
+    };
+
+    const iterator = source.values();
+    const first = als.run("FIRST", () => iterator.next());
+    const second = als.run("SECOND", () => iterator.next());
+    release(1);
+    await first;
+    await second;
+    expect(seen).toEqual(["FIRST", "FIRST", "FIRST"]);
+    expect(als.getStore()).toBeUndefined();
+  });
+
+  test("nested runs around a for-await keep their own stores", async () => {
+    const seen = [];
+    const source = {
+      async *values() {
+        seen.push(als.getStore());
+        yield 1;
+      },
+    };
+
+    await als.run("OUTER", async () => {
+      await als.run("INNER", async () => {
+        for await (const value of source.values()) {
+          seen.push(als.getStore() + ":" + value);
+        }
+      });
+      seen.push(als.getStore());
+    });
+    expect(seen).toEqual(["INNER", "INNER:1", "OUTER"]);
+  });
+});

--- a/tests/built-ins/AsyncHooks/bind.js
+++ b/tests/built-ins/AsyncHooks/bind.js
@@ -1,0 +1,43 @@
+/*---
+description: AsyncLocalStorage.bind and AsyncLocalStorage.snapshot pin a callback to the context of the call
+features: [AsyncLocalStorage]
+---*/
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
+describe("AsyncLocalStorage statics", () => {
+  test("bind pins a callback to the context it was bound in", () => {
+    const als = new AsyncLocalStorage();
+    let bound;
+    als.run("bound-in", () => {
+      bound = AsyncLocalStorage.bind(() => als.getStore());
+    });
+    expect(bound()).toBe("bound-in");
+    expect(als.getStore()).toBeUndefined();
+  });
+
+  test("bind forwards arguments", () => {
+    const als = new AsyncLocalStorage();
+    let bound;
+    als.run("ctx", () => {
+      bound = AsyncLocalStorage.bind((first, second) => [first, second, als.getStore()]);
+    });
+    expect(bound(1, 2)).toEqual([1, 2, "ctx"]);
+  });
+
+  test("snapshot returns a runner for the captured context", () => {
+    const als = new AsyncLocalStorage();
+    let snapshot;
+    als.run("snapshotted", () => {
+      snapshot = AsyncLocalStorage.snapshot();
+    });
+    expect(snapshot(() => als.getStore())).toBe("snapshotted");
+    expect(snapshot((first) => [first, als.getStore()], 1)).toEqual([1, "snapshotted"]);
+  });
+
+  test("does not shadow Function.prototype.bind for ordinary functions", () => {
+    const target = { tag: "target" };
+    const read = ((value) => [target.tag, value]).bind(null, 1);
+    expect(read()).toEqual(["target", 1]);
+  });
+});

--- a/tests/built-ins/AsyncHooks/bind.js
+++ b/tests/built-ins/AsyncHooks/bind.js
@@ -35,6 +35,31 @@ describe("AsyncLocalStorage statics", () => {
     expect(snapshot((first) => [first, als.getStore()], 1)).toEqual([1, "snapshotted"]);
   });
 
+  test("bind rejects a non-callable at bind time", () => {
+    expect(() => AsyncLocalStorage.bind(42)).toThrow(TypeError);
+  });
+
+  test("a snapshot runner rejects a non-callable at call time", () => {
+    // snapshot() has no callback to validate, so the check lands on its runner.
+    const snapshot = AsyncLocalStorage.snapshot();
+    expect(() => snapshot(42)).toThrow(TypeError);
+  });
+
+  test("bind and snapshot report Node's name and length", () => {
+    const target = (first, second) => [first, second];
+    expect(AsyncLocalStorage.bind(target).name).toBe("bound");
+    expect(AsyncLocalStorage.bind(target).length).toBe(2);
+    // The runner takes (callback, ...args), so its length is one regardless.
+    expect(AsyncLocalStorage.snapshot().name).toBe("bound");
+    expect(AsyncLocalStorage.snapshot().length).toBe(1);
+  });
+
+  test("bind forwards the call-site receiver", () => {
+    const read = ({ read() { return this.tag; } }).read;
+    expect(({ tag: "holder", method: AsyncLocalStorage.bind(read) }).method())
+      .toBe("holder");
+  });
+
   test("does not shadow Function.prototype.bind for ordinary functions", () => {
     const target = { tag: "target" };
     const read = ((value) => [target.tag, value]).bind(null, 1);

--- a/tests/built-ins/AsyncHooks/disable.js
+++ b/tests/built-ins/AsyncHooks/disable.js
@@ -1,0 +1,42 @@
+/*---
+description: AsyncLocalStorage.prototype.disable stops the instance reporting stores until it is used again
+features: [AsyncLocalStorage]
+---*/
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
+describe("AsyncLocalStorage.prototype.disable", () => {
+  test("getStore reports undefined after disable", () => {
+    const als = new AsyncLocalStorage();
+    als.disable();
+    expect(als.getStore()).toBeUndefined();
+  });
+
+  test("getStore reports the default value after disable", () => {
+    const als = new AsyncLocalStorage({ defaultValue: "DEF" });
+    als.disable();
+    expect(als.getStore()).toBe("DEF");
+  });
+
+  test("run re-enables the instance", () => {
+    const als = new AsyncLocalStorage({ defaultValue: "DEF" });
+    als.disable();
+    als.run("again", () => {
+      expect(als.getStore()).toBe("again");
+    });
+    expect(als.getStore()).toBe("DEF");
+  });
+
+  test("disabling inside a run drops the store for the rest of it", () => {
+    const als = new AsyncLocalStorage();
+    als.run("bound", () => {
+      expect(als.getStore()).toBe("bound");
+      als.disable();
+      expect(als.getStore()).toBeUndefined();
+    });
+  });
+
+  test("returns undefined", () => {
+    expect(new AsyncLocalStorage().disable()).toBeUndefined();
+  });
+});

--- a/tests/built-ins/AsyncHooks/disable.js
+++ b/tests/built-ins/AsyncHooks/disable.js
@@ -1,10 +1,14 @@
 /*---
-description: AsyncLocalStorage.prototype.disable stops the instance reporting stores until it is used again
+description: AsyncLocalStorage.prototype.disable deletes the binding from the current frame only
 features: [AsyncLocalStorage]
 ---*/
 
 import { AsyncLocalStorage } from "node:async_hooks";
 
+// disable() is a frame edit, not an instance-wide switch. Everything below was
+// probed against Node v24.0.1, whose AsyncContextFrame model this follows: a
+// continuation captured before the disable keeps the store it captured,
+// because the disable never reached that frame.
 describe("AsyncLocalStorage.prototype.disable", () => {
   test("getStore reports undefined after disable", () => {
     const als = new AsyncLocalStorage();
@@ -18,13 +22,20 @@ describe("AsyncLocalStorage.prototype.disable", () => {
     expect(als.getStore()).toBe("DEF");
   });
 
-  test("run re-enables the instance", () => {
+  test("run binds again after a disable", () => {
     const als = new AsyncLocalStorage({ defaultValue: "DEF" });
     als.disable();
     als.run("again", () => {
       expect(als.getStore()).toBe("again");
     });
     expect(als.getStore()).toBe("DEF");
+  });
+
+  test("enterWith binds again after a disable", () => {
+    const als = new AsyncLocalStorage({ defaultValue: "DEF" });
+    als.disable();
+    als.enterWith("entered");
+    expect(als.getStore()).toBe("entered");
   });
 
   test("disabling inside a run drops the store for the rest of it", () => {
@@ -34,6 +45,75 @@ describe("AsyncLocalStorage.prototype.disable", () => {
       als.disable();
       expect(als.getStore()).toBeUndefined();
     });
+  });
+
+  test("disabling inside an inner run leaves the outer store intact", () => {
+    const als = new AsyncLocalStorage();
+    als.run("outer", () => {
+      als.run("inner", () => {
+        als.disable();
+        expect(als.getStore()).toBeUndefined();
+      });
+      expect(als.getStore()).toBe("outer");
+    });
+  });
+
+  test("the disabled frame stays disabled across its own awaits", async () => {
+    const als = new AsyncLocalStorage();
+    await als.run("bound", async () => {
+      als.disable();
+      expect(als.getStore()).toBeUndefined();
+      await Promise.resolve();
+      expect(als.getStore()).toBeUndefined();
+    });
+  });
+
+  test("a continuation captured before the disable keeps its store", async () => {
+    const als = new AsyncLocalStorage();
+    let settle;
+    const pending = new Promise((resolve) => {
+      settle = resolve;
+    });
+    let seen = "unset";
+    als.run("captured", () => {
+      pending.then(() => {
+        seen = als.getStore();
+      });
+    });
+    als.disable();
+    settle(1);
+    await pending;
+    await Promise.resolve();
+    expect(seen).toBe("captured");
+  });
+
+  test("a disable followed by a re-binding run still leaves the capture intact", async () => {
+    const als = new AsyncLocalStorage();
+    let settle;
+    const pending = new Promise((resolve) => {
+      settle = resolve;
+    });
+    let seen = "unset";
+    als.run("captured", () => {
+      pending.then(() => {
+        seen = als.getStore();
+      });
+    });
+    als.disable();
+    als.run("rebound", () => {});
+    settle(1);
+    await pending;
+    await Promise.resolve();
+    expect(seen).toBe("captured");
+  });
+
+  test("exit on a disabled instance reports undefined, not the default value", () => {
+    const als = new AsyncLocalStorage({ defaultValue: "DEF" });
+    als.disable();
+    als.exit(() => {
+      expect(als.getStore()).toBeUndefined();
+    });
+    expect(als.getStore()).toBe("DEF");
   });
 
   test("returns undefined", () => {

--- a/tests/built-ins/AsyncHooks/enterWith.js
+++ b/tests/built-ins/AsyncHooks/enterWith.js
@@ -1,0 +1,38 @@
+/*---
+description: AsyncLocalStorage.prototype.enterWith binds a store for the rest of the current execution
+features: [AsyncLocalStorage]
+---*/
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
+describe("AsyncLocalStorage.prototype.enterWith", () => {
+  test("binds the store immediately and across a later await", async () => {
+    const als = new AsyncLocalStorage();
+    await als.run("start", async () => {
+      await Promise.resolve();
+      als.enterWith("entered");
+      expect(als.getStore()).toBe("entered");
+      await Promise.resolve();
+      expect(als.getStore()).toBe("entered");
+    });
+    expect(als.getStore()).toBeUndefined();
+  });
+
+  test("returns undefined", () => {
+    const als = new AsyncLocalStorage();
+    als.run("outer", () => {
+      expect(als.enterWith("inner")).toBeUndefined();
+      expect(als.getStore()).toBe("inner");
+    });
+  });
+
+  test("re-enables a disabled instance", () => {
+    const als = new AsyncLocalStorage({ defaultValue: "DEF" });
+    als.disable();
+    expect(als.getStore()).toBe("DEF");
+    als.run("scope", () => {
+      als.enterWith("entered");
+      expect(als.getStore()).toBe("entered");
+    });
+  });
+});

--- a/tests/built-ins/AsyncHooks/enterWith.js
+++ b/tests/built-ins/AsyncHooks/enterWith.js
@@ -26,6 +26,17 @@ describe("AsyncLocalStorage.prototype.enterWith", () => {
     });
   });
 
+  test("binds outside any run, with nothing to unwind it", () => {
+    // enterWith has no scope to leave, so this deliberately ends the test — and
+    // the file — with a context still installed. The engine drops the thread's
+    // async-context state when it is torn down; without that, the next file on
+    // the same worker inherited this snapshot and marking it walked a realm
+    // that no longer existed.
+    const als = new AsyncLocalStorage();
+    als.enterWith("outside-any-run");
+    expect(als.getStore()).toBe("outside-any-run");
+  });
+
   test("re-enables a disabled instance", () => {
     const als = new AsyncLocalStorage({ defaultValue: "DEF" });
     als.disable();

--- a/tests/built-ins/AsyncHooks/exit.js
+++ b/tests/built-ins/AsyncHooks/exit.js
@@ -1,0 +1,45 @@
+/*---
+description: AsyncLocalStorage.prototype.exit runs a callback with no store bound
+features: [AsyncLocalStorage]
+---*/
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
+describe("AsyncLocalStorage.prototype.exit", () => {
+  test("clears the store for the callback and restores it afterwards", () => {
+    const als = new AsyncLocalStorage();
+    als.run("with-store", () => {
+      als.exit(() => {
+        expect(als.getStore()).toBeUndefined();
+      });
+      expect(als.getStore()).toBe("with-store");
+    });
+  });
+
+  test("clears the store even when a default value is configured", () => {
+    const als = new AsyncLocalStorage({ defaultValue: "DEF" });
+    als.exit(() => {
+      expect(als.getStore()).toBeUndefined();
+    });
+    expect(als.getStore()).toBe("DEF");
+  });
+
+  test("returns the callback result and forwards extra arguments", () => {
+    const als = new AsyncLocalStorage();
+    expect(als.exit(() => 7)).toBe(7);
+    expect(als.exit((first, second) => [first, second], 1, 2)).toEqual([1, 2]);
+  });
+
+  test("leaves other instances untouched", () => {
+    const first = new AsyncLocalStorage();
+    const second = new AsyncLocalStorage();
+    first.run("A", () => {
+      second.run("B", () => {
+        first.exit(() => {
+          expect(first.getStore()).toBeUndefined();
+          expect(second.getStore()).toBe("B");
+        });
+      });
+    });
+  });
+});

--- a/tests/built-ins/AsyncHooks/exit.js
+++ b/tests/built-ins/AsyncHooks/exit.js
@@ -30,6 +30,11 @@ describe("AsyncLocalStorage.prototype.exit", () => {
     expect(als.exit((first, second) => [first, second], 1, 2)).toEqual([1, 2]);
   });
 
+  test("rejects a non-callable callback", () => {
+    const als = new AsyncLocalStorage();
+    expect(() => als.exit(42)).toThrow(TypeError);
+  });
+
   test("leaves other instances untouched", () => {
     const first = new AsyncLocalStorage();
     const second = new AsyncLocalStorage();

--- a/tests/built-ins/AsyncHooks/garbage-collection.js
+++ b/tests/built-ins/AsyncHooks/garbage-collection.js
@@ -1,0 +1,149 @@
+/*---
+description: async context survives a collection taken while a scoped context is installed
+features: [AsyncLocalStorage, AsyncResource]
+---*/
+
+import { AsyncLocalStorage, AsyncResource } from "node:async_hooks";
+
+// A snapshot displaced by run/exit/runInAsyncScope is reachable only from the
+// engine's saved-context stack. If that stack were not a collection root, a
+// collection taken from inside the callback would free the displaced snapshot
+// and the restore would read freed memory — a crash, not a wrong value. Every
+// test here forces two collections so a surviving snapshot has to be genuinely
+// rooted rather than merely not-yet-swept.
+const collect = () => {
+  Goccia.gc();
+  Goccia.gc();
+};
+
+describe("AsyncLocalStorage under garbage collection", () => {
+  test("a nested run restores the outer store after a collection", () => {
+    const als = new AsyncLocalStorage();
+    als.run("OUTER", () => {
+      als.run("INNER", () => {
+        collect();
+        expect(als.getStore()).toBe("INNER");
+      });
+      expect(als.getStore()).toBe("OUTER");
+    });
+    expect(als.getStore()).toBeUndefined();
+  });
+
+  test("exit restores the surrounding store after a collection", () => {
+    const als = new AsyncLocalStorage();
+    als.run("OUTER", () => {
+      als.exit(() => {
+        collect();
+        expect(als.getStore()).toBeUndefined();
+      });
+      expect(als.getStore()).toBe("OUTER");
+    });
+  });
+
+  test("runInAsyncScope restores the surrounding store after a collection", () => {
+    const als = new AsyncLocalStorage();
+    let resource;
+    als.run("CAPTURED", () => {
+      resource = new AsyncResource("probe");
+    });
+    als.run("OUTER", () => {
+      resource.runInAsyncScope(() => {
+        collect();
+        expect(als.getStore()).toBe("CAPTURED");
+      });
+      expect(als.getStore()).toBe("OUTER");
+    });
+  });
+
+  test("a bound function restores the surrounding store after a collection", () => {
+    const als = new AsyncLocalStorage();
+    let bound;
+    als.run("BOUND", () => {
+      bound = AsyncLocalStorage.bind(() => {
+        collect();
+        return als.getStore();
+      });
+    });
+    als.run("OUTER", () => {
+      expect(bound()).toBe("BOUND");
+      expect(als.getStore()).toBe("OUTER");
+    });
+  });
+
+  test("deeply nested runs each restore their own store after collections", () => {
+    const als = new AsyncLocalStorage();
+    const seen = [];
+    const descend = (depth) => {
+      if (depth === 0) {
+        collect();
+        return;
+      }
+      als.run(depth, () => {
+        descend(depth - 1);
+        seen.push(als.getStore());
+      });
+    };
+    descend(6);
+    expect(seen).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+
+  test("a store survives collections taken across a microtask drain", async () => {
+    const als = new AsyncLocalStorage();
+    const seen = [];
+    await als.run("DRAINED", () =>
+      Promise.resolve()
+        .then(() => {
+          collect();
+          seen.push(als.getStore());
+        })
+        .then(() => {
+          collect();
+          seen.push(als.getStore());
+        }));
+    expect(seen).toEqual(["DRAINED", "DRAINED"]);
+    expect(als.getStore()).toBeUndefined();
+  });
+
+  test("interleaved chains survive collections between their resumptions", async () => {
+    // The chains are `.then` chains rather than async callbacks on purpose.
+    // Collecting from inside a bytecode async function that has already
+    // resumed from a suspension faults the VM, independently of this module —
+    // `(async () => { await Promise.resolve(); Goccia.gc(); })()` alone
+    // reproduces it on 0.13.0. A `.then` handler runs as an ordinary microtask
+    // job, which is the seam under test here anyway.
+    const als = new AsyncLocalStorage();
+    const observed = [];
+    const chain = (tag) =>
+      als.run(tag, () =>
+        Promise.resolve()
+          .then(() => {
+            collect();
+            observed.push(tag === als.getStore());
+          })
+          .then(() => {
+            collect();
+            observed.push(tag === als.getStore());
+          }));
+    await Promise.all([chain("a"), chain("b"), chain("c")]);
+    expect(observed).toEqual([true, true, true, true, true, true]);
+  });
+
+  test("a continuation captured before a collection still carries its store", async () => {
+    const als = new AsyncLocalStorage();
+    let settle;
+    const pending = new Promise((resolve) => {
+      settle = resolve;
+    });
+    let seen = "unset";
+    als.run("CAPTURED", () => {
+      pending.then(() => {
+        seen = als.getStore();
+      });
+    });
+    collect();
+    settle(1);
+    await pending;
+    await Promise.resolve();
+    expect(seen).toBe("CAPTURED");
+  });
+});

--- a/tests/built-ins/AsyncHooks/getStore.js
+++ b/tests/built-ins/AsyncHooks/getStore.js
@@ -1,0 +1,33 @@
+/*---
+description: AsyncLocalStorage.prototype.getStore reports the bound store, or the instance default value
+features: [AsyncLocalStorage]
+---*/
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
+describe("AsyncLocalStorage.prototype.getStore", () => {
+  test("is undefined outside any run", () => {
+    expect(new AsyncLocalStorage().getStore()).toBeUndefined();
+  });
+
+  test("reports the configured default value when nothing is bound", () => {
+    const als = new AsyncLocalStorage({ defaultValue: "DEF" });
+    expect(als.getStore()).toBe("DEF");
+    als.run("bound", () => {
+      expect(als.getStore()).toBe("bound");
+    });
+    expect(als.getStore()).toBe("DEF");
+  });
+
+  test("an explicitly bound undefined store wins over the default value", () => {
+    const als = new AsyncLocalStorage({ defaultValue: "DEF" });
+    als.run(undefined, () => {
+      expect(als.getStore()).toBeUndefined();
+    });
+  });
+
+  test("name reports the configured name, or the empty string", () => {
+    expect(new AsyncLocalStorage({ name: "requests" }).name).toBe("requests");
+    expect(new AsyncLocalStorage().name).toBe("");
+  });
+});

--- a/tests/built-ins/AsyncHooks/module.js
+++ b/tests/built-ins/AsyncHooks/module.js
@@ -1,0 +1,40 @@
+/*---
+description: node:async_hooks exposes AsyncLocalStorage and AsyncResource
+features: [AsyncLocalStorage, AsyncResource]
+---*/
+
+import asyncHooks, { AsyncLocalStorage, AsyncResource } from "node:async_hooks";
+import * as namespace from "node:async_hooks";
+
+describe("node:async_hooks module", () => {
+  test("named exports are constructors", () => {
+    expect(typeof AsyncLocalStorage).toBe("function");
+    expect(typeof AsyncResource).toBe("function");
+  });
+
+  test("the namespace carries the two constructors and a default export", () => {
+    expect(Object.keys(namespace).sort())
+      .toEqual(["AsyncLocalStorage", "AsyncResource", "default"]);
+    expect(namespace.default).toBe(asyncHooks);
+  });
+
+  test("default export carries the same constructors", () => {
+    expect(asyncHooks.AsyncLocalStorage).toBe(AsyncLocalStorage);
+    expect(asyncHooks.AsyncResource).toBe(AsyncResource);
+  });
+
+  test("instances are instanceof their constructor", () => {
+    expect(new AsyncLocalStorage() instanceof AsyncLocalStorage).toBe(true);
+    expect(new AsyncResource("probe") instanceof AsyncResource).toBe(true);
+  });
+
+  test("an options object is accepted and may be omitted", () => {
+    expect(typeof new AsyncLocalStorage()).toBe("object");
+    expect(typeof new AsyncLocalStorage({})).toBe("object");
+  });
+
+  test("prototype methods reject a foreign receiver", () => {
+    const foreign = { getStore: AsyncLocalStorage.prototype.getStore };
+    expect(() => foreign.getStore()).toThrow(TypeError);
+  });
+});

--- a/tests/built-ins/AsyncHooks/promise-continuations.js
+++ b/tests/built-ins/AsyncHooks/promise-continuations.js
@@ -1,0 +1,66 @@
+/*---
+description: async context travels with promise reaction continuations, not with the code that settles the promise
+features: [AsyncLocalStorage]
+---*/
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
+describe("AsyncLocalStorage promise continuations", () => {
+  test("a then registered inside run sees the store when settled outside", async () => {
+    const als = new AsyncLocalStorage();
+    let settle;
+    const pending = new Promise((resolve) => {
+      settle = resolve;
+    });
+    const chained = als.run("registered", () =>
+      pending.then(() => als.getStore()).then((value) => {
+        expect(value).toBe("registered");
+        return als.getStore();
+      }));
+    settle(1);
+    expect(await chained).toBe("registered");
+    expect(als.getStore()).toBeUndefined();
+  });
+
+  test("catch and finally continuations carry the store", async () => {
+    const als = new AsyncLocalStorage();
+    const seen = [];
+    await als.run("handled", () =>
+      Promise.reject(new Error("rejected"))
+        .catch(() => seen.push(als.getStore()))
+        .finally(() => seen.push(als.getStore())));
+    expect(seen).toEqual(["handled", "handled"]);
+  });
+
+  test("a continuation does not leak its store into the frame that drained it", async () => {
+    const als = new AsyncLocalStorage();
+    let settle;
+    const pending = new Promise((resolve) => {
+      settle = resolve;
+    });
+    als.run("foreign", () => {
+      pending.then(() => {
+        expect(als.getStore()).toBe("foreign");
+      });
+    });
+
+    await als.run("own", async () => {
+      settle(1);
+      await pending;
+      expect(als.getStore()).toBe("own");
+    });
+    expect(als.getStore()).toBeUndefined();
+  });
+
+  test("a queued microtask sees the store of the scope that queued it", async () => {
+    const als = new AsyncLocalStorage();
+    let seen = "unset";
+    als.run("queued", () => {
+      queueMicrotask(() => {
+        seen = als.getStore();
+      });
+    });
+    await Promise.resolve();
+    expect(seen).toBe("queued");
+  });
+});

--- a/tests/built-ins/AsyncHooks/run.js
+++ b/tests/built-ins/AsyncHooks/run.js
@@ -1,0 +1,122 @@
+/*---
+description: AsyncLocalStorage.prototype.run binds a store for its callback and every continuation created inside it
+features: [AsyncLocalStorage]
+---*/
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
+describe("AsyncLocalStorage.prototype.run", () => {
+  test("binds the store for the synchronous callback", () => {
+    const als = new AsyncLocalStorage();
+    als.run("ctx", () => {
+      expect(als.getStore()).toBe("ctx");
+    });
+    expect(als.getStore()).toBeUndefined();
+  });
+
+  test("returns the callback result and forwards extra arguments", () => {
+    const als = new AsyncLocalStorage();
+    expect(als.run("ctx", () => 42)).toBe(42);
+    expect(als.run("ctx", (first, second) => [first, second, als.getStore()], 1, 2))
+      .toEqual([1, 2, "ctx"]);
+  });
+
+  test("the store survives an await", async () => {
+    const als = new AsyncLocalStorage();
+    await als.run("ctx-1", async () => {
+      expect(als.getStore()).toBe("ctx-1");
+      await Promise.resolve();
+      expect(als.getStore()).toBe("ctx-1");
+    });
+    expect(als.getStore()).toBeUndefined();
+  });
+
+  test("interleaved chains keep separate stores", async () => {
+    const als = new AsyncLocalStorage();
+    const seen = [];
+    await Promise.all([
+      als.run("a", async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+        seen.push(als.getStore());
+      }),
+      als.run("b", async () => {
+        await Promise.resolve();
+        seen.push(als.getStore());
+      }),
+    ]);
+    expect(seen.sort()).toEqual(["a", "b"]);
+  });
+
+  test("many concurrent chains each keep their own store", async () => {
+    const als = new AsyncLocalStorage();
+    const observed = [];
+    const chain = (tag) =>
+      als.run(tag, async () => {
+        for (const step of [0, 1, 2]) {
+          await Promise.resolve();
+          observed.push([tag, als.getStore()]);
+        }
+      });
+    await Promise.all([chain(1), chain(2), chain(3)]);
+    expect(observed.every(([tag, store]) => tag === store)).toBe(true);
+  });
+
+  test("nested runs restore the enclosing store", () => {
+    const als = new AsyncLocalStorage();
+    als.run("outer", () => {
+      als.run("inner", () => {
+        expect(als.getStore()).toBe("inner");
+      });
+      expect(als.getStore()).toBe("outer");
+    });
+  });
+
+  test("three instances stay independent", async () => {
+    const first = new AsyncLocalStorage();
+    const second = new AsyncLocalStorage();
+    const third = new AsyncLocalStorage();
+    await first.run("X", async () => {
+      await second.run("Y", async () => {
+        await third.run("Z", async () => {
+          await Promise.resolve();
+          expect([first.getStore(), second.getStore(), third.getStore()])
+            .toEqual(["X", "Y", "Z"]);
+        });
+        expect(third.getStore()).toBeUndefined();
+        expect([first.getStore(), second.getStore()]).toEqual(["X", "Y"]);
+      });
+    });
+    expect([first.getStore(), second.getStore(), third.getStore()])
+      .toEqual([undefined, undefined, undefined]);
+  });
+
+  test("a callback that throws after an await still restores the store", async () => {
+    const als = new AsyncLocalStorage();
+    let message = null;
+    try {
+      await als.run("rejecting", async () => {
+        await Promise.resolve();
+        expect(als.getStore()).toBe("rejecting");
+        throw new Error("boom");
+      });
+    } catch (error) {
+      message = error.message;
+    }
+    expect(message).toBe("boom");
+    expect(als.getStore()).toBeUndefined();
+  });
+
+  test("a rejection awaited inside the callback keeps the store", async () => {
+    const als = new AsyncLocalStorage();
+    await als.run("kept", async () => {
+      try {
+        await Promise.reject(new Error("inner"));
+      } catch {
+        // The store must survive the rejection path, not only the happy one.
+      }
+      expect(als.getStore()).toBe("kept");
+    });
+    expect(als.getStore()).toBeUndefined();
+  });
+});

--- a/tests/built-ins/AsyncHooks/run.js
+++ b/tests/built-ins/AsyncHooks/run.js
@@ -21,6 +21,12 @@ describe("AsyncLocalStorage.prototype.run", () => {
       .toEqual([1, 2, "ctx"]);
   });
 
+  test("rejects a non-callable callback", () => {
+    const als = new AsyncLocalStorage();
+    expect(() => als.run("ctx", 42)).toThrow(TypeError);
+    expect(als.getStore()).toBeUndefined();
+  });
+
   test("the store survives an await", async () => {
     const als = new AsyncLocalStorage();
     await als.run("ctx-1", async () => {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- `import { AsyncLocalStorage, AsyncResource } from "node:async_hooks"` now works, with real continuation-scoped context: a store bound by `run` survives `await` and every promise-reaction continuation, and interleaved chains keep separate stores. This was the last engine wall between GocciaScript and `convex-test`-style npm test tooling — a userland shim is provably insufficient because `run(store, async cb)` returns at the first `await` and the resumed continuation must still see the store.
- The engine carries one immutable context snapshot per continuation (all `AsyncLocalStorage` instances' bindings at once; `nil` when untouched, so programs that never use ALS allocate nothing). Two seams, both in machinery the interpreter and the bytecode VM share, so mode parity is structural: capture at promise-reaction registration (a reaction on a pending promise runs under the context of its registration, not its settlement) and install-with-restore around each microtask. Awaits suspend onto the same registration seam and drain on the same Pascal stack, so they need no seam of their own. Displaced snapshots are held on a GC-marked per-thread stack while guest code runs (a collection inside nested `run`/`exit`/`runInAsyncScope` crashed both modes before this was rooted), and engine teardown resets thread context state so a bare `enterWith` cannot leak into the next engine on a reused worker thread.
- Surface: `run`, `getStore`, `enterWith`, `exit`, `disable`, `defaultValue`/`name` options, static `bind`/`snapshot`; `AsyncResource` with `runInAsyncScope`, instance/static `bind`, `asyncId`, `triggerAsyncId`, `emitDestroy`. Semantics probed against Node v24 (not read off docs), including the context-frame `disable()` model (a captured continuation keeps its store across a later `disable`), call-site `this` forwarding for `bind` when `thisArg` is undefined, bind-time callable validation, and `bound `-prefixed names. Async-generator propagation was verified rather than assumed: resumptions ride the instrumented reaction seam, and probes plus tests lock in Node-identical behavior in both modes.
- Ships with a genuine bytecode-only bug fix found en route: `OP_CALL_METHOD` recognized `Function.prototype.bind` by callee *name*, silently hijacking any user-defined `bind` method in bytecode mode. It is now identity-matched via an intrinsic kind. (The sibling `call`/`apply` hazard is fixed in the next layer of this stack.)
- ADR 0112 records the mechanism and the scope cuts (no host-callback propagation — no timer queue exists; no `createHook` observer API). New reference doc `docs/built-ins-async-context.md`; `o-asynccontext.test.js` gates propagation against bun (the behaviors bun 1.3.14 gets wrong vs Node — constructor options, `emitDestroy`, and its instance-flag `disable` model — are covered against Node in `tests/built-ins/AsyncHooks/` instead, with the reasoning in `docs/differential-testing.md`).

## Testing

- [x] Verified no regressions and confirmed the feature in end-to-end JavaScript/TypeScript tests — full suite green in both modes incl. the AsyncHooks tests (nested run, exit-inside-run, enterWith-after-await, three concurrent instances, rejection paths, `.then` chains, async generators, and GC-forcing tests across nested contexts and microtask drains); differential suite 21p/0f in all three runtimes, zero divergence
- [x] Updated documentation (ADR 0112, `docs/built-ins-async-context.md`, README, built-ins/embedding/testing-api/differential-testing docs)
- [x] Native Pascal surface covered via the shared microtask/promise units exercised by the JS suites; `./format.pas --check` clean
- [x] GC discipline mutation-checked: with the saved-snapshot marking neutered, the GC tests fail in the interpreter and the bytecode VM faults; with it, all pass in both modes

Review: fresh-context high-effort pass with Node-probe verification (1 Blocking GC use-after-free, 4 Important incl. the `disable()` frame model and async-generator question — all resolved in-branch; the async-generator finding was empirically refuted with probes and pinned by tests). Follow-up filed separately: a pre-existing bytecode VM crash when a collection runs after an await resumption, present at 0.13.0.
