### PR TITLE
fix(bytecode): match call/apply/bind intrinsics by identity in method-call fast paths

### DIFF
--- a/docs/differential-testing.md
+++ b/docs/differential-testing.md
@@ -67,6 +67,7 @@ oracle instead of inheriting a default.
 | `m-nodemods.test.js` | language | skip | gate |
 | `n-nodemods.goccia.test.js` | language | skip | skip |
 | `o-asynccontext.test.js` | language | skip | gate |
+| `p-callintrinsics.test.js` | language | skip | gate |
 
 `o-asynccontext.test.js` covers `node:async_hooks` propagation only, and stops
 there on purpose. Bun 1.3.14 does not honour the `defaultValue` or `name`
@@ -83,6 +84,15 @@ surviving `await`, interleaved chains, several instances at once, `.then` /
 `.catch` / `.finally` continuations, `exit`, `enterWith`, bind-time callable
 validation, and async-generator resumptions — every bun since 1.3.14 and Node
 agree on.
+
+`p-callintrinsics.test.js` covers members named `call`, `apply` and `bind` that
+are not the `Function.prototype` intrinsics — static class methods, own and
+inherited function properties, and `Reflect.apply` installed as a function's own
+`apply` — alongside ordinary intrinsic use. That pairing is the point: the
+bytecode VM routes `.call`/`.apply`/`.bind` on a function receiver through call
+fast paths, and while those matched on the callee's *name* a user-defined member
+was silently redirected into the intrinsic in bytecode mode only. The suite fails
+in whichever mode stops distinguishing the two.
 
 `h-modulemock.test.js` and `i-modulemock-isolation.test.js` are a pair: the
 first mocks `./mods/mockable.js` with a `vi.mock` factory, the second mocks

