### PR TITLE
fix(classes): run field initializers in the definition environment at spec-mandated points

### DIFF
--- a/scripts/differential/l-modulefndecl.test.js
+++ b/scripts/differential/l-modulefndecl.test.js
@@ -9,7 +9,10 @@
 import {
   Counted,
   Factory,
+  ImplicitLeaf,
   Labelled,
+  OverriddenLeaf,
+  OverriddenMiddle,
   Point,
   StampedLabel,
   Tagged,
@@ -23,11 +26,14 @@ import {
   fnDeclConstruct,
   fnDeclDerivedConstruct,
   fnDeclFieldRead,
+  fnDeclImplicitLeafConstruct,
   fnDeclLocalImplicitSubclassConstruct,
   fnDeclLocalSubclassConstruct,
   fnDeclLocalSubclassOfDerivedConstruct,
   fnDeclNestedConstruct,
+  fnDeclOverriddenLeafConstruct,
   fnDeclSpreadConstruct,
+  implicitTickCount,
 } from "./mods/fndecl.js";
 
 const ENTRY_PREFIX = "entry-";
@@ -231,5 +237,38 @@ describe("construction from module function declarations", () => {
     expect(Object.keys(counted)).toEqual(["label", "x", "y", "seq", "owner"]);
     expect(counted.brand()).toBe("id-counted");
     expect(derivedTickCount() - ticksBefore).toBe(1);
+  });
+
+  // Classes with no constructor of their own take the implicit-default path
+  // (§15.7.14 step 15a), which is separate machinery from an explicit super().
+  // Every probe here is run from both sides of the import for that reason.
+  test("an override returned by a base constructor carries no fields from its own layer", () => {
+    for (const leaf of [fnDeclOverriddenLeafConstruct(), new OverriddenLeaf()]) {
+      // §10.2.2 step 12: Overriding's `a` went on the receiver it was called
+      // with, which the returned object replaced.
+      expect(Object.keys(leaf)).toEqual(["tag", "b", "c"]);
+      expect(leaf.tag).toBe("id-override");
+      expect(leaf.b).toBe("id-b");
+      expect(leaf.c).toBe("id-c");
+    }
+  });
+
+  test("an implicit layer below an explicit derived one initializes each layer once", () => {
+    for (const construct of [
+      fnDeclImplicitLeafConstruct,
+      () => new ImplicitLeaf(),
+    ]) {
+      const ticksBefore = implicitTickCount();
+      const leaf = construct();
+
+      expect(Object.keys(leaf)).toEqual(["x", "b", "c", "C", "d"]);
+      expect(implicitTickCount() - ticksBefore).toBe(3);
+      expect(leaf.c - leaf.b).toBe(1);
+      expect(leaf.d - leaf.c).toBe(1);
+    }
+  });
+
+  test("entry file: an all-implicit chain over a returning base still overrides", () => {
+    expect(Object.keys(new OverriddenMiddle())).toEqual(["tag", "b"]);
   });
 });

--- a/scripts/differential/l-modulefndecl.test.js
+++ b/scripts/differential/l-modulefndecl.test.js
@@ -9,7 +9,9 @@
 import {
   Counted,
   Factory,
+  Labelled,
   Point,
+  StampedLabel,
   Tagged,
   arrowClosureRead,
   arrowConstruct,
@@ -175,17 +177,18 @@ describe("construction from module function declarations", () => {
     for (const instance of [first, second]) {
       expect(instance instanceof Counted).toBe(true);
       expect(instance instanceof Point).toBe(true);
-      // Sorted: the three runtimes disagree on own-property *order* for a
-      // derived class's field initializers, which is a separate question from
-      // whether each field is initialized exactly once.
-      expect(Object.keys(instance).sort()).toEqual([
+      // Exact insertion order: each class's fields are initialized when its own
+      // super() returns (ES2026 §13.3.7.1 step 11), so Point's `label` comes
+      // first, then Point's constructor writes, then Counted's `seq`, then
+      // Counted's body, then Local's `stamp`, then Local's body.
+      expect(Object.keys(instance)).toEqual([
         "label",
-        "local",
-        "owner",
-        "seq",
-        "stamp",
         "x",
         "y",
+        "seq",
+        "owner",
+        "stamp",
+        "local",
       ]);
       expect(instance.label).toBe("point");
       expect(instance.x).toBe(20);
@@ -200,5 +203,33 @@ describe("construction from module function declarations", () => {
 
     expect(second.seq - first.seq).toBe(1);
     expect(derivedTickCount() - ticksBefore).toBe(2);
+  });
+
+  // The entry file has no PREFIX binding. A field initializer resolved against
+  // the scope that ran `new` would throw a ReferenceError here instead.
+  test("entry file: a module class's field initializers read module bindings", () => {
+    const labelled = new Labelled(7);
+    expect(Object.keys(labelled)).toEqual(["label", "n"]);
+    expect(labelled.label).toBe("id-labelled");
+    expect(labelled.n).toBe(7);
+  });
+
+  test("entry file: a derived module class keeps module scope and field order", () => {
+    const stamped = new StampedLabel(9);
+    expect(stamped instanceof Labelled).toBe(true);
+    expect(Object.keys(stamped)).toEqual(["label", "n", "stamp", "tail"]);
+    expect(stamped.label).toBe("id-labelled");
+    expect(stamped.stamp).toBe("id-stamp");
+    expect(stamped.tail).toBe("id-tail");
+    expect(stamped.secret()).toBe("id-secret");
+  });
+
+  test("entry file: constructing a derived module class initializes it once", () => {
+    const ticksBefore = derivedTickCount();
+    const counted = new Counted(30);
+
+    expect(Object.keys(counted)).toEqual(["label", "x", "y", "seq", "owner"]);
+    expect(counted.brand()).toBe("id-counted");
+    expect(derivedTickCount() - ticksBefore).toBe(1);
   });
 });

--- a/scripts/differential/mods/fndecl.js
+++ b/scripts/differential/mods/fndecl.js
@@ -28,6 +28,34 @@ export class Tagged extends Point {
   }
 }
 
+// ES2026 §15.7.10 ClassFieldDefinitionEvaluation step 2b: a field initializer
+// closes over the class's own definition environment. These two read PREFIX
+// from a *field* initializer rather than a constructor body, so constructing
+// them from the entry file — which has no PREFIX — is what shows the
+// initializer did not resolve against the scope that ran `new`.
+export class Labelled {
+  label = PREFIX + "labelled";
+
+  constructor(n) {
+    this.n = n;
+  }
+}
+
+export class StampedLabel extends Labelled {
+  stamp = PREFIX + "stamp";
+
+  #secret = PREFIX + "secret";
+
+  constructor(n) {
+    super(n);
+    this.tail = PREFIX + "tail";
+  }
+
+  secret() {
+    return this.#secret;
+  }
+}
+
 // A *derived* module class — it calls super(), and it owns both an instance
 // field with an observable side effect and a private field. Extending this one
 // rather than the base Point is what exercises the ordering rule that a derived

--- a/scripts/differential/mods/fndecl.js
+++ b/scripts/differential/mods/fndecl.js
@@ -82,6 +82,63 @@ export class Counted extends Point {
   }
 }
 
+// Implicit-constructor layers. A class with no constructor of its own takes the
+// implicit-default-constructor path (§15.7.14 step 15a), which is separate
+// machinery from an explicit super() — and in a module it is reached through
+// the linking-time function-declaration path as well.
+export class Overriding {
+  a = PREFIX + "a";
+
+  constructor() {
+    return { tag: PREFIX + "override" };
+  }
+}
+
+export class OverriddenMiddle extends Overriding {
+  b = PREFIX + "b";
+}
+
+export class OverriddenLeaf extends OverriddenMiddle {
+  c = PREFIX + "c";
+}
+
+let implicitTicks = 0;
+
+export function implicitTickCount() {
+  return implicitTicks;
+}
+
+export class ImplicitBase {
+  constructor() {
+    this.x = 1;
+  }
+}
+
+export class ImplicitMiddle extends ImplicitBase {
+  b = ++implicitTicks;
+}
+
+export class ExplicitOverMiddle extends ImplicitMiddle {
+  c = ++implicitTicks;
+
+  constructor() {
+    super();
+    this.C = 1;
+  }
+}
+
+export class ImplicitLeaf extends ExplicitOverMiddle {
+  d = ++implicitTicks;
+}
+
+export function fnDeclImplicitLeafConstruct() {
+  return new ImplicitLeaf();
+}
+
+export function fnDeclOverriddenLeafConstruct() {
+  return new OverriddenLeaf();
+}
+
 export function fnDeclConstruct() {
   return new Point(1, 2);
 }

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -24,12 +24,6 @@ uses
 
 type
   PGocciaValue = ^TGocciaValue;
-  TGocciaInstanceInitializationMode = (
-    iimFirstPass,
-    iimEagerReplacement,
-    iimReplay
-  );
-
 function Evaluate(const ANode: TGocciaASTNode; const AContext: TGocciaEvaluationContext): TGocciaControlFlow;
 function EvaluateExpression(const AExpression: TGocciaExpression; const AContext: TGocciaEvaluationContext): TGocciaValue;
 function EvaluateStatement(const AStatement: TGocciaStatement; const AContext: TGocciaEvaluationContext): TGocciaControlFlow;
@@ -109,7 +103,7 @@ procedure StampRawPrivateInstanceBrand(const AReceiver: TGocciaObjectValue;
   const AAccessClass: TGocciaClassValue);
 
 procedure InitializeInstanceProperties(const AInstance: TGocciaInstanceValue; const AClassValue: TGocciaClassValue; const AContext: TGocciaEvaluationContext);
-procedure InitializePrivateInstanceProperties(const AInstance: TGocciaObjectValue; const AClassValue: TGocciaClassValue; const AContext: TGocciaEvaluationContext; const AInitializationMode: TGocciaInstanceInitializationMode = iimFirstPass);
+procedure InitializePrivateInstanceProperties(const AInstance: TGocciaObjectValue; const AClassValue: TGocciaClassValue; const AContext: TGocciaEvaluationContext);
 function InstantiateClass(const AClassValue: TGocciaClassValue; const AArguments: TGocciaArgumentsCollection; const AContext: TGocciaEvaluationContext; const ANewTarget: TGocciaValue = nil): TGocciaValue;
 procedure ValidateClassConstructorReturn(const AClassValue: TGocciaClassValue; const AValue: TGocciaValue);
 
@@ -253,8 +247,7 @@ uses
 
 procedure RunClassInstanceInitializers(const AClassValue: TGocciaClassValue;
   const AInstance: TGocciaObjectValue;
-  const AContext: TGocciaEvaluationContext;
-  const AInitializationMode: TGocciaInstanceInitializationMode); forward;
+  const AContext: TGocciaEvaluationContext); forward;
 function DisposeTrackedResources(const ATracker: TGocciaDisposalTracker;
   const AExistingError: TGocciaValue): TGocciaValue; forward;
 function DisposeTrackedResourcesAsync(const ATracker: TGocciaDisposalTracker;
@@ -3691,9 +3684,7 @@ end;
 function ClassRequiresObjectConstructorReturn(
   const AClassValue: TGocciaClassValue): Boolean;
 begin
-  Result := Assigned(AClassValue) and
-    (Assigned(AClassValue.SuperClass) or
-     Assigned(AClassValue.NativeSuperConstructor));
+  Result := Assigned(AClassValue) and AClassValue.HasDerivedConstructorKind;
 end;
 
 procedure ValidateClassConstructorReturn(
@@ -3705,6 +3696,24 @@ begin
     ThrowTypeError(
       'Derived constructor returned non-object',
       SSuggestNotConstructorType);
+end;
+
+{ ES2026 §10.2.2 [[Construct]] step 5b: a ~base~ constructor initializes its
+  instance elements between binding `this` and evaluating its body. A ~derived~
+  constructor does not — §13.3.7.1 SuperCall step 11 initializes them when its
+  own super() returns. So invoking a superclass constructor body directly must
+  pre-initialize only when that superclass is a base class; doing it
+  unconditionally is what put a subclass's fields ahead of its base's
+  constructor assignments. }
+procedure RunBaseSuperclassInitializers(const AClassValue: TGocciaClassValue;
+  const AReceiver: TGocciaValue; const AContext: TGocciaEvaluationContext);
+begin
+  if ClassRequiresObjectConstructorReturn(AClassValue) then
+    Exit;
+  if not (AReceiver is TGocciaObjectValue) then
+    Exit;
+  RunClassInstanceInitializers(AClassValue, TGocciaObjectValue(AReceiver),
+    AContext);
 end;
 
 function InvokeConstructableWithReceiver(const AConstructor: TGocciaValue;
@@ -3762,11 +3771,11 @@ var
       ValidateClassConstructorReturn(ClassConstructor, Result);
       if Result is TGocciaObjectValue then
         RunClassInstanceInitializers(ClassConstructor,
-          TGocciaObjectValue(Result), AContext, iimFirstPass)
+          TGocciaObjectValue(Result), AContext)
       else if AReceiver is TGocciaObjectValue then
       begin
         RunClassInstanceInitializers(ClassConstructor,
-          TGocciaObjectValue(AReceiver), AContext, iimFirstPass);
+          TGocciaObjectValue(AReceiver), AContext);
         Result := AReceiver;
       end;
     finally
@@ -3823,20 +3832,19 @@ begin
       ValidateClassConstructorReturn(ClassConstructor, SuperResult)
     else if Assigned(ClassConstructor.ConstructorMethod) then
     begin
-      if AReceiver is TGocciaObjectValue then
-        RunClassInstanceInitializers(ClassConstructor,
-          TGocciaObjectValue(AReceiver), AContext, iimFirstPass);
+      RunBaseSuperclassInitializers(ClassConstructor, AReceiver, AContext);
       SuperResult := ClassConstructor.ConstructorMethod.CallWithThisValue(
         AArguments, AReceiver, ConstructorThisValue, EffectiveNewTarget);
       ValidateClassConstructorReturn(ClassConstructor, SuperResult);
       if not (SuperResult is TGocciaObjectValue) and
          (ConstructorThisValue is TGocciaObjectValue) then
         SuperResult := ConstructorThisValue;
+      { A derived constructor whose super() replaced `this` already ran its own
+        initializers against the replacement, inside that super() call. }
       if (SuperResult is TGocciaObjectValue) and
          (SuperResult <> AReceiver) and
          (SuperResult = ConstructorThisValue) then
-        RunClassInstanceInitializers(ClassConstructor,
-          TGocciaObjectValue(SuperResult), AContext, iimFirstPass);
+        RunBaseSuperclassInitializers(ClassConstructor, SuperResult, AContext);
     end
     else
       SuperResult := InvokeImplicitClassConstructor;
@@ -4101,17 +4109,22 @@ var
       Sequence.Expressions[0]);
     Result := True;
   end;
-  procedure InitializeReplacementThis(const AReplacement: TGocciaObjectValue;
-    const APreviousThis: TGocciaValue);
+  { ES2026 §13.3.7.1 SuperCall steps 7-11: once the super construction has
+    produced the receiver and it has been bound as `this`, the constructor's
+    own class initializes its instance elements against it. This is the point
+    at which a derived class's fields land — after everything the base
+    constructor assigned, and before the rest of the derived body. }
+  procedure InitializeOwnInstanceElementsAfterSuper(
+    const AFinalThis: TGocciaValue);
   begin
-    if (not Assigned(AReplacement)) or (AReplacement = APreviousThis) then
+    if not (AFinalThis is TGocciaObjectValue) then
       Exit;
     CurrentCtorClassValue := AContext.Scope.FindOwningClass;
     if not (CurrentCtorClassValue is TGocciaClassValue) then
       Exit;
     CurrentCtorClass := TGocciaClassValue(CurrentCtorClassValue);
-    RunClassInstanceInitializers(CurrentCtorClass, AReplacement, AContext,
-      iimEagerReplacement);
+    RunClassInstanceInitializers(CurrentCtorClass,
+      TGocciaObjectValue(AFinalThis), AContext);
   end;
   procedure MarkSuperConstructorCalled;
   var
@@ -4182,8 +4195,6 @@ begin
       begin
         if SuperResult is TGocciaObjectValue then
         begin
-          InitializeReplacementThis(TGocciaObjectValue(SuperResult),
-            AContext.Scope.ThisValue);
           AContext.Scope.ThisValue := TGocciaObjectValue(SuperResult);
           ThisScope := AContext.Scope.FindFunctionOrModuleScope;
           if Assigned(ThisScope) then
@@ -4193,13 +4204,13 @@ begin
       end
       else if Assigned(SuperClass) and Assigned(SuperClass.ConstructorMethod) then
       begin
+        RunBaseSuperclassInitializers(SuperClass, AContext.Scope.ThisValue,
+          AContext);
         SuperResult := SuperClass.ConstructorMethod.CallWithThisValue(
           Arguments, AContext.Scope.ThisValue, ConstructorThisValue,
           AContext.Scope.FindNewTarget);
         if SuperResult is TGocciaObjectValue then
         begin
-          InitializeReplacementThis(TGocciaObjectValue(SuperResult),
-            AContext.Scope.ThisValue);
           AContext.Scope.ThisValue := TGocciaObjectValue(SuperResult);
           ThisScope := AContext.Scope.FindFunctionOrModuleScope;
           if Assigned(ThisScope) then
@@ -4215,8 +4226,6 @@ begin
             SSuggestNotConstructorType)
         else if ConstructorThisValue is TGocciaObjectValue then
         begin