--- a/scripts/differential/p-callintrinsics.test.js
+++ b/scripts/differential/p-callintrinsics.test.js
@@ -1,0 +1,216 @@
+// Calls to a member named `call`, `apply` or `bind` must run the function the
+// receiver actually carries, not the `Function.prototype` intrinsic that shares
+// the name. The interesting shapes all put the callee on a function object,
+// where the intrinsic is the plausible alternative reading, and invoke it with
+// the argument shape the intrinsic itself would accept.
+//
+// Bun gates: this is ECMAScript property lookup and call semantics, and the
+// testing API is incidental. Vitest is skipped for the same reason as the other
+// language suites. See the CLASSIFICATION entry in
+// scripts/test-cli-differential.ts.
+
+describe("user-defined call/apply/bind on function objects", () => {
+  test("static class methods run instead of the intrinsics", () => {
+    class Registry {
+      static call(name, ...rest) {
+        return `Registry.call(${name})[${rest.join(",")}]`;
+      }
+
+      static apply(name, list) {
+        return `Registry.apply(${name})[${list.join(",")}]`;
+      }
+
+      static bind(name) {
+        return `Registry.bind(${name})`;
+      }
+    }
+
+    expect(Registry.call("a", 1, 2)).toBe("Registry.call(a)[1,2]");
+    expect(Registry.apply("a", [1, 2])).toBe("Registry.apply(a)[1,2]");
+    expect(Registry.bind("a")).toBe("Registry.bind(a)");
+    expect(Registry.call.name).toBe("call");
+    expect(Registry.apply).not.toBe(Function.prototype.apply);
+  });
+
+  test("own properties on a plain function run instead of the intrinsics", () => {
+    const host = function () {
+      return "host";
+    };
+    host.call = (...args) => `own call(${args.join(",")})`;
+    host.apply = (thisArg, list) => `own apply(${thisArg},[${list.join(",")}])`;
+    host.bind = (...args) => `own bind(${args.join(",")})`;
+
+    expect(host.call("t", 1, 2)).toBe("own call(t,1,2)");
+    expect(host.apply("t", [1, 2])).toBe("own apply(t,[1,2])");
+    expect(host.bind("t", 1)).toBe("own bind(t,1)");
+    expect(host()).toBe("host");
+  });
+
+  test("an inherited `call` from the function's prototype chain wins", () => {
+    const behaviour = {
+      call(tag) {
+        return `inherited call(${tag})`;
+      },
+      apply(tag, list) {
+        return `inherited apply(${tag},${list.length})`;
+      },
+    };
+    const host = function () {
+      return "host";
+    };
+    Object.setPrototypeOf(host, behaviour);
+
+    expect(host.call("t")).toBe("inherited call(t)");
+    expect(host.apply("t", [1, 2, 3])).toBe("inherited apply(t,3)");
+  });
+
+  test("a different built-in installed as `apply` keeps its own semantics", () => {
+    const inner = function () {
+      return `inner(thisIsArray=${Array.isArray(this)})`;
+    };
+    const host = function () {
+      return "host";
+    };
+    host.apply = Reflect.apply;
+
+    // Reflect.apply(target, thisArgument, argumentsList): the receiver `host` is
+    // not involved at all, and the array in the third position is what
+    // Function.prototype.apply would have consumed from the second.
+    expect(host.apply(inner, [], [])).toBe("inner(thisIsArray=true)");
+    expect(host.apply.name).toBe("apply");
+    expect(host.apply).not.toBe(Function.prototype.apply);
+  });
+
+  test("arity variants of a user-defined call are all forwarded", () => {
+    const host = function () {
+      return "host";
+    };
+    host.call = (...args) => args.length;
+
+    expect(host.call()).toBe(0);
+    expect(host.call(1)).toBe(1);
+    expect(host.call(1, 2)).toBe(2);
+    expect(host.call(1, 2, 3)).toBe(3);
+    expect(host.call(1, 2, 3, 4)).toBe(4);
+    expect(host.call(...[1, 2, 3, 4, 5])).toBe(5);
+  });
+
+  test("user-defined call/apply on plain objects and instances", () => {
+    const gadget = {
+      tag: "gadget",
+      call(x) {
+        return `${this.tag}.call(${x})`;
+      },
+      apply(x, list) {
+        return `${this.tag}.apply(${x},${list.length})`;
+      },
+    };
+    expect(gadget.call(1)).toBe("gadget.call(1)");
+    expect(gadget.apply(1, [2, 3])).toBe("gadget.apply(1,2)");
+
+    class Dispatcher {
+      constructor(tag) {
+        this.tag = tag;
+      }
+
+      call(x) {
+        return `${this.tag}.call(${x})`;
+      }
+
+      apply(x, list) {
+        return `${this.tag}.apply(${x},${list.length})`;
+      }
+    }
+    const dispatcher = new Dispatcher("d");
+    expect(dispatcher.call(1)).toBe("d.call(1)");
+    expect(dispatcher.apply(1, [2, 3])).toBe("d.apply(1,2)");
+  });
+
+  test("shadowing an intrinsic does not disturb the intrinsic itself", () => {
+    const host = function (a, b) {
+      return `${this.tag}:${a}:${b}`;
+    };
+    host.call = () => "shadowed";
+    host.apply = () => "shadowed";
+
+    expect(host.call(1)).toBe("shadowed");
+    expect(Function.prototype.call.call(host, { tag: "t" }, 1, 2)).toBe("t:1:2");
+    expect(Function.prototype.apply.call(host, { tag: "t" }, [1, 2])).toBe("t:1:2");
+  });
+});
+
+describe("the Function.prototype intrinsics themselves", () => {
+  const collect = function (...args) {
+    return `${this === undefined ? "undefined" : this.tag}:${args.join(",")}`;
+  };
+
+  test("call forwards the this value and every argument", () => {
+    const receiver = { tag: "r" };
+    expect(collect.call(receiver)).toBe("r:");
+    expect(collect.call(receiver, 1)).toBe("r:1");
+    expect(collect.call(receiver, 1, 2)).toBe("r:1,2");
+    expect(collect.call(receiver, 1, 2, 3)).toBe("r:1,2,3");
+    expect(collect.call(receiver, 1, 2, 3, 4)).toBe("r:1,2,3,4");
+    expect(collect.call(...[receiver, 1, 2])).toBe("r:1,2");
+  });
+
+  test("apply forwards array arguments of every length", () => {
+    const receiver = { tag: "r" };
+    expect(collect.apply(receiver, [])).toBe("r:");
+    expect(collect.apply(receiver, [1])).toBe("r:1");
+    expect(collect.apply(receiver, [1, 2])).toBe("r:1,2");
+    expect(collect.apply(receiver, [1, 2, 3])).toBe("r:1,2,3");
+    expect(collect.apply(receiver, [1, 2, 3, 4])).toBe("r:1,2,3,4");
+  });
+
+  test("apply accepts array-likes and absent argument lists", () => {
+    const receiver = { tag: "r" };
+    expect(collect.apply(receiver, { 0: "x", 1: "y", length: 2 })).toBe("r:x,y");
+    expect(collect.apply(receiver)).toBe("r:");
+    expect(collect.apply(receiver, null)).toBe("r:");
+  });
+
+  test("bind fixes the this value and partially applies", () => {
+    const receiver = { tag: "r" };
+    expect(collect.bind(receiver)()).toBe("r:");
+    expect(collect.bind(receiver, 1)(2)).toBe("r:1,2");
+    expect(collect.bind(receiver, 1, 2)(3)).toBe("r:1,2,3");
+    expect(typeof collect.bind(receiver)).toBe("function");
+    expect(collect.bind(receiver)).not.toBe(collect);
+  });
+
+  test("methods reached through a class instance keep their receiver", () => {
+    class Counter {
+      constructor() {
+        this.count = 7;
+      }
+
+      read(offset) {
+        return this.count + offset;
+      }
+    }
+    const counter = new Counter();
+    expect(counter.read.call(counter, 1)).toBe(8);
+    expect(counter.read.apply(counter, [2])).toBe(9);
+    expect(counter.read.bind(counter, 3)()).toBe(10);
+    expect(counter.read.call({ count: 100 }, 1)).toBe(101);
+  });
+
+  test("the intrinsics work when detached from the function", () => {
+    const call = Function.prototype.call;
+    const apply = Function.prototype.apply;
+    const bind = Function.prototype.bind;
+    const receiver = { tag: "r" };
+
+    expect(call.call(collect, receiver, 1)).toBe("r:1");
+    expect(apply.call(collect, receiver, [1, 2])).toBe("r:1,2");
+    expect(bind.call(collect, receiver, 1)(2)).toBe("r:1,2");
+    expect(call.apply(collect, [receiver, 1, 2, 3])).toBe("r:1,2,3");
+  });
+
+  test("call and apply reject non-callable receivers", () => {
+    const notCallable = { call: Function.prototype.call, apply: Function.prototype.apply };
+    expect(() => notCallable.call(undefined)).toThrow(TypeError);
+    expect(() => notCallable.apply(undefined, [])).toThrow(TypeError);
+  });
+});