-          InitializeReplacementThis(TGocciaObjectValue(ConstructorThisValue),
-            AContext.Scope.ThisValue);
           AContext.Scope.ThisValue := TGocciaObjectValue(ConstructorThisValue);
           ThisScope := AContext.Scope.FindFunctionOrModuleScope;
           if Assigned(ThisScope) then
@@ -4228,8 +4237,34 @@ begin
       end
       else if Assigned(SuperClass) then
       begin
-        if AContext.Scope.ThisValue is TGocciaInstanceValue then
-          TGocciaInstanceValue(AContext.Scope.ThisValue).InitializeNativeFromArguments(Arguments);
+        if (SuperClass.NativeInstanceDefaultPrototype = nil) and
+           (Assigned(SuperClass.SuperClass) or
+            Assigned(SuperClass.NativeSuperConstructor)) then
+        begin
+          // The superclass declares no constructor, so its implicit default
+          // constructor (§15.7.14 step 15a) still has to forward to the rest
+          // of the chain and then initialize its own instance elements.
+          // Skipping that dropped every ancestor constructor sitting below an
+          // intermediate class with no constructor of its own.
+          SuperResult := InvokeConstructableWithReceiver(SuperClass, Arguments,
+            AContext.Scope.ThisValue, AContext, AContext.Scope.FindNewTarget);
+          if (SuperResult is TGocciaObjectValue) and
+             (SuperResult <> AContext.Scope.ThisValue) then
+          begin
+            AContext.Scope.ThisValue := TGocciaObjectValue(SuperResult);
+            ThisScope := AContext.Scope.FindFunctionOrModuleScope;
+            if Assigned(ThisScope) then
+              ThisScope.ThisValue := AContext.Scope.ThisValue;
+          end;
+        end
+        else
+        begin
+          if AContext.Scope.ThisValue is TGocciaInstanceValue then
+            TGocciaInstanceValue(AContext.Scope.ThisValue).InitializeNativeFromArguments(Arguments);
+          if AContext.Scope.ThisValue is TGocciaObjectValue then
+            RunClassInstanceInitializers(SuperClass,
+              TGocciaObjectValue(AContext.Scope.ThisValue), AContext);
+        end;
         Result := AContext.Scope.ThisValue;
       end
       else if SuperClassValue is TGocciaObjectValue then
@@ -4239,8 +4274,6 @@ begin
           AContext.Scope.FindNewTarget);
         if SuperResult is TGocciaObjectValue then
         begin
-          InitializeReplacementThis(TGocciaObjectValue(SuperResult),
-            AContext.Scope.ThisValue);
           AContext.Scope.ThisValue := TGocciaObjectValue(SuperResult);
           ThisScope := AContext.Scope.FindFunctionOrModuleScope;
           if Assigned(ThisScope) then
@@ -4260,6 +4293,7 @@ begin
     end;
     MarkSuperConstructorCalled;
     AddValueRoot(Roots, Result);
+    InitializeOwnInstanceElementsAfterSuper(Result);
     CollectInterpreterMemoryPressure(Result);
     Roots.Clear;
     Exit;