--- a/scripts/test-cli-differential.ts
+++ b/scripts/test-cli-differential.ts
@@ -178,6 +178,15 @@ const CLASSIFICATION: Record<string, Classification> = {
   // and a `run` after one leaks. All of that is covered against Node's
   // behaviour in tests/built-ins/AsyncHooks, where bun is not the oracle.
   "o-asynccontext.test.js": { kind: "language", bun: "gate", vitest: "skip" },
+  // Members named `call`, `apply` and `bind` that are not the
+  // `Function.prototype` intrinsics — the shape a name-matching call fast path
+  // confuses: both a user-defined `bind` and `Reflect.apply` installed as a
+  // function's own `apply` were hijacked into the intrinsic in bytecode mode
+  // only, until the fast paths matched on intrinsic identity instead of on the
+  // callee name. Bun gates: this is property lookup and call semantics,
+  // and the testing API is incidental. Vitest is skipped for the same reason as
+  // the other language suites.
+  "p-callintrinsics.test.js": { kind: "language", bun: "gate", vitest: "skip" },
 };
 
 type Verdict = {

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -13630,6 +13630,7 @@ var
   KeyIndex: Integer;
   ArgsArray: TGocciaArrayValue;
   CallArgs: TGocciaArgumentsCollection;
+  CalleeIntrinsicKind: TGocciaNativeIntrinsicKind;
   I: Integer;
   GlobalName: string;
   GlobalBindingValue: TGocciaValue;
@@ -16211,12 +16212,13 @@ begin
              (FRegisters[A].Kind = grkObject) and
              (FRegisters[A].ObjectValue is TGocciaNativeFunctionValue) then
           begin
-            GlobalName := TGocciaNativeFunctionValue(FRegisters[A].ObjectValue).Name;
-            { Identity, not name: an own static named `bind` on a function
-              object is a different function, and matching on the name alone
-              silently redirected the call into Function.prototype.bind. }
-            if (TGocciaNativeFunctionValue(FRegisters[A].ObjectValue)
-                 .IntrinsicKind = nikFunctionBind) and
+            { Identity, not name: an own `bind`, `call` or `apply` on a function
+              object is a different function — `Reflect.apply` assigned as one,
+              or the two statics node:async_hooks installs — and matching on the
+              name alone silently redirected the call into the intrinsic. }
+            CalleeIntrinsicKind :=
+              TGocciaNativeFunctionValue(FRegisters[A].ObjectValue).IntrinsicKind;
+            if (CalleeIntrinsicKind = nikFunctionBind) and
                (FRegisters[A - 1].ObjectValue is TGocciaFunctionBase) then
             begin
               case B of
@@ -16251,7 +16253,7 @@ begin
                  (not BytecodeFunction.FClosure.Template.IsAsync) and
                  (not BytecodeFunction.FClosure.Template.IsGenerator) then
               begin
-                if GlobalName = 'call' then
+                if CalleeIntrinsicKind = nikFunctionCall then
                 begin
                   if B = 0 then
                     CallThisRegister := RegisterUndefined
@@ -16304,7 +16306,7 @@ begin
                   end;
                   Continue;
                 end
-                else if (GlobalName = 'apply') and (B >= 2) and
+                else if (CalleeIntrinsicKind = nikFunctionApply) and (B >= 2) and
                         (FRegisters[A + 2].Kind = grkObject) and
                         (FRegisters[A + 2].ObjectValue is TGocciaArrayValue) then
                 begin

--- a/source/units/Goccia.Values.FunctionBase.pas
+++ b/source/units/Goccia.Values.FunctionBase.pas
@@ -1010,8 +1010,12 @@ var
     Intrinsic: TGocciaValue;
   begin
     Intrinsic := GetProperty(AName);
-    if Intrinsic is TGocciaNativeFunctionValue then
-      TGocciaNativeFunctionValue(Intrinsic).IntrinsicKind := AKind;
+    // A miss here would silently disengage every fast path keyed on the
+    // kind — the slow path stays correct, so no test could notice.
+    Assert(Intrinsic is TGocciaNativeFunctionValue,
+      'Function.prototype.' + AName + ' must be a native function to carry ' +
+      'its intrinsic kind');
+    TGocciaNativeFunctionValue(Intrinsic).IntrinsicKind := AKind;
   end;
 
 begin

--- a/source/units/Goccia.Values.FunctionBase.pas
+++ b/source/units/Goccia.Values.FunctionBase.pas
@@ -999,9 +999,21 @@ end;
 
 constructor TGocciaFunctionSharedPrototype.Create;
 var
-  BindIntrinsic: TGocciaValue;
   Members: array[0..4] of TGocciaMemberDefinition;
   Thrower: TGocciaNativeFunctionValue;
+
+  // Stamp the identity the bytecode VM's call fast paths match on, so they
+  // recognise the intrinsic itself rather than any callable sharing its name.
+  procedure MarkIntrinsic(const AName: string;
+    const AKind: TGocciaNativeIntrinsicKind);
+  var
+    Intrinsic: TGocciaValue;
+  begin
+    Intrinsic := GetProperty(AName);
+    if Intrinsic is TGocciaNativeFunctionValue then
+      TGocciaNativeFunctionValue(Intrinsic).IntrinsicKind := AKind;
+  end;
+
 begin
   inherited Create;
 
@@ -1033,10 +1045,9 @@ begin
       1,
       []);
     RegisterMemberDefinitions(Self, Members);