@@ -7979,6 +8013,21 @@ begin
   Result := EnumValue;
 end;
 
+// ES2026 §15.7.10 ClassFieldDefinitionEvaluation step 2b: an instance field
+// initializer is a function whose [[Environment]] is the class environment
+// captured at ClassDefinitionEvaluation time, so its scope chain must hang off
+// that, never off the scope that happens to be running `new`. Classes built by
+// paths that do not record a definition scope (native classes, bytecode class
+// values reaching the tree-walk evaluator) fall back to the caller's scope.
+function ClassInitializerScopeParent(const AClassValue: TGocciaClassValue;
+  const AFallbackScope: TGocciaScope): TGocciaScope;
+begin
+  if Assigned(AClassValue) and Assigned(AClassValue.DefinitionScope) then
+    Result := AClassValue.DefinitionScope
+  else
+    Result := AFallbackScope;
+end;
+
 procedure InitializeInstanceProperties(const AInstance: TGocciaInstanceValue; const AClassValue: TGocciaClassValue; const AContext: TGocciaEvaluationContext);
 var
   PropertyValue: TGocciaValue;
@@ -7990,12 +8039,15 @@ var
   LocalScope: TGocciaScope;
 begin
   LocalContext := AContext;
-  LocalScope := TGocciaClassInitScope.Create(AContext.Scope, AClassValue);
+  LocalScope := TGocciaClassInitScope.Create(
+    ClassInitializerScopeParent(AClassValue, AContext.Scope), AClassValue);
   LocalScope.ThisValue := AInstance;
   LocalContext.Scope := LocalScope;
 
-  if Assigned(AClassValue.SuperClass) then
-    InitializeInstanceProperties(AInstance, AClassValue.SuperClass, LocalContext);
+  { ES2026 §7.3.33 InitializeInstanceElements only ever defines the fields of
+    the one class it is handed. A superclass initializes its own fields inside
+    its own [[Construct]] — §10.2.2 step 5b for a base class, §13.3.7.1
+    SuperCall step 11 for a derived one — so this must not walk the chain. }
 
   if AClassValue.HasPrivateInstanceElements then
     StampRawPrivateInstanceBrand(AInstance, AClassValue);
@@ -8057,10 +8109,9 @@ end;
 
 procedure InitializeRawPrivateInstanceProperty(
   const AReceiver: TGocciaObjectValue; const APrivateName: string;
-  const AValue: TGocciaValue; const AAccessClass: TGocciaClassValue;
-  const AInitializationMode: TGocciaInstanceInitializationMode); forward;
+  const AValue: TGocciaValue; const AAccessClass: TGocciaClassValue); forward;
 
-procedure InitializeObjectInstanceProperties(const AInstance: TGocciaObjectValue; const AClassValue: TGocciaClassValue; const AContext: TGocciaEvaluationContext; const AInitializationMode: TGocciaInstanceInitializationMode);
+procedure InitializeObjectInstanceProperties(const AInstance: TGocciaObjectValue; const AClassValue: TGocciaClassValue; const AContext: TGocciaEvaluationContext);
 var
   PropertyValue: TGocciaValue;
   Entry: TGocciaExpressionMap.TKeyValuePair;
@@ -8070,16 +8121,11 @@ var
   SuperInitContext: TGocciaEvaluationContext;
   SuperInitScope: TGocciaScope;
 begin
-  if (AInitializationMode <> iimEagerReplacement) and
-     Assigned(AClassValue.SuperClass) then
-  begin
-    SuperInitContext := AContext;
-    SuperInitScope := TGocciaClassInitScope.Create(AContext.Scope, AClassValue.SuperClass);
-    SuperInitScope.ThisValue := AInstance;
-    SuperInitContext.Scope := SuperInitScope;
-    InitializeObjectInstanceProperties(AInstance, AClassValue.SuperClass,
-      SuperInitContext, AInitializationMode);
-  end;
+  { §7.3.33 InitializeInstanceElements defines this class's fields only — each
+    superclass initializes its own inside its own [[Construct]]. Walking the
+    chain here re-ran an ancestor's private field initializers on a receiver
+    that already had them, which is a "Cannot initialize private elements
+    twice" TypeError. }
 
   if AClassValue.HasPrivateInstanceElements then
     StampRawPrivateInstanceBrand(AInstance, AClassValue);
@@ -8116,7 +8162,7 @@ begin
           else
             PropertyValue := TGocciaUndefinedLiteralValue.UndefinedValue;
           InitializeRawPrivateInstanceProperty(AInstance, FOEntry.Name,
-            PropertyValue, AClassValue, AInitializationMode);
+            PropertyValue, AClassValue);
         end;
       end
       else
@@ -8136,8 +8182,7 @@ begin
       PropertyValue := EvaluateExpression(Entry.Value, AContext);
       AInstance.AssignProperty(Entry.Key, PropertyValue);
     end;
-    InitializePrivateInstanceProperties(AInstance, AClassValue, AContext,
-      AInitializationMode);
+    InitializePrivateInstanceProperties(AInstance, AClassValue, AContext);
   end;
 end;
 
@@ -9378,6 +9423,14 @@ begin
   ClassRoots.Initialize;
   try
   ClassValue := TGocciaClassValue.Create(ClassName, SuperClass);
+  { ES2026 §15.7.14 ClassDefinitionEvaluation steps 14-15 run the class
+    elements with the LexicalEnvironment set to _classEnv_, and §15.7.10
+    ClassFieldDefinitionEvaluation step 2b captures that environment as the
+    initializer function's [[Environment]]. AContext.Scope is that
+    environment here (EvaluateClass/EvaluateClassExpression create it for a
+    named class), so remember it: the initializers must see it later, no
+    matter which scope calls `new`. }
+  ClassValue.DefinitionScope := AContext.Scope;
   ClassRoots.Add(ClassValue);
   if not AContext.HideFunctionSourceText then
     ClassValue.SetSourceText(AClassDef.SourceText);
@@ -10253,11 +10306,6 @@ begin
   Result := '#slot:' + AAccessClass.PrivateBrandToken + ':' + APrivateName;
 end;
 
-function RawPrivateInitializedKey(const AAccessClass: TGocciaClassValue): string;
-begin
-  Result := '#initialized:' + AAccessClass.PrivateBrandToken;
-end;
-
 function TryGetRawObjectPrivateDescriptor(const AReceiver: TGocciaObjectValue;
   const AKey: string; out ADescriptor: TGocciaPropertyDescriptor): Boolean;
 begin
@@ -10282,35 +10330,6 @@ begin
     ExistingDescriptor.Free;
   AReceiver.Properties.Add(AKey,
     TGocciaPropertyDescriptorData.Create(AValue, AFlags));
-end;
-
-function HasRawPrivateInstanceInitializersApplied(
-  const AReceiver: TGocciaObjectValue;
-  const AAccessClass: TGocciaClassValue): Boolean;
-var
-  Descriptor: TGocciaPropertyDescriptor;
-begin
-  Result := False;
-  if not Assigned(AAccessClass) then
-    Exit;
-  TryGetRawObjectPrivateDescriptor(AReceiver,
-    RawPrivateInitializedKey(AAccessClass), Descriptor);
-  Result := Descriptor is TGocciaPropertyDescriptorData;
-end;
-
-procedure StampRawPrivateInstanceInitializersApplied(
-  const AReceiver: TGocciaObjectValue;
-  const AAccessClass: TGocciaClassValue);
-begin
-  if not Assigned(AAccessClass) then
-    Exit;
-  if not AAccessClass.HasInstanceInitializerWork then
-    Exit;
-  if HasRawPrivateInstanceInitializersApplied(AReceiver, AAccessClass) then
-    Exit;
-  DefineRawObjectPrivateDataProperty(AReceiver,
-    RawPrivateInitializedKey(AAccessClass),
-    TGocciaBooleanLiteralValue.TrueValue, []);
 end;
 
 function HasRawPrivateInstanceBrand(const AReceiver: TGocciaObjectValue;
@@ -10393,8 +10412,7 @@ end;
 
 procedure InitializeRawPrivateInstanceProperty(
   const AReceiver: TGocciaObjectValue; const APrivateName: string;
-  const AValue: TGocciaValue; const AAccessClass: TGocciaClassValue;
-  const AInitializationMode: TGocciaInstanceInitializationMode);
+  const AValue: TGocciaValue; const AAccessClass: TGocciaClassValue);
 var
   PrivateSlotKey: string;
   Descriptor: TGocciaPropertyDescriptor;
@@ -10405,21 +10423,10 @@ begin
   PrivateSlotKey := RawPrivateInstanceKey(AAccessClass, APrivateName);
   if TryGetRawObjectPrivateDescriptor(AReceiver, PrivateSlotKey,
      Descriptor) then
-  begin
-    if AInitializationMode = iimReplay then
-      Exit;
-    if (AInitializationMode = iimEagerReplacement) and
-       not HasRawPrivateInstanceInitializersApplied(AReceiver,
-         AAccessClass) then
-    begin
-      if not AReceiver.Extensible then
-        ThrowTypeError('Cannot add private elements to a non-extensible object',
-          SSuggestObjectNotExtensible);
-    end
-    else
-      ThrowTypeError('Cannot initialize private elements twice',
-        SSuggestPrivateFieldAccess);
-  end;
+    // ES2026 §7.3.28 PrivateFieldAdd step 2: a private field may only be
+    // added once per receiver.
+    ThrowTypeError('Cannot initialize private elements twice',
+      SSuggestPrivateFieldAccess);
   DefineRawObjectPrivateDataProperty(AReceiver, PrivateSlotKey, AValue,
     [pfWritable, pfConfigurable]);
 end;
@@ -11079,7 +11086,7 @@ begin
   end;
 end;
 
-procedure InitializePrivateInstanceProperties(const AInstance: TGocciaObjectValue; const AClassValue: TGocciaClassValue; const AContext: TGocciaEvaluationContext; const AInitializationMode: TGocciaInstanceInitializationMode);
+procedure InitializePrivateInstanceProperties(const AInstance: TGocciaObjectValue; const AClassValue: TGocciaClassValue; const AContext: TGocciaEvaluationContext);
 var
   PropertyValue: TGocciaValue;
   Entry: TGocciaExpressionMap.TKeyValuePair;
@@ -11095,32 +11102,29 @@ begin
         Entry.Key, PropertyValue, AClassValue, True)
     else
       InitializeRawPrivateInstanceProperty(
-        AInstance, Entry.Key, PropertyValue, AClassValue,
-        AInitializationMode);
+        AInstance, Entry.Key, PropertyValue, AClassValue);
   end;
 end;
 
 procedure RunClassInstanceInitializers(const AClassValue: TGocciaClassValue;
   const AInstance: TGocciaObjectValue;
-  const AContext: TGocciaEvaluationContext;
-  const AInitializationMode: TGocciaInstanceInitializationMode);
+  const AContext: TGocciaEvaluationContext);
 var
-  InitContext, SuperInitContext: TGocciaEvaluationContext;
-  InitScope, SuperInitScope: TGocciaScope;
-  WalkClass: TGocciaClassValue;
+  InitContext: TGocciaEvaluationContext;
+  InitScope: TGocciaScope;
   Roots: TGocciaActiveRootFrame;
 begin
   InitContext := AContext;
-  InitScope := TGocciaClassInitScope.Create(AContext.Scope, AClassValue);
+  InitScope := TGocciaClassInitScope.Create(
+    ClassInitializerScopeParent(AClassValue, AContext.Scope), AClassValue);
   InitScope.ThisValue := AInstance;
   InitContext.Scope := InitScope;
 
-  { Field initializers are arbitrary guest code and they run against these
-    scopes, which bind `this` to the instance and are pointed at by nothing —
-    the same hazard ExecuteStaticBlock has. The instance and class join them:
+  { Field initializers are arbitrary guest code and they run against this
+    scope, which binds `this` to the instance and is pointed at by nothing —
+    the same hazard ExecuteStaticBlock has. The instance and class join it:
     the instance is still inside construction, so a `new` whose field
-    initializer collects has nothing else holding it. One frame covers the
-    per-superclass scopes too; the walk is bounded by the inheritance depth. }
+    initializer collects has nothing else holding it. }
   Roots.Initialize;
   try
   Roots.Add(InitScope);
@@ -11131,38 +11135,18 @@ begin
   begin
     InitializeInstanceProperties(TGocciaInstanceValue(AInstance), AClassValue, InitContext);
 
+    { A class whose fields never made it into the field-order table still has
+      its private fields to initialize; the superclasses do their own. }
     if AClassValue.FieldOrderCount = 0 then
-    begin
-      WalkClass := AClassValue.SuperClass;
-      while Assigned(WalkClass) do
-      begin
-        CheckExecutionTimeout;
-        IncrementInstructionCounter;
-        CheckInstructionLimit;
-        SuperInitContext := AContext;
-        SuperInitScope := TGocciaClassInitScope.Create(AContext.Scope, WalkClass);
-        SuperInitScope.ThisValue := AInstance;
-        SuperInitContext.Scope := SuperInitScope;
-        Roots.Add(SuperInitScope);
-        if WalkClass.FieldOrderCount = 0 then
-          InitializePrivateInstanceProperties(
-            AInstance, WalkClass, SuperInitContext, AInitializationMode);
-        WalkClass := WalkClass.SuperClass;
-      end;
-
-      InitializePrivateInstanceProperties(AInstance, AClassValue, InitContext,
-        AInitializationMode);
-    end;
+      InitializePrivateInstanceProperties(AInstance, AClassValue,
+        InitContext);
   end
   else
-    InitializeObjectInstanceProperties(AInstance, AClassValue, InitContext,
-      AInitializationMode);
+    InitializeObjectInstanceProperties(AInstance, AClassValue, InitContext);
 
   AClassValue.RunMethodInitializers(AInstance);
   AClassValue.RunFieldInitializers(AInstance);
   AClassValue.RunDecoratorFieldInitializers(AInstance);
-  if AInitializationMode = iimEagerReplacement then
-    StampRawPrivateInstanceInitializersApplied(AInstance, AClassValue);
   finally
     Roots.Clear;
   end;
@@ -11182,7 +11166,6 @@ var
   ConstructorThisValue: TGocciaValue;
   EffectiveNewTarget: TGocciaValue;
   InstancePrototype: TGocciaObjectValue;
-  InitializerReplayReceiver: TGocciaObjectValue;
   function ConstructNativeSuperInstance(
     const AConstructor: TGocciaObjectValue): TGocciaObjectValue;
   var
@@ -11248,18 +11231,13 @@ var
     begin
       ThisObject := TGocciaObjectValue(AConstructorThisValue);
       SetFinalInstance(ThisObject);
-      InitializerReplayReceiver := ThisObject;
     end;
 
     if AValue is TGocciaObjectValue then
     begin
       ReturnObject := TGocciaObjectValue(AValue);
       if ReturnObject <> Instance then
-      begin
         SetFinalInstance(ReturnObject);
-        if ReturnObject <> InitializerReplayReceiver then
-          InitializerReplayReceiver := nil;
-      end;
     end
     else if HasDerivedConstructorReturnRestriction and
             not IsUndefinedConstructedValue(AValue) then
@@ -11274,14 +11252,11 @@ var
       if TGocciaObjectValue(AValue) = Instance then
         Exit;
       SetFinalInstance(TGocciaObjectValue(AValue));
-      InitializerReplayReceiver := Instance;
     end;
   end;
-  procedure RunInstanceInitializers(
-    const AInitializationMode: TGocciaInstanceInitializationMode);
+  procedure RunInstanceInitializers;
   begin
-    RunClassInstanceInitializers(AClassValue, Instance, AContext,
-      AInitializationMode);
+    RunClassInstanceInitializers(AClassValue, Instance, AContext);
   end;
 begin
   CheckExecutionTimeout;
@@ -11342,10 +11317,15 @@ begin
   end;
 
   RootedInstance := Instance;
-  InitializerReplayReceiver := nil;
   TGarbageCollector.Instance.AddTempRoot(RootedInstance);
   try
-    RunInstanceInitializers(iimFirstPass);
+    // ES2026 §10.2.2 [[Construct]] step 5b: only a ~base~ constructor
+    // initializes its instance elements before the constructor body runs. A
+    // ~derived~ one initializes them when its super() returns (§13.3.7.1
+    // SuperCall step 11), which is what puts a subclass's own fields after
+    // everything its base constructor assigned.
+    if not HasDerivedConstructorReturnRestriction then
+      RunInstanceInitializers;
 
     if Assigned(AClassValue.ConstructorMethod) then
     begin
@@ -11376,6 +11356,7 @@ begin
       else if Assigned(ImplicitSuperClass) and
          Assigned(ImplicitSuperClass.ConstructorMethod) then
       begin
+        RunBaseSuperclassInitializers(ImplicitSuperClass, Instance, AContext);
         ConstructedValue := ImplicitSuperClass.ConstructorMethod.CallWithThisValue(
           AArguments, Instance, ConstructorThisValue, EffectiveNewTarget);
         ValidateClassConstructorReturn(ImplicitSuperClass, ConstructedValue);
@@ -11401,13 +11382,26 @@ begin
       begin
         TGocciaInstanceValue(NativeInstance).InitializeNativeFromArguments(AArguments);
         TGocciaInstanceValue(NativeInstance).FinalizeNativeFromArguments(AArguments);
-      end;
+      end
+      else if Assigned(ImplicitSuperClass) then
+        // The superclass declares no constructor either, so its own implicit
+        // default constructor has to carry the chain further up before this
+        // class initializes its instance elements below.
+        ApplyReplacementResult(InvokeConstructableWithReceiver(
+          ImplicitSuperClass, AArguments, Instance, AContext,
+          EffectiveNewTarget));
+
+      // The implicit derived constructor (§15.7.14 step 15a) forwards to
+      // super and then initializes its instance elements — so they run once
+      // the super construction above has completed, against whatever receiver
+      // it left behind.
+      if HasDerivedConstructorReturnRestriction then
+        RunInstanceInitializers;
     end;
 
-    if Assigned(InitializerReplayReceiver) and
-       (Instance = InitializerReplayReceiver) and
-       not HasRawPrivateInstanceInitializersApplied(Instance, AClassValue) then
-      RunInstanceInitializers(iimReplay);
+    { No replay pass: the initializers now run once, on the receiver super()
+      settled on, so a constructor that replaces `this` never leaves them
+      applied to the wrong object for a later pass to redo. }
   finally
     TGarbageCollector.Instance.RemoveTempRoot(RootedInstance);
   end;

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -3839,12 +3839,8 @@ begin
       if not (SuperResult is TGocciaObjectValue) and
          (ConstructorThisValue is TGocciaObjectValue) then
         SuperResult := ConstructorThisValue;
-      { A derived constructor whose super() replaced `this` already ran its own
-        initializers against the replacement, inside that super() call. }
-      if (SuperResult is TGocciaObjectValue) and
-         (SuperResult <> AReceiver) and
-         (SuperResult = ConstructorThisValue) then
-        RunBaseSuperclassInitializers(ClassConstructor, SuperResult, AContext);
+      { No initializer pass on a replaced `this`: only a derived constructor
+        can have one, and its own super() already ran them there. }
     end
     else
       SuperResult := InvokeImplicitClassConstructor;
@@ -4293,9 +4289,16 @@ begin
     end;
     MarkSuperConstructorCalled;
     AddValueRoot(Roots, Result);
-    InitializeOwnInstanceElementsAfterSuper(Result);
-    CollectInterpreterMemoryPressure(Result);
-    Roots.Clear;
+    { The field initializers below are guest code and can throw, and the
+      pressure check can raise a RangeError, so the root frame has to be
+      released from a finally — TGocciaActiveRootFrame.Clear is a count
+      rollback that must run on the exception path too. }
+    try
+      InitializeOwnInstanceElementsAfterSuper(Result);
+      CollectInterpreterMemoryPressure(Result);
+    finally
+      Roots.Clear;
+    end;
     Exit;
   end;
 
@@ -8118,8 +8121,6 @@ var
   I: Integer;
   FOEntry: TGocciaClassFieldOrderEntry;
   Expr: TGocciaExpression;