-    BindIntrinsic := GetProperty('bind');
-    if BindIntrinsic is TGocciaNativeFunctionValue then
-      TGocciaNativeFunctionValue(BindIntrinsic).IntrinsicKind :=
-        nikFunctionBind;
+    MarkIntrinsic('call', nikFunctionCall);
+    MarkIntrinsic('apply', nikFunctionApply);
+    MarkIntrinsic('bind', nikFunctionBind);
   except
     if (CurrentRealm <> nil) and (CurrentRealm.GetSlot(GFunctionPrototypeSlot) = Self) then
       CurrentRealm.SetSlot(GFunctionPrototypeSlot, nil);

--- a/source/units/Goccia.Values.NativeFunction.pas
+++ b/source/units/Goccia.Values.NativeFunction.pas
@@ -23,7 +23,14 @@ type
       happens to be named `bind` — an own static named `bind` on a function
       object (node:async_hooks installs two) is a different function and must
       not be redirected into TGocciaBoundFunctionValue. }
-    nikFunctionBind
+    nikFunctionBind,
+    { Function.prototype.call and Function.prototype.apply, marked for the same
+      reason as bind: the VM's OP_CALL_METHOD fast paths invoke the receiver
+      itself, so any other callable found under those names — `Reflect.apply`
+      assigned as a function's own `apply`, a future built-in named `call` —
+      must be called on its own terms instead. }
+    nikFunctionCall,
+    nikFunctionApply
   );
 
   TGocciaNativeFunctionValue = class(TGocciaFunctionBase)