-  SuperInitContext: TGocciaEvaluationContext;
-  SuperInitScope: TGocciaScope;
 begin
   { §7.3.33 InitializeInstanceElements defines this class's fields only — each
     superclass initializes its own inside its own [[Construct]]. Walking the

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -5728,7 +5728,11 @@ begin
     begin
       VMClassConstructor := TGocciaVMClassValue(ClassConstructor);
       VMClassConstructor.FVM.FPendingNewTarget := EffectiveNewTarget;
-      VMClassConstructor.FVM.RunClassInitializers(ClassConstructor, AReceiver);
+      // ES2026 §10.2.2 [[Construct]] step 5b: only a ~base~ constructor
+      // initializes its instance elements ahead of its body; a ~derived~ one
+      // does it when its own super() returns (§13.3.7.1 step 11).
+      if not ClassConstructor.HasDerivedConstructorKind then
+        VMClassConstructor.FVM.RunClassInitializers(ClassConstructor, AReceiver);
       SuperResult := VMClassConstructor.FVM.InvokeFunctionValue(
         VMClassConstructor.FConstructorValue, AArguments, AReceiver);
       ValidateClassConstructorReturn(ClassConstructor, SuperResult);
@@ -6896,7 +6900,11 @@ begin
           if (ImplicitSuperClass is TGocciaVMClassValue) and
                   Assigned(TGocciaVMClassValue(ImplicitSuperClass).FConstructorValue) then
           begin
-            FVM.RunClassInitializers(ImplicitSuperClass, Instance);
+            // ES2026 §10.2.2 [[Construct]] step 5b: only a ~base~ superclass
+            // initializes its instance elements ahead of its constructor body; a
+            // ~derived~ one does it when its own super() returns (§13.3.7.1 step 11).
+            if not ImplicitSuperClass.HasDerivedConstructorKind then
+              FVM.RunClassInitializers(ImplicitSuperClass, Instance);
             if Assigned(ANewTarget) then
               TGocciaVMClassValue(ImplicitSuperClass).FVM.FPendingNewTarget := ANewTarget
             else
@@ -6922,7 +6930,11 @@ begin
 
             if Assigned(ConstructorToCall) then
             begin
-              FVM.RunClassInitializers(ImplicitSuperClass, Instance);
+              // ES2026 §10.2.2 [[Construct]] step 5b: only a ~base~ superclass
+              // initializes its instance elements ahead of its constructor body; a
+              // ~derived~ one does it when its own super() returns (§13.3.7.1 step 11).
+              if not ImplicitSuperClass.HasDerivedConstructorKind then
+                FVM.RunClassInitializers(ImplicitSuperClass, Instance);
               if Assigned(ANewTarget) then
                 ConstructedValue := ConstructorToCall.CallWithThisValue(
                   AArguments, Instance, ConstructorThisValue, ANewTarget)
@@ -6969,11 +6981,16 @@ begin
         FVM.FCurrentConstructorSuperCalled := PreviousConstructorSuperCalled;
       end;
 
+      { This is the no-constructor branch, so the class runs the implicit
+        default constructor of §15.7.14 step 15a: forward to super, then
+        initialize its own instance elements. That second half is owed whether
+        the class is ~base~ or ~derived~ — skipping it for a derived class
+        dropped every field of a subclass that declares no constructor.
+        InstantiateRegisters, the path a bytecode `new` takes, has always run
+        it unconditionally here; this is the same step. }
       if not Assigned(InitializerReplayReceiver) or
          (Instance <> InitializerReplayReceiver) then
-        if (not HasDerivedConstructorReturnRestriction) or
-           Assigned(NativeInstance) then
-          FVM.RunClassInitializers(Self, Instance);
+        FVM.RunClassInitializers(Self, Instance);
 
       if Assigned(InitializerReplayReceiver) and
          (Instance = InitializerReplayReceiver) then
@@ -7300,8 +7317,12 @@ begin
             if (ImplicitSuperClass is TGocciaVMClassValue) and
                     Assigned(TGocciaVMClassValue(ImplicitSuperClass).FConstructorValue) then
             begin
-              TGocciaVMClassValue(ImplicitSuperClass).FVM.RunClassInitializers(
-                ImplicitSuperClass, Instance);
+              // ES2026 §10.2.2 [[Construct]] step 5b: only a ~base~ superclass
+              // initializes its instance elements ahead of its constructor body; a
+              // ~derived~ one does it when its own super() returns (§13.3.7.1 step 11).
+              if not ImplicitSuperClass.HasDerivedConstructorKind then
+                TGocciaVMClassValue(ImplicitSuperClass).FVM.RunClassInitializers(
+                  ImplicitSuperClass, Instance);
               TGocciaVMClassValue(ImplicitSuperClass).FVM.FPendingNewTarget := Self;
               if TGocciaVMClassValue(ImplicitSuperClass).FConstructorValue is TGocciaBytecodeFunctionValue then
               begin
@@ -7355,7 +7376,11 @@ begin
               if Assigned(ConstructorToCall) then
               begin
                 EnsureBoxedArgs;
-                FVM.RunClassInitializers(ImplicitSuperClass, Instance);
+                // ES2026 §10.2.2 [[Construct]] step 5b: only a ~base~ superclass
+                // initializes its instance elements ahead of its constructor body; a
+                // ~derived~ one does it when its own super() returns (§13.3.7.1 step 11).
+                if not ImplicitSuperClass.HasDerivedConstructorKind then
+                  FVM.RunClassInitializers(ImplicitSuperClass, Instance);
                 ConstructedValue := ConstructorToCall.CallWithThisValue(
                   BoxedArgs, Instance, ConstructorThisValue, Self);
                 ValidateClassConstructorReturn(ImplicitSuperClass, ConstructedValue);
@@ -10614,7 +10639,11 @@ begin
   if (AClassValue is TGocciaVMClassValue) and
      Assigned(TGocciaVMClassValue(AClassValue).FConstructorValue) then
   begin
-    RunClassInitializers(AClassValue, AInstance);
+    // ES2026 §10.2.2 [[Construct]] step 5b: only a ~base~ constructor
+    // initializes its instance elements ahead of its body; a ~derived~
+    // one does it when its own super() returns (§13.3.7.1 step 11).
+    if not AClassValue.HasDerivedConstructorKind then
+      RunClassInitializers(AClassValue, AInstance);
     SuperResult := TGocciaVMClassValue(AClassValue).FVM.InvokeFunctionValue(
       TGocciaVMClassValue(AClassValue).FConstructorValue,
       AArguments, AInstance);
@@ -10627,8 +10656,9 @@ begin
     SuperResult := SelectImplicitSuperResult(SuperResult, ConstructorThisValue);
     if SuperResult is TGocciaObjectValue then
     begin
-      if SuperResult <> AInstance then
-        RunClassInitializers(AClassValue, SuperResult);
+      // §10.2.2 step 12: an object the constructor returns replaces the
+      // receiver wholesale — it never receives that constructor's own
+      // instance elements, which went on the receiver it was called with.
       Exit(SuperResult);
     end;
     Exit;
@@ -10637,15 +10667,20 @@ begin
   if (AClassValue is TGocciaVMClassValue) and
      Assigned(TGocciaVMClassValue(AClassValue).NativeSuperConstructor) then
   begin
-    RunClassInitializers(AClassValue, AInstance);
+    // ES2026 §10.2.2 [[Construct]] step 5b: only a ~base~ constructor
+    // initializes its instance elements ahead of its body; a ~derived~
+    // one does it when its own super() returns (§13.3.7.1 step 11).
+    if not AClassValue.HasDerivedConstructorKind then
+      RunClassInitializers(AClassValue, AInstance);
     SuperResult := InvokeConstructableWithReceiver(
       TGocciaVMClassValue(AClassValue).NativeSuperConstructor,
       AArguments, AInstance);
     ValidateImplicitSuperResult(SuperResult);
     if SuperResult is TGocciaObjectValue then
     begin
-      if SuperResult <> AInstance then
-        RunClassInitializers(AClassValue, SuperResult);
+      // §10.2.2 step 12: an object the constructor returns replaces the
+      // receiver wholesale — it never receives that constructor's own
+      // instance elements, which went on the receiver it was called with.
       Exit(SuperResult);
     end;
     Exit;
@@ -10653,13 +10688,18 @@ begin
 
   if Assigned(AClassValue.ConstructorMethod) then
   begin
-    RunClassInitializers(AClassValue, AInstance);
+    // ES2026 §10.2.2 [[Construct]] step 5b: only a ~base~ constructor
+    // initializes its instance elements ahead of its body; a ~derived~
+    // one does it when its own super() returns (§13.3.7.1 step 11).
+    if not AClassValue.HasDerivedConstructorKind then
+      RunClassInitializers(AClassValue, AInstance);
     SuperResult := AClassValue.ConstructorMethod.Call(AArguments, AInstance);
     ValidateImplicitSuperResult(SuperResult);
     if SuperResult is TGocciaObjectValue then
     begin
-      if SuperResult <> AInstance then
-        RunClassInitializers(AClassValue, SuperResult);
+      // §10.2.2 step 12: an object the constructor returns replaces the
+      // receiver wholesale — it never receives that constructor's own
+      // instance elements, which went on the receiver it was called with.
       Exit(SuperResult);
     end;
     Exit;
@@ -10774,7 +10814,11 @@ begin
   if (AClassValue is TGocciaVMClassValue) and
      Assigned(TGocciaVMClassValue(AClassValue).FConstructorValue) then
   begin
-    RunClassInitializers(AClassValue, AInstance);
+    // ES2026 §10.2.2 [[Construct]] step 5b: only a ~base~ constructor
+    // initializes its instance elements ahead of its body; a ~derived~
+    // one does it when its own super() returns (§13.3.7.1 step 11).
+    if not AClassValue.HasDerivedConstructorKind then
+      RunClassInitializers(AClassValue, AInstance);
     if TGocciaVMClassValue(AClassValue).FConstructorValue is TGocciaBytecodeFunctionValue then
     begin
       BytecodeConstructor := TGocciaBytecodeFunctionValue(
@@ -10793,8 +10837,9 @@ begin
           ConstructorThisValue);
         if SuperResult is TGocciaObjectValue then
         begin
-          if SuperResult <> AInstance then
-            RunClassInitializers(AClassValue, SuperResult);
+          // §10.2.2 step 12: an object the constructor returns replaces the
+          // receiver wholesale — it never receives that constructor's own
+          // instance elements, which went on the receiver it was called with.
           Exit(SuperResult);
         end;
         Exit;
@@ -10818,8 +10863,9 @@ begin
     SuperResult := SelectImplicitSuperResult(SuperResult, ConstructorThisValue);
     if SuperResult is TGocciaObjectValue then
     begin
-      if SuperResult <> AInstance then
-        RunClassInitializers(AClassValue, SuperResult);
+      // §10.2.2 step 12: an object the constructor returns replaces the
+      // receiver wholesale — it never receives that constructor's own
+      // instance elements, which went on the receiver it was called with.
       Exit(SuperResult);
     end;
     Exit;
@@ -10830,7 +10876,11 @@ begin
   begin
     BoxedArgs := MaterializeArguments(AArguments);
     try
-      RunClassInitializers(AClassValue, AInstance);
+      // ES2026 §10.2.2 [[Construct]] step 5b: only a ~base~ constructor
+      // initializes its instance elements ahead of its body; a ~derived~
+      // one does it when its own super() returns (§13.3.7.1 step 11).
+      if not AClassValue.HasDerivedConstructorKind then
+        RunClassInitializers(AClassValue, AInstance);
       SuperResult := InvokeConstructableWithReceiver(
         TGocciaVMClassValue(AClassValue).NativeSuperConstructor,
         BoxedArgs, AInstance);
@@ -10840,8 +10890,9 @@ begin
     ValidateImplicitSuperResult(SuperResult);
     if SuperResult is TGocciaObjectValue then
     begin
-      if SuperResult <> AInstance then
-        RunClassInitializers(AClassValue, SuperResult);
+      // §10.2.2 step 12: an object the constructor returns replaces the
+      // receiver wholesale — it never receives that constructor's own
+      // instance elements, which went on the receiver it was called with.
       Exit(SuperResult);
     end;
     Exit;
@@ -10851,7 +10902,11 @@ begin
   begin
     BoxedArgs := MaterializeArguments(AArguments);
     try
-      RunClassInitializers(AClassValue, AInstance);
+      // ES2026 §10.2.2 [[Construct]] step 5b: only a ~base~ constructor
+      // initializes its instance elements ahead of its body; a ~derived~
+      // one does it when its own super() returns (§13.3.7.1 step 11).
+      if not AClassValue.HasDerivedConstructorKind then
+        RunClassInitializers(AClassValue, AInstance);
       SuperResult := AClassValue.ConstructorMethod.Call(BoxedArgs, AInstance);
     finally
       ReleaseArguments(BoxedArgs);
@@ -10859,8 +10914,9 @@ begin
     ValidateImplicitSuperResult(SuperResult);
     if SuperResult is TGocciaObjectValue then
     begin
-      if SuperResult <> AInstance then
-        RunClassInitializers(AClassValue, SuperResult);
+      // §10.2.2 step 12: an object the constructor returns replaces the
+      // receiver wholesale — it never receives that constructor's own
+      // instance elements, which went on the receiver it was called with.
       Exit(SuperResult);
     end;
     Exit;

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -6257,17 +6257,22 @@ begin
      Assigned(TGocciaVMClassValue(SuperClass).FConstructorValue) then
   begin
     TGocciaVMClassValue(SuperClass).FVM.FPendingNewTarget := FNewTarget;
-    TGocciaVMClassValue(SuperClass).FVM.RunClassInitializers(
-      SuperClass, AThisValue);
+    // ES2026 §10.2.2 [[Construct]] step 5b: only a ~base~ superclass
+    // initializes its instance elements ahead of its constructor body. A
+    // ~derived~ one does it when its own super() returns (§13.3.7.1 step 11,
+    // reached through InitializeCurrentCtorReceiver); running them here too
+    // put its fields before its base's constructor and evaluated them twice.
+    if not SuperClass.HasDerivedConstructorKind then
+      TGocciaVMClassValue(SuperClass).FVM.RunClassInitializers(
+        SuperClass, AThisValue);
     SuperResult := TGocciaVMClassValue(SuperClass).FVM.InvokeFunctionValue(
       TGocciaVMClassValue(SuperClass).FConstructorValue,
       AArguments, AThisValue);
     if SuperResult is TGocciaObjectValue then
       begin
-        if (SuperResult <> AThisValue) and
-           not HasBytecodePrivateInitializersApplied(SuperResult, SuperClass) then
-          TGocciaVMClassValue(SuperClass).FVM.RunClassInitializers(
-            SuperClass, SuperResult);
+        // §10.2.2 step 12: an object the super constructor *returns* replaces
+        // the receiver but never inherits that constructor's instance
+        // elements — those were installed on the receiver it was called with.
         MarkCurrentConstructorSuperCalled;
         InitializeCurrentCtorReceiver(SuperResult);
         Exit(SuperResult);
@@ -6297,18 +6302,17 @@ begin
 
   if Assigned(SuperClass.ConstructorMethod) then
   begin
-    if SuperClass is TGocciaVMClassValue then
+    // §10.2.2 step 5b again: pre-initialize only for a ~base~ superclass.
+    if (SuperClass is TGocciaVMClassValue) and
+       not SuperClass.HasDerivedConstructorKind then
       TGocciaVMClassValue(SuperClass).FVM.RunClassInitializers(
         SuperClass, AThisValue);
     SuperResult := SuperClass.ConstructorMethod.CallWithThisValue(
       AArguments, AThisValue, ConstructorThisValue, FNewTarget);
     if SuperResult is TGocciaObjectValue then
       begin
-        if (SuperResult <> AThisValue) and
-           (SuperClass is TGocciaVMClassValue) and
-           not HasBytecodePrivateInitializersApplied(SuperResult, SuperClass) then
-          TGocciaVMClassValue(SuperClass).FVM.RunClassInitializers(
-            SuperClass, SuperResult);
+        // §10.2.2 step 12 again: the returned object does not receive the
+        // returning constructor's own instance elements.
         MarkCurrentConstructorSuperCalled;
         InitializeCurrentCtorReceiver(SuperResult);
         Exit(SuperResult);

--- a/source/units/Goccia.Values.ClassValue.pas
+++ b/source/units/Goccia.Values.ClassValue.pas
@@ -15,6 +15,7 @@ uses
   Goccia.CapabilityAudit,
   Goccia.Constants,
   Goccia.Realm,
+  Goccia.Scope,
   Goccia.Values.FunctionBase,
   Goccia.Values.FunctionValue,
   Goccia.Values.ObjectPropertyDescriptor,
@@ -71,6 +72,12 @@ type
     FNameDeleted: Boolean;
     FLengthDeleted: Boolean;
     FSourceText: string;
+    // ES2026 §15.7.14 ClassDefinitionEvaluation steps 1-2 and §15.7.10
+    // ClassFieldDefinitionEvaluation step 2b: the class environment that was
+    // current when this class was evaluated. A field initializer is a function
+    // whose [[Environment]] is that environment, not the environment of
+    // whatever scope happens to run `new`.
+    FDefinitionScope: TGocciaScope;
     function GetPropertyGetter(const AName: string): TGocciaFunctionBase; {$IFDEF FPC}inline;{$ENDIF}
     function GetPropertySetter(const AName: string): TGocciaFunctionBase; {$IFDEF FPC}inline;{$ENDIF}
     function GetStaticPropertyGetter(const AName: string): TGocciaFunctionBase; {$IFDEF FPC}inline;{$ENDIF}
@@ -146,6 +153,12 @@ type
       const AReceiver: TGocciaValue; const ANewTarget: TGocciaValue;
       out AResult: TGocciaValue): Boolean; virtual;
     function EstimatedInstancePropertyCapacity: Integer;
+    // ES2026 §15.7.14 ClassDefinitionEvaluation step 19: [[ConstructorKind]]
+    // is ~derived~ exactly when the class has a ClassHeritage. It decides when
+    // instance elements are initialized: a ~base~ constructor does it before
+    // its body (§10.2.2 step 5b), a ~derived~ one when super() returns
+    // (§13.3.7.1 step 11).
+    function HasDerivedConstructorKind: Boolean;
     function HasInstanceInitializerWork: Boolean;
     // ECMAScript: number of expected constructor parameters before the first
     // default/rest. Built-in classes default to 0; user classes derive from
@@ -172,6 +185,8 @@ type
     function GetOwnStaticSymbolDescriptor(const ASymbol: TGocciaSymbolValue): TGocciaPropertyDescriptor;
 
     property Name: string read FName;
+    property DefinitionScope: TGocciaScope read FDefinitionScope
+      write FDefinitionScope;
     property SourceText: string read FSourceText write FSourceText;
     property CreationRealm: TGocciaRealm read FCreationRealm;
     property PrivateBrandToken: string read FPrivateBrandToken;
@@ -762,6 +777,7 @@ begin
   FConstructorMethod := nil;
   FNameDeleted := False;
   FLengthDeleted := False;
+  FDefinitionScope := nil;
   if Assigned(FSuperClass) then
     FClassPrototype.Prototype := FSuperClass.Prototype
   else if TGocciaObjectValue.SharedObjectPrototype <> nil then
@@ -801,6 +817,12 @@ begin
 
   if Assigned(FSuperClass) then
     FSuperClass.MarkReferences;
+
+  { The class environment outlives the class definition exactly the way a
+    function's closure outlives its declaration: field initializers are
+    closures over it, so it is reachable for as long as the class is. }
+  if Assigned(FDefinitionScope) then
+    FDefinitionScope.MarkReferences;
 
   if Assigned(FNativeSuperConstructor) then
     FNativeSuperConstructor.MarkReferences;
@@ -1606,6 +1628,11 @@ begin
         Inc(Result);
     WalkClass := WalkClass.SuperClass;
   end;
+end;
+
+function TGocciaClassValue.HasDerivedConstructorKind: Boolean;
+begin
+  Result := Assigned(FSuperClass) or Assigned(FNativeSuperConstructor);
 end;
 
 function TGocciaClassValue.HasInstanceInitializerWork: Boolean;

--- a/source/units/Goccia.Values.ClassValue.pas
+++ b/source/units/Goccia.Values.ClassValue.pas
@@ -153,11 +153,15 @@ type
       const AReceiver: TGocciaValue; const ANewTarget: TGocciaValue;
       out AResult: TGocciaValue): Boolean; virtual;
     function EstimatedInstancePropertyCapacity: Integer;