--- a/tests/built-ins/Function/prototype/apply.js
+++ b/tests/built-ins/Function/prototype/apply.js
@@ -106,4 +106,68 @@ describe("Function.prototype.apply", () => {
     expect(String.apply(null, [42])).toBe("42");
     expect(Boolean.apply(null, [1])).toBe(true);
   });
+
+  test("forwards argument arrays of every length", () => {
+    const collect = ({
+      m(...args) {
+        return `${this.tag}:${args.join(",")}`;
+      },
+    }).m;
+    const receiver = { tag: "r" };
+
+    expect(collect.apply(receiver, [])).toBe("r:");
+    expect(collect.apply(receiver, [1])).toBe("r:1");
+    expect(collect.apply(receiver, [1, 2])).toBe("r:1,2");
+    expect(collect.apply(receiver, [1, 2, 3])).toBe("r:1,2,3");
+    expect(collect.apply(receiver, [1, 2, 3, 4])).toBe("r:1,2,3,4");
+  });
+
+  test("an own apply property is invoked instead of the intrinsic", () => {
+    const host = () => "host";
+    host.apply = (thisArg, list) => `own apply(${thisArg},[${list.join(",")}])`;
+
+    expect(host.apply("t", [1, 2])).toBe("own apply(t,[1,2])");
+    expect(host()).toBe("host");
+    expect(Function.prototype.apply.call(host, undefined, [])).toBe("host");
+  });
+
+  test("a different built-in installed as apply keeps its own semantics", () => {
+    const inner = ({
+      m() {
+        return `inner(thisIsArray=${Array.isArray(this)})`;
+      },
+    }).m;
+    const host = () => "host";
+    host.apply = Reflect.apply;
+
+    // Reflect.apply(target, thisArgument, argumentsList) ignores the receiver
+    // entirely, and reads its argument list from the third position rather than
+    // the second — where Function.prototype.apply would have read it.
+    expect(host.apply(inner, [], [])).toBe("inner(thisIsArray=true)");
+    expect(host.apply.name).toBe("apply");
+    expect(host.apply).not.toBe(Function.prototype.apply);
+  });
+
+  test("an apply inherited from the function's prototype chain is invoked", () => {
+    const behaviour = {
+      apply(tag, list) {
+        return `inherited apply(${tag},${list.length})`;
+      },
+    };
+    const host = () => "host";
+    Object.setPrototypeOf(host, behaviour);
+
+    expect(host.apply("t", [1, 2, 3])).toBe("inherited apply(t,3)");
+  });
+
+  test("a class static named apply is the class's own method", () => {
+    class Registry {
+      static apply(name, list) {
+        return `Registry.apply(${name})[${list.join(",")}]`;
+      }
+    }
+
+    expect(Registry.apply("a", [1, 2])).toBe("Registry.apply(a)[1,2]");
+    expect(Registry.apply).not.toBe(Function.prototype.apply);
+  });
 });

--- a/tests/built-ins/Function/prototype/bind.js
+++ b/tests/built-ins/Function/prototype/bind.js
@@ -107,4 +107,24 @@ describe("Function.prototype.bind", () => {
 
     expect(bound.name).toBe("bound before");
   });
+
+  test("an own bind property is invoked instead of the intrinsic", () => {
+    const host = () => "host";
+    host.bind = (...args) => `own bind(${args.join(",")})`;
+
+    expect(host.bind("t")).toBe("own bind(t)");
+    expect(host.bind("t", 1, 2)).toBe("own bind(t,1,2)");
+    expect(Function.prototype.bind.call(host, null)()).toBe("host");
+  });
+
+  test("a class static named bind is the class's own method", () => {
+    class Registry {
+      static bind(name) {
+        return `Registry.bind(${name})`;
+      }
+    }
+
+    expect(Registry.bind("a")).toBe("Registry.bind(a)");
+    expect(Registry.bind).not.toBe(Function.prototype.bind);
+  });
 });

--- a/tests/built-ins/Function/prototype/call.js
+++ b/tests/built-ins/Function/prototype/call.js
@@ -57,4 +57,55 @@ describe("Function.prototype.call", () => {
     expect(Boolean.call(null, 1)).toBe(true);
     expect(Boolean.call(null, 0)).toBe(false);
   });
+
+  test("forwards every argument count", () => {
+    const collect = ({
+      m(...args) {
+        return `${this.tag}:${args.join(",")}`;
+      },
+    }).m;
+    const receiver = { tag: "r" };
+
+    expect(collect.call(receiver)).toBe("r:");
+    expect(collect.call(receiver, 1)).toBe("r:1");
+    expect(collect.call(receiver, 1, 2)).toBe("r:1,2");
+    expect(collect.call(receiver, 1, 2, 3)).toBe("r:1,2,3");
+    expect(collect.call(receiver, 1, 2, 3, 4)).toBe("r:1,2,3,4");
+    expect(collect.call(...[receiver, 1, 2])).toBe("r:1,2");
+  });
+
+  test("an own call property is invoked instead of the intrinsic", () => {
+    const host = () => "host";
+    host.call = (...args) => `own call(${args.join(",")})`;
+
+    expect(host.call()).toBe("own call()");
+    expect(host.call("t")).toBe("own call(t)");
+    expect(host.call("t", 1, 2)).toBe("own call(t,1,2)");
+    expect(host()).toBe("host");
+    expect(Function.prototype.call.call(host, undefined)).toBe("host");
+  });
+
+  test("a call inherited from the function's prototype chain is invoked", () => {
+    const behaviour = {
+      call(tag) {
+        return `inherited call(${tag})`;
+      },
+    };
+    const host = () => "host";
+    Object.setPrototypeOf(host, behaviour);
+
+    expect(host.call("t")).toBe("inherited call(t)");
+  });
+
+  test("a class static named call is the class's own method", () => {
+    class Registry {
+      static call(name, ...rest) {
+        return `Registry.call(${name})[${rest.join(",")}]`;
+      }
+    }
+
+    expect(Registry.call("a")).toBe("Registry.call(a)[]");
+    expect(Registry.call("a", 1, 2)).toBe("Registry.call(a)[1,2]");
+    expect(Registry.call).not.toBe(Function.prototype.call);
+  });
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Closes out the intrinsic name-matching bug class in the bytecode VM's `OP_CALL_METHOD` fast paths. `Function.prototype.call` and `apply` were recognized by callee *name*; the reachable consequence: assigning a different built-in as a function's own `apply` (`host.apply = Reflect.apply`) silently took the `Function.prototype.apply` fast path in bytecode mode while the interpreter correctly called the assigned function — a real mode divergence, characterized at base before fixing.
- All three fast paths (`call`, `apply`, `bind`) now branch on intrinsic identity via `nikFunctionCall`/`nikFunctionApply` kinds alongside the existing `nikFunctionBind`, stamped where the shared function prototype is built. The fast paths themselves are unchanged and verified still engaged for genuine `.call`/`.apply` (instrumented marker build), and the per-instruction callee-name string read is gone from `OP_CALL_METHOD`.
- The `call` half of the hazard has no reachable shipped native named `call` today (a reflective global walk found only `Reflect.apply` as a divergence vehicle); it was proven load-bearing with a temporary `Reflect.call` alias experiment and is covered by the same identity mechanism.

## Testing

- [x] Verified no regressions and confirmed the bugfix in end-to-end JavaScript/TypeScript tests — full suite 12398/12398 in both modes; new `p-callintrinsics.test.js` differential suite 14p/0f across interp/bytecode/bun with zero divergence; repo tests under `tests/built-ins/Function/prototype/` for call/apply/bind shadowing and genuine-intrinsic behavior
- [x] Updated documentation (`docs/differential-testing.md` suite row)
- [x] Mutation-checked: reverting identity back to name matching fails the new `apply` tests with a bytecode-only divergence (the `call` half is mutation-covered only via the alias experiment, since no shipped native is named `call`)
- [x] Not benchmark-relevant (fast-path dispatch unchanged; one string read removed per OP_CALL_METHOD)

Follow-up to the `bind` identity fix that shipped with the `node:async_hooks` layer; flagged there as the remaining sibling hazard.