-    // ES2026 §15.7.14 ClassDefinitionEvaluation step 19: [[ConstructorKind]]
-    // is ~derived~ exactly when the class has a ClassHeritage. It decides when
-    // instance elements are initialized: a ~base~ constructor does it before
-    // its body (§10.2.2 step 5b), a ~derived~ one when super() returns
-    // (§13.3.7.1 step 11).
+    // Approximates ES2026 §15.7.14 ClassDefinitionEvaluation step 19's
+    // [[ConstructorKind]] = ~derived~, which decides when instance elements
+    // are initialized: a ~base~ constructor does it before its body (§10.2.2
+    // step 5b), a ~derived~ one when super() returns (§13.3.7.1 step 11).
+    // Reports True when a resolved superclass or a linked native super
+    // constructor is present. Known gap: `class A extends null {}` is
+    // ~derived~ per the spec but reports False here, because extends-null
+    // records no superclass. Tree-walk `extends null` is separately broken;
+    // do not lean on this predicate for it.
     function HasDerivedConstructorKind: Boolean;
     function HasInstanceInitializerWork: Boolean;
     // ECMAScript: number of expected constructor parameters before the first

--- a/tests/language/classes/class-inheritance.js
+++ b/tests/language/classes/class-inheritance.js
@@ -339,7 +339,11 @@ test("default constructor throws when a derived superclass constructor returns p
   expect(() => new Leaf()).toThrow(TypeError);
 });
 
-test("super() replacement receives superclass initializers", () => {
+// ES2026 §10.2.2 [[Construct]] steps 5b and 12: a base constructor installs
+// its instance elements on the object allocated for it, then a returned object
+// replaces the receiver wholesale. The replacement therefore never carries the
+// base class's fields.
+test("super() replacement does not receive the returning class's initializers", () => {
   let leafPrototype;
 
   class Base {
@@ -365,7 +369,8 @@ test("super() replacement receives superclass initializers", () => {
   leafPrototype = Leaf.prototype;
 
   const leaf = new Leaf();
-  expect(leaf.readBase()).toBe("base");
+  expect(leaf.readBase()).toBeUndefined();
+  expect(Object.keys(leaf)).toEqual([]);
 });
 
 test("super() replacement initializes constructor layers in order", () => {

--- a/tests/language/classes/field-initializer-timing.js
+++ b/tests/language/classes/field-initializer-timing.js
@@ -243,6 +243,121 @@ describe("base and derived field initializer timing", () => {
   });
 });
 
+// A class with no constructor of its own takes the implicit-default-constructor
+// path (§15.7.14 step 15a), which is separate machinery from an explicit
+// super(). These shapes put implicit layers above, below, and between explicit
+// ones so neither path can drift from the other.
+describe("implicit constructors between explicit ones", () => {
+  test("an override returned by a base constructor carries no fields from the layer that returned it", () => {
+    class A {
+      a = 1;
+
+      constructor() {
+        return { tag: "override" };
+      }
+    }
+
+    class B extends A {
+      b = 2;
+    }
+
+    class C extends B {
+      c = 3;
+    }
+
+    // §10.2.2 step 12: A's `a` went on the receiver A was called with, which
+    // the returned object replaced. B and C then initialize onto the override.
+    expect(Object.keys(new C())).toEqual(["tag", "b", "c"]);
+  });
+
+  test("an override returned under a single implicit layer behaves the same", () => {
+    class A {
+      a = 1;
+
+      constructor() {
+        return { tag: "override" };
+      }
+    }
+
+    class B extends A {
+      b = 2;
+    }
+
+    expect(Object.keys(new B())).toEqual(["tag", "b"]);
+  });
+
+  test("an implicit layer below an explicit derived one initializes each layer once", () => {
+    const order = [];
+
+    class A {
+      constructor() {
+        this.x = 1;
+      }
+    }
+
+    class B extends A {
+      b = (order.push("B"), 1);
+    }
+
+    class C extends B {
+      c = (order.push("C"), 1);
+
+      constructor() {
+        super();
+        this.C = 1;
+      }
+    }
+
+    class D extends C {
+      d = (order.push("D"), 1);
+    }
+
+    expect(Object.keys(new D())).toEqual(["x", "b", "c", "C", "d"]);
+    expect(order).toEqual(["B", "C", "D"]);
+  });
+
+  test("private fields survive an implicit layer below an explicit derived one", () => {
+    class A {
+      constructor() {
+        this.x = 1;
+      }
+    }
+
+    class B extends A {
+      #b = "b";
+
+      readB() {
+        return this.#b;
+      }
+    }
+
+    class C extends B {
+      #c = "c";
+
+      constructor() {
+        super();
+        this.C = 1;
+      }
+
+      readC() {
+        return this.#c;
+      }
+    }
+
+    class D extends C {
+      #d = "d";
+
+      readD() {
+        return this.#d;
+      }
+    }
+
+    const d = new D();
+    expect(Object.keys(d)).toEqual(["x", "C"]);
+    expect([d.readB(), d.readC(), d.readD()]).toEqual(["b", "c", "d"]);
+  });
+});
+
 describe("field initializers close over the class definition environment", () => {
   const makeLabelled = () => {
     const PREFIX = "id-";

--- a/tests/language/classes/field-initializer-timing.js
+++ b/tests/language/classes/field-initializer-timing.js
@@ -1,0 +1,350 @@
+/*---
+description: Instance field initializers run in the class's definition environment, at the point [[Construct]] reaches them
+features: [classes, private-fields]
+---*/
+
+// ES2026 §10.2.2 [[Construct]] step 5b initializes a *base* class's instance
+// elements after `this` is bound and before the constructor body runs, while
+// §13.3.7.1 SuperCall step 11 initializes a *derived* class's elements when its
+// own super() returns. §15.7.10 ClassFieldDefinitionEvaluation step 2b makes
+// every initializer a closure over the class's definition environment, not over
+// whichever scope happens to call `new`.
+
+describe("base and derived field initializer timing", () => {
+  test("a base class initializes its fields before its constructor body", () => {
+    class Base {
+      f = 1;
+
+      constructor() {
+        this.afterF = this.f + 1;
+      }
+    }
+
+    const base = new Base();
+    expect(Object.keys(base)).toEqual(["f", "afterF"]);
+    expect(base.afterF).toBe(2);
+  });
+
+  test("a derived class initializes its fields when super() returns", () => {
+    class Base {
+      constructor() {
+        this.x = 1;
+      }
+    }
+
+    class Derived extends Base {
+      f = 2;
+
+      constructor() {
+        super();
+        this.y = 3;
+      }
+    }
+
+    expect(Object.keys(new Derived())).toEqual(["x", "f", "y"]);
+  });
+
+  test("a derived field initializer sees what the base constructor assigned", () => {
+    class Base {
+      constructor() {
+        this.x = 10;
+      }
+    }
+
+    class Derived extends Base {
+      copied = this.x;
+    }
+
+    expect(new Derived().copied).toBe(10);
+  });
+
+  test("a base field initializer cannot see its own constructor's writes", () => {
+    class Base {
+      copied = this.x;
+
+      constructor() {
+        this.x = 11;
+      }
+    }
+
+    expect(new Base().copied).toBeUndefined();
+  });
+
+  test("each layer of a three-class chain contributes keys in construction order", () => {
+    class A {
+      constructor() {
+        this.x = 1;
+      }
+    }
+
+    class B extends A {
+      f = 2;
+
+      constructor() {
+        super();
+        this.y = 3;
+      }
+    }
+
+    class C extends B {
+      g = 4;
+
+      constructor() {
+        super();
+        this.z = 5;
+      }
+    }
+
+    expect(Object.keys(new C())).toEqual(["x", "f", "y", "g", "z"]);
+  });
+
+  test("implicit constructors keep the same ordering across the chain", () => {
+    class A {
+      constructor() {
+        this.x = 1;
+      }
+    }
+
+    class B extends A {
+      f = 2;
+    }
+
+    class C extends B {
+      g = 3;
+    }
+
+    expect(Object.keys(new B())).toEqual(["x", "f"]);
+    expect(Object.keys(new C())).toEqual(["x", "f", "g"]);
+  });
+
+  test("an intermediate class without a constructor still runs its ancestor's", () => {
+    class A {
+      constructor() {
+        this.x = 1;
+      }
+    }
+
+    class B extends A {}
+
+    class C extends B {
+      g = 4;
+
+      constructor() {
+        super();
+        this.z = 5;
+      }
+    }
+
+    expect(Object.keys(new C())).toEqual(["x", "g", "z"]);
+  });
+
+  test("initializer side effects are observable between super() and the body", () => {
+    const order = [];
+
+    class Base {
+      constructor() {
+        order.push("base body");
+      }
+    }
+
+    class Derived extends Base {
+      f = order.push("derived field");
+
+      constructor() {
+        order.push("before super");
+        super();
+        order.push("after super");
+      }
+    }
+
+    new Derived();
+    expect(order).toEqual([
+      "before super",
+      "base body",
+      "derived field",
+      "after super",
+    ]);
+  });
+
+  test("side effects interleave per layer down a derived-of-derived chain", () => {
+    const order = [];
+
+    class A {
+      f = order.push("A field");
+
+      constructor() {
+        order.push("A body");
+      }
+    }
+
+    class B extends A {
+      f2 = order.push("B field");
+
+      constructor() {
+        order.push("B before super");
+        super();
+        order.push("B after super");
+      }
+    }
+
+    class C extends B {
+      f3 = order.push("C field");
+
+      constructor() {
+        order.push("C before super");
+        super();
+        order.push("C after super");
+      }
+    }
+
+    new C();
+    expect(order).toEqual([
+      "C before super",
+      "B before super",
+      "A field",
+      "A body",
+      "B field",
+      "B after super",
+      "C field",
+      "C after super",
+    ]);
+  });
+
+  test("private fields follow the same per-layer timing", () => {
+    class Base {
+      #p = "base-private";
+
+      constructor() {
+        this.x = 1;
+      }
+
+      basePrivate() {
+        return this.#p;
+      }
+    }
+
+    class Derived extends Base {
+      #q = "derived-private";
+
+      constructor() {
+        super();
+        this.y = 2;
+      }
+
+      derivedPrivate() {
+        return this.#q;
+      }
+    }
+
+    const derived = new Derived();
+    expect(Object.keys(derived)).toEqual(["x", "y"]);
+    expect(derived.basePrivate()).toBe("base-private");
+    expect(derived.derivedPrivate()).toBe("derived-private");
+  });
+});
+
+describe("field initializers close over the class definition environment", () => {
+  const makeLabelled = () => {
+    const PREFIX = "id-";
+
+    class Labelled {
+      label = PREFIX + "labelled";
+
+      constructor(n) {
+        this.n = n;
+      }
+    }
+
+    return Labelled;
+  };
+
+  const makeStamped = () => {
+    const PREFIX = "far-";
+
+    class Base {
+      base = PREFIX + "base";
+
+      constructor() {
+        this.mid = PREFIX + "mid";
+      }
+    }
+
+    class Stamped extends Base {
+      stamp = PREFIX + "stamp";
+
+      #secret = PREFIX + "secret";
+
+      constructor() {
+        super();
+        this.tail = PREFIX + "tail";
+      }
+
+      secret() {
+        return this.#secret;
+      }
+    }
+
+    return Stamped;
+  };
+
+  test("constructing from a scope without the binding still resolves it", () => {
+    const Labelled = makeLabelled();
+    const labelled = new Labelled(7);
+
+    expect(Object.keys(labelled)).toEqual(["label", "n"]);
+    expect(labelled.label).toBe("id-labelled");
+    expect(labelled.n).toBe(7);
+  });
+
+  test("a derived class resolves the binding at the far call site too", () => {
+    const Stamped = makeStamped();
+    const stamped = new Stamped();
+
+    expect(Object.keys(stamped)).toEqual(["base", "mid", "stamp", "tail"]);
+    expect(stamped.base).toBe("far-base");
+    expect(stamped.stamp).toBe("far-stamp");
+    expect(stamped.secret()).toBe("far-secret");
+  });
+
+  test("a shadowing binding at the call site does not capture the initializer", () => {
+    const makeTagged = () => {
+      const TAG = "definition";
+
+      class Tagged {
+        tag = TAG;
+      }
+
+      return Tagged;
+    };
+
+    const Tagged = makeTagged();
+    const TAG = "call-site";
+
+    expect(new Tagged().tag).toBe("definition");
+    expect(TAG).toBe("call-site");
+  });
+
+  test("a block-scoped class keeps its block bindings after the block exits", () => {
+    let Boxed;
+
+    {
+      const INNER = "boxed";
+
+      class Inner {
+        tag = INNER;
+      }
+
+      Boxed = Inner;
+    }
+
+    expect(new Boxed().tag).toBe("boxed");
+  });
+
+  test("a field initializer resolves the class's own inner name binding", () => {
+    const Named = class Inner {
+      self = Inner;
+    };
+
+    expect(new Named().self).toBe(Named);
+  });
+});

--- a/tests/language/modules/hoisted-function-import-capture/class-construction.js
+++ b/tests/language/modules/hoisted-function-import-capture/class-construction.js
@@ -6,7 +6,9 @@ features: [modules, compat-function, class]
 import {
   Counted,
   Factory,
+  Labelled,
   Point,
+  StampedLabel,
   Tagged,
   arrowConstruct,
   derivedTickCount,
@@ -82,17 +84,18 @@ describe("imported module functions construct module classes", () => {
     for (const instance of [first, second]) {
       expect(instance instanceof Counted).toBe(true);
       expect(instance instanceof Point).toBe(true);
-      // Sorted because the two modes disagree on own-property *order* for a
-      // derived class's field initializers, which is a separate question from
-      // whether each field is initialized exactly once.
-      expect(Object.keys(instance).sort()).toEqual([
+      // Exact insertion order: each class's fields land when its own super()
+      // returns (§13.3.7.1 step 11), so Point's `label`, then Point's
+      // constructor writes, then Counted's `seq`, then Counted's body, then
+      // Local's `stamp`, then Local's body.
+      expect(Object.keys(instance)).toEqual([
         "label",
-        "local",
-        "owner",
-        "seq",
-        "stamp",
         "x",
         "y",
+        "seq",
+        "owner",
+        "stamp",
+        "local",
       ]);
       expect(instance.label).toBe("point");
       expect(instance.x).toBe(20);
@@ -116,5 +119,33 @@ describe("imported module functions construct module classes", () => {
   test("constructing an imported class from the entry file is unchanged", () => {
     expect(Object.keys(new Point(1, 2))).toEqual(["label", "x", "y"]);
     expect(new Tagged(4).tag).toBe("id-tagged");
+  });
+
+  // The entry file has no PREFIX binding of its own. A field initializer that
+  // resolved against the scope running `new` would throw a ReferenceError here.
+  test("entry-file construction runs field initializers in the module scope", () => {
+    const labelled = new Labelled(7);
+    expect(Object.keys(labelled)).toEqual(["label", "n"]);
+    expect(labelled.label).toBe("id-labelled");
+    expect(labelled.n).toBe(7);
+  });
+
+  test("entry-file construction of a derived class keeps module scope and order", () => {
+    const stamped = new StampedLabel(9);
+    expect(stamped instanceof Labelled).toBe(true);
+    expect(Object.keys(stamped)).toEqual(["label", "n", "stamp", "tail"]);
+    expect(stamped.label).toBe("id-labelled");
+    expect(stamped.stamp).toBe("id-stamp");
+    expect(stamped.tail).toBe("id-tail");
+    expect(stamped.secret()).toBe("id-secret");
+  });
+
+  test("entry-file construction of a derived module class initializes once", () => {
+    const ticksBefore = derivedTickCount();
+    const counted = new Counted(30);
+
+    expect(Object.keys(counted)).toEqual(["label", "x", "y", "seq", "owner"]);
+    expect(counted.brand()).toBe("id-counted");
+    expect(derivedTickCount() - ticksBefore).toBe(1);
   });
 });

--- a/tests/language/modules/hoisted-function-import-capture/helpers/module-classes.js
+++ b/tests/language/modules/hoisted-function-import-capture/helpers/module-classes.js
@@ -20,6 +20,34 @@ export class Tagged extends Point {
   }
 }
 
+// ES2026 §15.7.10 ClassFieldDefinitionEvaluation step 2b captures the class's
+// own definition environment as each field initializer's [[Environment]].
+// These two read PREFIX from a *field* initializer rather than a constructor
+// body, so constructing them from the entry file — which has no PREFIX — is
+// what proves the initializer did not resolve against the caller's scope.
+export class Labelled {
+  label = PREFIX + "labelled";
+
+  constructor(n) {
+    this.n = n;
+  }
+}
+
+export class StampedLabel extends Labelled {
+  stamp = PREFIX + "stamp";
+
+  #secret = PREFIX + "secret";
+
+  constructor(n) {
+    super(n);
+    this.tail = PREFIX + "tail";
+  }
+
+  secret() {
+    return this.#secret;
+  }
+}
+
 let derivedTicks = 0;
 
 export function derivedTickCount() {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Class field initializers now behave per spec in both what they see and when they run — closing out five defects in one coherent change to the initializer machinery:
  - **Definition environment (ES2026 §15.7.10):** an initializer closes over the environment where the class was evaluated, not the instantiation site's scope. Before: constructing an imported class from the entry file threw `ReferenceError` in the interpreter when a field initializer read a module-level binding (it only ever worked because classes are usually constructed where they're declared). `TGocciaClassValue` now records its definition scope (GC-marked like a function closure) and initializer scopes parent on it.
  - **Timing (§10.2.2 step 5b, §13.3.7.1 step 11, §15.7.14 step 15a):** a base class initializes its own fields before its constructor body; a derived class initializes when its `super()` returns; each class initializes only its own elements (§7.3.33). This fixes wrong own-key insertion order for derived classes (interpreter gave `["f","x","y"]` where Node gives `["x","f","y"]`), bytecode double-evaluation of derived-of-derived fields, fields wrongly applied to a base constructor's returned override object (§10.2.2 step 12 says it gets nothing), and an interpreter bug where an initializer-less intermediate class dropped every ancestor constructor.
- The wrong timing had spawned compensating machinery — a first-pass/replay initializer system with private-brand re-stamping — that becomes dead with initializers running once at the right point; it is removed (net −193 lines).
- The `l-modulefndecl` differential suite and its repo-test twin drop their sorted-key carve-outs (added when these bugs were characterized during the compiled-class construction fix) and now assert exact insertion order; one existing test that pinned the anti-spec return-override behavior is corrected against Node with a clause citation.
- Spec clauses verified via the project tc39 MCP: `sec-runtime-semantics-classdefinitionevaluation` (15.7.14), `sec-runtime-semantics-classfielddefinitionevaluation` (15.7.10), `sec-initializeinstanceelements` (7.3.33), `sec-ecmascript-function-objects-construct-argumentslist-newtarget` (10.2.2), `sec-super-keyword-runtime-semantics-evaluation` (13.3.7.1), `sec-privatefieldadd` (7.3.28).

- A follow-up review pass extended the same two rules (derived-kind guard; no field application to override returns) across all eleven remaining `RunClassInitializers` sites in the bytecode VM's implicit-super paths — without which the first commit would have turned formerly-shared bugs into cross-mode divergences on plain ES2022 shapes (an implicit-constructor class below an explicit derived one; a returning base constructor under implicit layers). That sweep exposed and fixed a third pre-existing bytecode bug: an implicit-derived class lost its own fields when constructed through a module function declaration.

## Testing

- [x] Verified no regressions and confirmed the fixes in end-to-end tests — full suite 12409/12409 in both modes; a 20-shape harness (base/derived/derived-of-derived, implicit ctors, private fields, computed keys, `extends Error`/`Array`, return-override, closure capture) byte-identical to Node in both modes; `tests/language/classes/field-initializer-timing.js` (19 tests, pre-validated against bun and vitest); differential `l-modulefndecl` 16p/0f in all runtimes with exact-order assertions, probing the implicit-constructor shapes from both sides of the import
- [x] test262 class subset (8455 tests, diffed against a pristine-HEAD build): 7 newly passing, zero new failures, bytecode unchanged at zero non-PASS
- [x] Mutation-checked: reverting the definition-scope capture fails 5 tests (interpreter-only, as characterized); reverting the timing fix fails 15 interpreter + 1 bytecode assertions; neutering the eleven sibling-site guards fails with exactly a bytecode-only ordering divergence
- [x] Not benchmark-relevant beyond removing a redundant initializer pass

Review: fresh-context high-effort pass with a HEAD-baseline A/B against Node (zero Blocking; its two Important findings — the sibling sites and `Reflect.construct` dropping fields — are respectively fixed here and filed as a follow-up, `Reflect.construct` being a pre-existing defect in both modes).
