### PR TITLE
fix(runtime): resolve argument-array holes through the prototype chain

### DIFF
--- a/scripts/differential/p-callintrinsics.test.js
+++ b/scripts/differential/p-callintrinsics.test.js
@@ -208,6 +208,67 @@ describe("the Function.prototype intrinsics themselves", () => {
     expect(call.apply(collect, [receiver, 1, 2, 3])).toBe("r:1,2,3");
   });
 
+  // CreateListFromArrayLike reads every index of the argument array with Get,
+  // so an elision is an absent property that resolves to undefined. A hole must
+  // never reach the callee as a distinguishable value, in any argument count and
+  // through any of the entry points that build the list.
+  test("apply turns argument-array holes into undefined", () => {
+    const args = function (...rest) {
+      return rest.map((value) => String(value)).join("|");
+    };
+
+    expect(args.apply(undefined, [1, , 3])).toBe("1|undefined|3");
+    expect(args.apply(undefined, [, 2, 3])).toBe("undefined|2|3");
+    expect(args.apply(undefined, [1, 2, ,])).toBe("1|2|undefined");
+    expect(args.apply(undefined, [, , ,])).toBe("undefined|undefined|undefined");
+    expect(args.apply(undefined, [,])).toBe("undefined");
+    expect(args.apply(undefined, [, ,])).toBe("undefined|undefined");
+    expect(args.apply(undefined, [1, , , 4])).toBe("1|undefined|undefined|4");
+    expect(args.apply(undefined, [1, , 3, , 5])).toBe("1|undefined|3|undefined|5");
+    expect(((...rest) => rest.length).apply(undefined, [,])).toBe(1);
+  });
+
+  test("holes stay undefined through bound functions and detached apply", () => {
+    const args = function (...rest) {
+      return rest.map((value) => String(value)).join("|");
+    };
+    const apply = Function.prototype.apply;
+
+    expect(args.bind(undefined).apply(undefined, [1, , 3])).toBe("1|undefined|3");
+    expect(args.bind(undefined, 0).apply(undefined, [, 2])).toBe("0|undefined|2");
+    expect(apply.call(args, undefined, [1, , 3])).toBe("1|undefined|3");
+    expect(Reflect.apply(args, undefined, [1, , 3])).toBe("1|undefined|3");
+    expect(args(...[1, , 3])).toBe("1|undefined|3");
+    expect(((a, b, c) => b === undefined).apply(undefined, [1, , 3])).toBe(true);
+  });
+
+  test("argument-array holes are read through the prototype chain", () => {
+    const args = function (...rest) {
+      return rest.map((value) => String(value)).join("|");
+    };
+    let reads = 0;
+
+    Object.defineProperty(Array.prototype, 1, {
+      get() {
+        reads += 1;
+        return "inherited";
+      },
+      configurable: true,
+    });
+
+    try {
+      expect(args.apply(undefined, [1, , 3])).toBe("1|inherited|3");
+      expect(args.apply(undefined, [1, ,])).toBe("1|inherited");
+      expect(args.apply(undefined, [1, , 3, 4])).toBe("1|inherited|3|4");
+      expect(args.bind(undefined).apply(undefined, [1, , 3])).toBe("1|inherited|3");
+      expect(Reflect.apply(args, undefined, [1, , 3])).toBe("1|inherited|3");
+      expect(args(...[1, , 3])).toBe("1|inherited|3");
+      expect(reads).toBe(6);
+    } finally {
+      delete Array.prototype[1];
+    }
+  });
+
   test("call and apply reject non-callable receivers", () => {
     const notCallable = { call: Function.prototype.call, apply: Function.prototype.apply };
     expect(() => notCallable.call(undefined)).toThrow(TypeError);

--- a/scripts/differential/p-callintrinsics.test.js
+++ b/scripts/differential/p-callintrinsics.test.js
@@ -269,6 +269,106 @@ describe("the Function.prototype intrinsics themselves", () => {
     }
   });
 
+  // The list is built index 0 upwards, so inherited getters must fire in
+  // ascending order — a detail only observable through their side effects, and
+  // one an engine loses the moment it reads the arguments in whatever order its
+  // call sequence happens to evaluate.
+  test("inherited index getters fire in ascending index order", () => {
+    const args = function (...rest) {
+      return rest.map((value) => String(value)).join("|");
+    };
+    let order = "";
+    const define = (index) =>
+      Object.defineProperty(Array.prototype, index, {
+        get() {
+          order += String(index);
+          return `g${index}`;
+        },
+        configurable: true,
+      });
+
+    define(0);
+    define(1);
+    define(2);
+
+    try {
+      const run = (fn) => {
+        order = "";
+        return `${fn()} order=${order}`;
+      };
+
+      expect(run(() => args.apply(undefined, [, ,]))).toBe("g0|g1 order=01");
+      expect(run(() => args.apply(undefined, [, , ,]))).toBe("g0|g1|g2 order=012");
+      expect(run(() => args.apply(undefined, [, , , 4]))).toBe("g0|g1|g2|4 order=012");
+      expect(run(() => args.bind(undefined).apply(undefined, [, , ,]))).toBe(
+        "g0|g1|g2 order=012",
+      );
+      expect(run(() => Function.prototype.apply.call(args, undefined, [, , ,]))).toBe(
+        "g0|g1|g2 order=012",
+      );
+      expect(run(() => Reflect.apply(args, undefined, [, , ,]))).toBe(
+        "g0|g1|g2 order=012",
+      );
+      expect(run(() => args(...[, , ,]))).toBe("g0|g1|g2 order=012");
+    } finally {
+      delete Array.prototype[0];
+      delete Array.prototype[1];
+      delete Array.prototype[2];
+    }
+  });
+
+  test("a getter that truncates the argument array keeps the original count", () => {
+    const args = function (...rest) {
+      return rest.map((value) => String(value)).join("|");
+    };
+    let reading = null;
+
+    Object.defineProperty(Array.prototype, 1, {
+      get() {
+        reading.length = 1;
+        return "g";
+      },
+      configurable: true,
+    });
+
+    const truncatingCall = (call) => {
+      reading = [1, , 3];
+      return call(reading);
+    };
+
+    try {
+      // The length is read once up front, so shrinking the array from inside a
+      // getter cannot shorten the argument list: index 2 is merely absent when
+      // its turn comes. Reading indices in descending order would instead
+      // report the pre-truncation index 2 and lose index 0.
+      expect(truncatingCall((a) => args.apply(undefined, a))).toBe("1|g|undefined");
+      expect(truncatingCall((a) => Reflect.apply(args, undefined, a))).toBe(
+        "1|g|undefined",
+      );
+      expect(truncatingCall((a) => args.bind(undefined).apply(undefined, a))).toBe(
+        "1|g|undefined",
+      );
+    } finally {
+      delete Array.prototype[1];
+    }
+  });
+
+  test("apply uses the array's length, not its dense element count", () => {
+    const args = function (...rest) {
+      return rest.map((value) => String(value)).join("|");
+    };
+    const grown = [1, 2];
+    grown.length = 5;
+
+    expect(args.apply(undefined, grown)).toBe("1|2|undefined|undefined|undefined");
+    expect(Reflect.apply(args, undefined, grown)).toBe(
+      "1|2|undefined|undefined|undefined",
+    );
+    expect(args.bind(undefined).apply(undefined, grown)).toBe(
+      "1|2|undefined|undefined|undefined",
+    );
+  });
+
   test("call and apply reject non-callable receivers", () => {
     const notCallable = { call: Function.prototype.call, apply: Function.prototype.apply };
     expect(() => notCallable.call(undefined)).toThrow(TypeError);

--- a/source/units/Goccia.Arguments.ArrayLike.pas
+++ b/source/units/Goccia.Arguments.ArrayLike.pas
@@ -14,13 +14,19 @@ uses
 // Throws TypeError if the value is not an object.
 function CreateListFromArrayLike(const AValue: TGocciaValue; const AMethodName: string): TGocciaArgumentsCollection;
 
-// ES2026 §7.3.19 step 6b: Let next be ? Get(obj, indexName).
-// Reads one index of a dense array with [[Get]] semantics: a hole is not an own
-// property, so the read continues up the prototype chain (ES2026 §10.1.8.1
-// OrdinaryGet step 2) and yields undefined only when nothing inherits the index.
-// Argument-list materialization must never hand a hole sentinel to a callee.
-function ArrayArgumentElement(const AArray: TGocciaArrayValue;
-  const AIndex: Integer): TGocciaValue;
+// True when every index below the array's length is a plain dense data element.
+// Callers use this to decide whether an argument list can be read straight out
+// of the element storage: on a dense hole-free array such a read observes no
+// accessor and therefore runs no guest code, so no intermediate needs a GC root
+// and no read order is observable. Both conditions matter:
+//   - a hole is not an own property, so resolving it per ES2026 §7.3.19 step 6b
+//     continues up the prototype chain and can invoke an inherited accessor;
+//   - a length grown past the dense element count (`a.length = 5`) means the
+//     element count is not LengthOfArrayLike, so the generic path has to run to
+//     produce the spec argument count and the RangeError ceiling.
+// An own accessor on an index is covered too: defining one punches a hole in the
+// dense storage (Goccia.Values.ArrayValue DefineProperty).
+function IsDenseHoleFreeArgumentArray(const AArray: TGocciaArrayValue): Boolean;
 
 implementation
 
@@ -39,21 +45,19 @@ const
   // pathological OOM from script-controlled length values like { length: 2e9 }.
   MAX_ARGUMENTS_LIST_LENGTH = 1048576; // 2^20
 
-function ArrayArgumentElement(const AArray: TGocciaArrayValue;
-  const AIndex: Integer): TGocciaValue;
+function IsDenseHoleFreeArgumentArray(const AArray: TGocciaArrayValue): Boolean;
+var
+  I: Integer;
 begin
-  if (AIndex >= 0) and (AIndex < AArray.Elements.Count) then
-  begin
-    Result := AArray.Elements[AIndex];
-    if Result <> TGocciaHoleValue.HoleValue then
-      Exit;
-  end;
+  Result := False;
+  if not AArray.HasDenseElementLength then
+    Exit;
 
-  // Hole or out-of-range: resolve through the full property lookup so
-  // inherited index properties and accessors on Array.prototype are observed.
-  Result := AArray.GetProperty(IntToStr(AIndex));
-  if not Assigned(Result) then
-    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+  for I := 0 to AArray.Elements.Count - 1 do
+    if AArray.Elements[I] = TGocciaHoleValue.HoleValue then
+      Exit;
+
+  Result := True;
 end;
 
 // ES2026 §7.3.19 CreateListFromArrayLike(obj [, elementTypes])
@@ -69,13 +73,17 @@ begin
   if not (AValue is TGocciaObjectValue) then
     ThrowTypeError(Format('%s: argumentsList must be an array-like object', [AMethodName]));
 
-  // Fast path: TGocciaArrayValue — direct element access
-  if AValue is TGocciaArrayValue then
+  // Fast path: dense hole-free TGocciaArrayValue — direct element access.
+  // Every other array (holes, or a length grown past the dense element count)
+  // falls through to the generic path so that the argument count is
+  // LengthOfArrayLike and every index is read with Get.
+  if (AValue is TGocciaArrayValue) and
+     IsDenseHoleFreeArgumentArray(TGocciaArrayValue(AValue)) then
   begin
     ArrVal := TGocciaArrayValue(AValue);
     Result := TGocciaArgumentsCollection.CreateWithCapacity(ArrVal.Elements.Count);
     for I := 0 to ArrVal.Elements.Count - 1 do
-      Result.Add(ArrayArgumentElement(ArrVal, I));
+      Result.Add(ArrVal.Elements[I]);
     Exit;
   end;
 

--- a/source/units/Goccia.Arguments.ArrayLike.pas
+++ b/source/units/Goccia.Arguments.ArrayLike.pas
@@ -6,12 +6,21 @@ interface
 
 uses
   Goccia.Arguments.Collection,
+  Goccia.Values.ArrayValue,
   Goccia.Values.Primitives;
 
-// ES2026 §7.3.18 CreateListFromArrayLike(obj [, elementTypes])
+// ES2026 §7.3.19 CreateListFromArrayLike(obj [, elementTypes])
 // Converts an array or array-like object to a TGocciaArgumentsCollection.
 // Throws TypeError if the value is not an object.
 function CreateListFromArrayLike(const AValue: TGocciaValue; const AMethodName: string): TGocciaArgumentsCollection;
+
+// ES2026 §7.3.19 step 6b: Let next be ? Get(obj, indexName).
+// Reads one index of a dense array with [[Get]] semantics: a hole is not an own
+// property, so the read continues up the prototype chain (ES2026 §10.1.8.1
+// OrdinaryGet step 2) and yields undefined only when nothing inherits the index.
+// Argument-list materialization must never hand a hole sentinel to a callee.
+function ArrayArgumentElement(const AArray: TGocciaArrayValue;
+  const AIndex: Integer): TGocciaValue;
 
 implementation
 
@@ -20,7 +29,6 @@ uses
 
   Goccia.Constants.PropertyNames,
   Goccia.Utils,
-  Goccia.Values.ArrayValue,
   Goccia.Values.ErrorHelper,
   Goccia.Values.HoleValue,
   Goccia.Values.ObjectValue;
@@ -31,7 +39,24 @@ const
   // pathological OOM from script-controlled length values like { length: 2e9 }.
   MAX_ARGUMENTS_LIST_LENGTH = 1048576; // 2^20
 
-// ES2026 §7.3.18 CreateListFromArrayLike(obj [, elementTypes])
+function ArrayArgumentElement(const AArray: TGocciaArrayValue;
+  const AIndex: Integer): TGocciaValue;
+begin
+  if (AIndex >= 0) and (AIndex < AArray.Elements.Count) then
+  begin
+    Result := AArray.Elements[AIndex];
+    if Result <> TGocciaHoleValue.HoleValue then
+      Exit;
+  end;
+
+  // Hole or out-of-range: resolve through the full property lookup so
+  // inherited index properties and accessors on Array.prototype are observed.
+  Result := AArray.GetProperty(IntToStr(AIndex));
+  if not Assigned(Result) then
+    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+end;
+
+// ES2026 §7.3.19 CreateListFromArrayLike(obj [, elementTypes])
 function CreateListFromArrayLike(const AValue: TGocciaValue; const AMethodName: string): TGocciaArgumentsCollection;
 var
   ArrVal: TGocciaArrayValue;
@@ -40,7 +65,7 @@ var
   Len, I: Integer;
   Element: TGocciaValue;
 begin
-  // ES2026 §7.3.18 step 1: If obj is not an Object, throw a TypeError exception
+  // ES2026 §7.3.19 step 2: If obj is not an Object, throw a TypeError exception
   if not (AValue is TGocciaObjectValue) then
     ThrowTypeError(Format('%s: argumentsList must be an array-like object', [AMethodName]));
 
@@ -50,16 +75,11 @@ begin
     ArrVal := TGocciaArrayValue(AValue);
     Result := TGocciaArgumentsCollection.CreateWithCapacity(ArrVal.Elements.Count);
     for I := 0 to ArrVal.Elements.Count - 1 do
-    begin
-      Element := ArrVal.Elements[I];
-      if Element = TGocciaHoleValue.HoleValue then
-        Element := TGocciaUndefinedLiteralValue.UndefinedValue;
-      Result.Add(Element);
-    end;
+      Result.Add(ArrayArgumentElement(ArrVal, I));
     Exit;
   end;
 
-  // ES2026 §7.3.18 step 2: Let len be ? LengthOfArrayLike(obj)
+  // ES2026 §7.3.19 step 3: Let len be ? LengthOfArrayLike(obj)
   // ES2026 §7.3.3 LengthOfArrayLike: ToLength(? Get(obj, "length"))
   // ES2026 §7.1.22 ToLength: NaN/negative → 0, spec caps at 2^53−1.
   ArrayObj := TGocciaObjectValue(AValue);
@@ -76,11 +96,11 @@ begin
     ThrowRangeError(Format('%s: arguments list length %d exceeds maximum of %d',
       [AMethodName, Len, MAX_ARGUMENTS_LIST_LENGTH]));
 
-  // ES2026 §7.3.18 steps 3-5: Iterate and collect elements
+  // ES2026 §7.3.19 steps 4-6: Iterate and collect elements
   Result := TGocciaArgumentsCollection.CreateWithCapacity(Len);
   for I := 0 to Len - 1 do
   begin
-    // ES2026 §7.3.18 step 5a: Let next be ? Get(obj, indexName)
+    // ES2026 §7.3.19 step 6b: Let next be ? Get(obj, indexName)
     Element := ArrayObj.GetProperty(IntToStr(I));
     if not Assigned(Element) then
       Element := TGocciaUndefinedLiteralValue.UndefinedValue;

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -514,6 +514,7 @@ uses
   TextSemantics,
   TimingUtils,
 
+  Goccia.Arguments.ArrayLike,
   Goccia.Arithmetic,
   Goccia.AST.Node,
   Goccia.AST.Statements,
@@ -13728,6 +13729,7 @@ var
   CallThisRegister: TGocciaRegister;
   CallGlobalThisValue: TGocciaValue;
   FixedArg0, FixedArg1, FixedArg2: TGocciaRegister;
+  ApplyArgRegister0, ApplyArgRegister1, ApplyArgRegister2: TGocciaRegister;
   BytecodeFunction: TGocciaBytecodeFunctionValue;
   BoundFunction: TGocciaBoundFunctionValue;
   JumpOffset: Integer;
@@ -16366,9 +16368,21 @@ begin
                   end;
                   Continue;
                 end
+                // The dense hole-free gate is what makes the direct element
+                // reads below legal: no read can reach an accessor, so the
+                // argument values cannot be produced by guest code that
+                // allocates (and collects) while the earlier ones sit in plain
+                // locals, and no read order is observable. A holey array or one
+                // whose length was grown past its element count falls through
+                // to the generic call, which runs Function.prototype.apply and
+                // therefore CreateListFromArrayLike — ascending Get order, a
+                // rooted arguments collection, and the spec argument count,
+                // exactly as the interpreter does.
                 else if (CalleeIntrinsicKind = nikFunctionApply) and (B >= 2) and
                         (FRegisters[A + 2].Kind = grkObject) and
-                        (FRegisters[A + 2].ObjectValue is TGocciaArrayValue) then
+                        (FRegisters[A + 2].ObjectValue is TGocciaArrayValue) and
+                        IsDenseHoleFreeArgumentArray(
+                          TGocciaArrayValue(FRegisters[A + 2].ObjectValue)) then
                 begin
                   ArgsArray := TGocciaArrayValue(FRegisters[A + 2].ObjectValue);
                   CallThisRegister := FRegisters[A + 1];
@@ -16387,31 +16401,44 @@ begin
                         RegisterUndefined, RegisterUndefined, RegisterUndefined,
                         True, True, Frame, Template, PrevCovLine, ProfileEntryTimestamp);
                     1:
-                      SetupNewFrame(BytecodeFunction.FClosure,
-	                        CallThisRegister, TGocciaRegisterArray(nil), 1,
-	                        VMValueToRegisterFast(ArgsArray.GetProperty('0')),
-	                        RegisterUndefined, RegisterUndefined,
-                        True, True, Frame, Template, PrevCovLine, ProfileEntryTimestamp);
+                      begin
+                        ApplyArgRegister0 :=
+                          VMValueToRegisterFast(ArgsArray.Elements[0]);
+                        SetupNewFrame(BytecodeFunction.FClosure,
+                          CallThisRegister, TGocciaRegisterArray(nil), 1,
+                          ApplyArgRegister0, RegisterUndefined, RegisterUndefined,
+                          True, True, Frame, Template, PrevCovLine, ProfileEntryTimestamp);
+                      end;
                     2:
-                      SetupNewFrame(BytecodeFunction.FClosure,
-	                        CallThisRegister, TGocciaRegisterArray(nil), 2,
-	                        VMValueToRegisterFast(ArgsArray.GetProperty('0')),
-	                        VMValueToRegisterFast(ArgsArray.GetProperty('1')),
-	                        RegisterUndefined,
-                        True, True, Frame, Template, PrevCovLine, ProfileEntryTimestamp);
+                      begin
+                        ApplyArgRegister0 :=
+                          VMValueToRegisterFast(ArgsArray.Elements[0]);
+                        ApplyArgRegister1 :=
+                          VMValueToRegisterFast(ArgsArray.Elements[1]);
+                        SetupNewFrame(BytecodeFunction.FClosure,
+                          CallThisRegister, TGocciaRegisterArray(nil), 2,
+                          ApplyArgRegister0, ApplyArgRegister1, RegisterUndefined,
+                          True, True, Frame, Template, PrevCovLine, ProfileEntryTimestamp);
+                      end;
                     3:
-                      SetupNewFrame(BytecodeFunction.FClosure,
-	                        CallThisRegister, TGocciaRegisterArray(nil), 3,
-	                        VMValueToRegisterFast(ArgsArray.GetProperty('0')),
-	                        VMValueToRegisterFast(ArgsArray.GetProperty('1')),
-	                        VMValueToRegisterFast(ArgsArray.GetProperty('2')),
-                        True, True, Frame, Template, PrevCovLine, ProfileEntryTimestamp);
+                      begin
+                        ApplyArgRegister0 :=
+                          VMValueToRegisterFast(ArgsArray.Elements[0]);
+                        ApplyArgRegister1 :=
+                          VMValueToRegisterFast(ArgsArray.Elements[1]);
+                        ApplyArgRegister2 :=
+                          VMValueToRegisterFast(ArgsArray.Elements[2]);
+                        SetupNewFrame(BytecodeFunction.FClosure,
+                          CallThisRegister, TGocciaRegisterArray(nil), 3,
+                          ApplyArgRegister0, ApplyArgRegister1, ApplyArgRegister2,
+                          True, True, Frame, Template, PrevCovLine, ProfileEntryTimestamp);
+                      end;
                   else
                     begin
-	                      SetLength(RegisterArgs, ArgsArray.Elements.Count);
-	                      for I := 0 to High(RegisterArgs) do
-	                        RegisterArgs[I] := VMValueToRegisterFast(
-	                          ArgsArray.GetProperty(IntToStr(I)));
+                      SetLength(RegisterArgs, ArgsArray.Elements.Count);
+                      for I := 0 to High(RegisterArgs) do
+                        RegisterArgs[I] :=
+                          VMValueToRegisterFast(ArgsArray.Elements[I]);
                       SetupNewFrame(BytecodeFunction.FClosure,
                         CallThisRegister, RegisterArgs, Length(RegisterArgs),
                         RegisterUndefined, RegisterUndefined, RegisterUndefined,

--- a/source/units/Goccia.Values.FunctionBase.pas
+++ b/source/units/Goccia.Values.FunctionBase.pas
@@ -1216,6 +1216,7 @@ var
   NewThisValue: TGocciaValue;
   ArgArray: TGocciaValue;
   ArrVal: TGocciaArrayValue;
+  FastArg0, FastArg1, FastArg2: TGocciaValue;
 begin
   // Step 1: Perform ? RequireObjectCoercible(this)
   if not AThisValue.IsCallable then
@@ -1253,7 +1254,12 @@ begin
   if TryCallStringFromCodePointApplyFast(AThisValue, ArgArray, Result) then
     Exit;
 
-  // Fast path: small arrays use specialized call methods (FunctionBase only)
+  // Fast path: small arrays use specialized call methods (FunctionBase only).
+  // Elements still go through ArrayArgumentElement so that ES2026 §7.3.19 step
+  // 6b Get semantics hold: a hole is not an own property, so it resolves through
+  // the prototype chain and never reaches the callee as the hole sentinel.
+  // Indices are read into locals in ascending order because an inherited
+  // accessor makes the read order observable.
   if (AThisValue is TGocciaFunctionBase) and (ArgArray is TGocciaArrayValue) then
   begin
     ArrVal := TGocciaArrayValue(ArgArray);
@@ -1261,13 +1267,25 @@ begin
       0:
         Exit(TGocciaFunctionBase(AThisValue).CallNoArgs(NewThisValue));
       1:
-        Exit(TGocciaFunctionBase(AThisValue).CallOneArg(ArrVal.Elements[0], NewThisValue));
+        begin
+          FastArg0 := ArrayArgumentElement(ArrVal, 0);
+          Exit(TGocciaFunctionBase(AThisValue).CallOneArg(FastArg0, NewThisValue));
+        end;
       2:
-        Exit(TGocciaFunctionBase(AThisValue).CallTwoArgs(ArrVal.Elements[0],
-          ArrVal.Elements[1], NewThisValue));
+        begin
+          FastArg0 := ArrayArgumentElement(ArrVal, 0);
+          FastArg1 := ArrayArgumentElement(ArrVal, 1);
+          Exit(TGocciaFunctionBase(AThisValue).CallTwoArgs(FastArg0, FastArg1,
+            NewThisValue));
+        end;
       3:
-        Exit(TGocciaFunctionBase(AThisValue).CallThreeArgs(ArrVal.Elements[0],
-          ArrVal.Elements[1], ArrVal.Elements[2], NewThisValue));
+        begin
+          FastArg0 := ArrayArgumentElement(ArrVal, 0);
+          FastArg1 := ArrayArgumentElement(ArrVal, 1);
+          FastArg2 := ArrayArgumentElement(ArrVal, 2);
+          Exit(TGocciaFunctionBase(AThisValue).CallThreeArgs(FastArg0, FastArg1,
+            FastArg2, NewThisValue));
+        end;
     end;
   end;
 

--- a/source/units/Goccia.Values.FunctionBase.pas
+++ b/source/units/Goccia.Values.FunctionBase.pas
@@ -1216,7 +1216,6 @@ var
   NewThisValue: TGocciaValue;
   ArgArray: TGocciaValue;
   ArrVal: TGocciaArrayValue;
-  FastArg0, FastArg1, FastArg2: TGocciaValue;
 begin
   // Step 1: Perform ? RequireObjectCoercible(this)
   if not AThisValue.IsCallable then
@@ -1254,38 +1253,29 @@ begin
   if TryCallStringFromCodePointApplyFast(AThisValue, ArgArray, Result) then
     Exit;
 
-  // Fast path: small arrays use specialized call methods (FunctionBase only).
-  // Elements still go through ArrayArgumentElement so that ES2026 §7.3.19 step
-  // 6b Get semantics hold: a hole is not an own property, so it resolves through
-  // the prototype chain and never reaches the callee as the hole sentinel.
-  // Indices are read into locals in ascending order because an inherited
-  // accessor makes the read order observable.
-  if (AThisValue is TGocciaFunctionBase) and (ArgArray is TGocciaArrayValue) then
+  // Fast path: small dense hole-free arrays use specialized call methods
+  // (FunctionBase only). The gate is what keeps the direct element reads legal:
+  // on a dense hole-free array no read can reach an accessor, so no guest code
+  // runs between the reads and the call and these plain locals cannot be
+  // invalidated by a collection. A hole (ES2026 §7.3.19 step 6b resolves it with
+  // Get, which can invoke an inherited accessor) or a length grown past the
+  // element count sends the call down CreateListFromArrayLike instead, where the
+  // arguments collection is itself a GC root source and the reads are ascending.
+  if (AThisValue is TGocciaFunctionBase) and (ArgArray is TGocciaArrayValue) and
+     IsDenseHoleFreeArgumentArray(TGocciaArrayValue(ArgArray)) then
   begin
     ArrVal := TGocciaArrayValue(ArgArray);
     case ArrVal.Elements.Count of
       0:
         Exit(TGocciaFunctionBase(AThisValue).CallNoArgs(NewThisValue));
       1:
-        begin
-          FastArg0 := ArrayArgumentElement(ArrVal, 0);
-          Exit(TGocciaFunctionBase(AThisValue).CallOneArg(FastArg0, NewThisValue));
-        end;
+        Exit(TGocciaFunctionBase(AThisValue).CallOneArg(ArrVal.Elements[0], NewThisValue));
       2:
-        begin
-          FastArg0 := ArrayArgumentElement(ArrVal, 0);
-          FastArg1 := ArrayArgumentElement(ArrVal, 1);
-          Exit(TGocciaFunctionBase(AThisValue).CallTwoArgs(FastArg0, FastArg1,
-            NewThisValue));
-        end;
+        Exit(TGocciaFunctionBase(AThisValue).CallTwoArgs(ArrVal.Elements[0],
+          ArrVal.Elements[1], NewThisValue));
       3:
-        begin
-          FastArg0 := ArrayArgumentElement(ArrVal, 0);
-          FastArg1 := ArrayArgumentElement(ArrVal, 1);
-          FastArg2 := ArrayArgumentElement(ArrVal, 2);
-          Exit(TGocciaFunctionBase(AThisValue).CallThreeArgs(FastArg0, FastArg1,
-            FastArg2, NewThisValue));
-        end;
+        Exit(TGocciaFunctionBase(AThisValue).CallThreeArgs(ArrVal.Elements[0],
+          ArrVal.Elements[1], ArrVal.Elements[2], NewThisValue));
     end;
   end;
 

--- a/tests/built-ins/Function/prototype/apply.js
+++ b/tests/built-ins/Function/prototype/apply.js
@@ -79,6 +79,77 @@ describe("Function.prototype.apply", () => {
     expect(fn.apply(undefined, { 0: "ignored", length: "bar" })).toBe(0);
   });
 
+  // CreateListFromArrayLike reads every index with Get, so an elision in the
+  // argument array is an absent property that resolves to undefined — never a
+  // hole that survives into the callee's parameters.
+  test("passes holes in a sparse argument array as undefined", () => {
+    const collect = (...args) => args.map((a) => String(a)).join("|");
+
+    expect(collect.apply(undefined, [1, , 3])).toBe("1|undefined|3");
+    expect(collect.apply(undefined, [, 2, 3])).toBe("undefined|2|3");
+    expect(collect.apply(undefined, [1, 2, ,])).toBe("1|2|undefined");
+    expect(collect.apply(undefined, [, , ,])).toBe(
+      "undefined|undefined|undefined",
+    );
+    expect(collect.apply(undefined, [,])).toBe("undefined");
+    expect(collect.apply(undefined, [, ,])).toBe("undefined|undefined");
+    expect(collect.apply(undefined, [1, , , 4])).toBe("1|undefined|undefined|4");
+    expect(collect.apply(undefined, [1, , 3, , 5])).toBe(
+      "1|undefined|3|undefined|5",
+    );
+  });
+
+  test("holes in a sparse argument array are strictly undefined", () => {
+    const isUndefined = (a, b, c) => [
+      a === undefined,
+      b === undefined,
+      c === undefined,
+    ];
+
+    expect(isUndefined.apply(undefined, [1, , 3])).toEqual([false, true, false]);
+    expect(isUndefined.apply(undefined, [, ,])).toEqual([true, true, true]);
+    expect(((...args) => args.length).apply(undefined, [,])).toBe(1);
+  });
+
+  test("bound functions receive sparse argument arrays as undefined", () => {
+    const collect = (...args) => args.map((a) => String(a)).join("|");
+    const bound = collect.bind(undefined);
+
+    expect(bound.apply(undefined, [1, , 3])).toBe("1|undefined|3");
+    expect(bound.apply(undefined, [, ,])).toBe("undefined|undefined");
+    expect(Function.prototype.apply.call(collect, undefined, [1, , 3])).toBe(
+      "1|undefined|3",
+    );
+  });
+
+  test("holes resolve through the array prototype chain", () => {
+    const collect = (...args) => args.map((a) => String(a)).join("|");
+    let reads = 0;
+
+    Object.defineProperty(Array.prototype, 1, {
+      get() {
+        reads += 1;
+        return "inherited";
+      },
+      configurable: true,
+    });
+
+    try {
+      // One-, two- and three-element arrays take the small-argument fast path;
+      // longer ones go through the generic list build. Both must observe the
+      // inherited accessor rather than substituting undefined for the hole.
+      expect(collect.apply(undefined, [1, , 3])).toBe("1|inherited|3");
+      expect(collect.apply(undefined, [1, ,])).toBe("1|inherited");
+      expect(collect.apply(undefined, [1, , 3, 4])).toBe("1|inherited|3|4");
+      expect(collect.bind(undefined).apply(undefined, [1, , 3])).toBe(
+        "1|inherited|3",
+      );
+      expect(reads).toBe(4);
+    } finally {
+      delete Array.prototype[1];
+    }
+  });
+
   test("throws RangeError for excessively large array-like length", () => {
     const fn = () => {};
     expect(() => fn.apply(undefined, { length: 2000000000 })).toThrow(RangeError);

--- a/tests/built-ins/Function/prototype/apply.js
+++ b/tests/built-ins/Function/prototype/apply.js
@@ -150,6 +150,105 @@ describe("Function.prototype.apply", () => {
     }
   });
 
+  test("reads inherited index getters in ascending index order", () => {
+    const collect = (...args) => args.map((a) => String(a)).join("|");
+    let order = "";
+    const define = (index) =>
+      Object.defineProperty(Array.prototype, index, {
+        get() {
+          order += String(index);
+          return `g${index}`;
+        },
+        configurable: true,
+      });
+
+    define(0);
+    define(1);
+    define(2);
+
+    try {
+      const run = (fn) => {
+        order = "";
+        return `${fn()} order=${order}`;
+      };
+
+      expect(run(() => collect.apply(undefined, [, ,]))).toBe("g0|g1 order=01");
+      expect(run(() => collect.apply(undefined, [, , ,]))).toBe(
+        "g0|g1|g2 order=012",
+      );
+      expect(run(() => collect.apply(undefined, [, , , 4]))).toBe(
+        "g0|g1|g2|4 order=012",
+      );
+      expect(run(() => collect.bind(undefined).apply(undefined, [, , ,]))).toBe(
+        "g0|g1|g2 order=012",
+      );
+    } finally {
+      delete Array.prototype[0];
+      delete Array.prototype[1];
+      delete Array.prototype[2];
+    }
+  });
+
+  test("a getter that truncates the argument array keeps the original count", () => {
+    const collect = (...args) => args.map((a) => String(a)).join("|");
+    const argArray = [1, , 3];
+
+    Object.defineProperty(Array.prototype, 1, {
+      get() {
+        argArray.length = 1;
+        return "g";
+      },
+      configurable: true,
+    });
+
+    try {
+      // LengthOfArrayLike is read once, up front, so shrinking the array from
+      // inside a getter cannot change the argument count; index 2 is simply
+      // absent by the time it is read.
+      expect(collect.apply(undefined, argArray)).toBe("1|g|undefined");
+    } finally {
+      delete Array.prototype[1];
+    }
+  });
+
+  test("uses the array's length, not its dense element count", () => {
+    const collect = (...args) => args.map((a) => String(a)).join("|");
+    const grown = [1, 2];
+    grown.length = 5;
+
+    expect(collect.apply(undefined, grown)).toBe(
+      "1|2|undefined|undefined|undefined",
+    );
+
+    const emptyGrown = [];
+    emptyGrown.length = 3;
+    expect(collect.apply(undefined, emptyGrown)).toBe(
+      "undefined|undefined|undefined",
+    );
+
+    Object.defineProperty(Array.prototype, 3, {
+      get() {
+        return "p3";
+      },
+      configurable: true,
+    });
+
+    try {
+      expect(collect.apply(undefined, grown)).toBe("1|2|undefined|p3|undefined");
+    } finally {
+      delete Array.prototype[3];
+    }
+  });
+
+  test("throws RangeError for an array whose length exceeds the maximum", () => {
+    const fn = () => {};
+    const huge = [1, 2];
+    huge.length = 2000000;
+
+    expect(() => fn.apply(undefined, huge)).toThrow(RangeError);
+    expect(() => Reflect.apply(fn, undefined, huge)).toThrow(RangeError);
+  });
+
   test("throws RangeError for excessively large array-like length", () => {
     const fn = () => {};
     expect(() => fn.apply(undefined, { length: 2000000000 })).toThrow(RangeError);

--- a/tests/built-ins/Reflect/apply.js
+++ b/tests/built-ins/Reflect/apply.js
@@ -103,6 +103,20 @@ describe("Reflect.apply", () => {
     }
   });
 
+  test("uses the array's length, not its dense element count", () => {
+    const collect = (...args) => args.map((a) => String(a)).join("|");
+    const grown = [1, 2];
+    grown.length = 5;
+
+    expect(Reflect.apply(collect, undefined, grown)).toBe(
+      "1|2|undefined|undefined|undefined",
+    );
+
+    const huge = [1, 2];
+    huge.length = 2000000;
+    expect(() => Reflect.apply(collect, undefined, huge)).toThrow(RangeError);
+  });
+
   test("works with array-like object with string length", () => {
     const fn = (a) => a;
     const arrayLike = { 0: "hello", length: "1" };

--- a/tests/built-ins/Reflect/apply.js
+++ b/tests/built-ins/Reflect/apply.js
@@ -58,6 +58,51 @@ describe("Reflect.apply", () => {
     expect(result).toEqual(["arg1", 2, undefined, null]);
   });
 
+  test("holes at every position of argumentsList become undefined", () => {
+    const collect = (...args) => args.map((a) => String(a)).join("|");
+
+    expect(Reflect.apply(collect, undefined, [1, , 3])).toBe("1|undefined|3");
+    expect(Reflect.apply(collect, undefined, [, 2, 3])).toBe("undefined|2|3");
+    expect(Reflect.apply(collect, undefined, [1, 2, ,])).toBe("1|2|undefined");
+    expect(Reflect.apply(collect, undefined, [, , ,])).toBe(
+      "undefined|undefined|undefined",
+    );
+    expect(Reflect.apply(collect, undefined, [,])).toBe("undefined");
+    expect(
+      Reflect.apply((a, b, c) => b === undefined, undefined, [1, , 3]),
+    ).toBe(true);
+  });
+
+  // CreateListFromArrayLike step 6b reads each index with Get, so a hole is
+  // resolved through the prototype chain rather than replaced with undefined.
+  test("holes in argumentsList resolve through the array prototype chain", () => {
+    const collect = (...args) => args.map((a) => String(a)).join("|");
+
+    Object.defineProperty(Array.prototype, 1, {
+      get() {
+        return "inherited";
+      },
+      configurable: true,
+    });
+
+    try {
+      expect(Reflect.apply(collect, undefined, [1, , 3])).toBe("1|inherited|3");
+      expect(Reflect.apply(collect, undefined, [1, , 3, 4])).toBe(
+        "1|inherited|3|4",
+      );
+
+      class Box {
+        constructor(...args) {
+          this.tag = args.map((a) => String(a)).join("|");
+        }
+      }
+
+      expect(Reflect.construct(Box, [1, , 3]).tag).toBe("1|inherited|3");
+    } finally {
+      delete Array.prototype[1];
+    }
+  });
+
   test("works with array-like object with string length", () => {
     const fn = (a) => a;
     const arrayLike = { 0: "hello", length: "1" };

--- a/tests/built-ins/Reflect/construct.js
+++ b/tests/built-ins/Reflect/construct.js
@@ -305,6 +305,26 @@ describe("Reflect.construct", () => {
     expect(obj.ntName).toBe("Custom");
   });
 
+  test("holes in argumentsList are passed as undefined", () => {
+    class Collect {
+      constructor(...args) {
+        this.tag = args.map((a) => String(a)).join("|");
+        this.secondIsUndefined = args[1] === undefined;
+      }
+    }
+
+    expect(Reflect.construct(Collect, [1, , 3]).tag).toBe("1|undefined|3");
+    expect(Reflect.construct(Collect, [1, , 3]).secondIsUndefined).toBe(true);
+    expect(Reflect.construct(Collect, [, 2]).tag).toBe("undefined|2");
+    expect(Reflect.construct(Collect, [1, ,]).tag).toBe("1|undefined");
+    expect(Reflect.construct(Collect, [, , ,]).tag).toBe(
+      "undefined|undefined|undefined",
+    );
+    expect(Reflect.construct(Collect, [1, , , 4]).tag).toBe(
+      "1|undefined|undefined|4",
+    );
+  });
+
   test("new.target is the class itself for normal new expression", () => {
     class Bar {
       constructor() {

--- a/tests/built-ins/callback-gc-roots.js
+++ b/tests/built-ins/callback-gc-roots.js
@@ -292,4 +292,61 @@ describe.runIf(hasGoccia)("native callback GC roots", () => {
 
     expect("abc".split(separator, 7)).toEqual(["abc", "7"]);
   });
+
+  // Holes in an argument array are resolved with Get (ES2026 §7.3.19 step 6b),
+  // so an inherited index accessor is user code running in the middle of
+  // building the argument list. Every argument already materialized has to stay
+  // rooted across that call: an argument the caller never stored anywhere else
+  // is reachable only from the list being built, and the churn after gc() is
+  // what makes a freed slot observable — the earlier argument comes back as
+  // whatever object landed in its memory.
+  test("argument list elements survive a GC run from an inherited index getter", () => {
+    const churn = (tag) => {
+      Goccia.gc();
+      Goccia.gc();
+      let total = 0;
+      for (const i of [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) {
+        const scratch = { a: i * 7.5, b: [i, i + 1], c: tag + i };
+        total += scratch.a + scratch.b[0];
+      }
+      return total;
+    };
+    const tags = (...args) =>
+      args.map((value) => (value && value.tag) || String(value)).join("|");
+
+    Object.defineProperty(Array.prototype, 0, {
+      get() {
+        return { tag: "first", pad: ["first", "first"] };
+      },
+      configurable: true,
+    });
+    Object.defineProperty(Array.prototype, 1, {
+      get() {
+        churn("second");
+        return { tag: "second", pad: ["second", "second"] };
+      },
+      configurable: true,
+    });
+
+    try {
+      expect(tags.apply(undefined, [,])).toBe("first");
+      expect(tags.apply(undefined, [, ,])).toBe("first|second");
+      expect(tags.apply(undefined, [, , 3])).toBe("first|second|3");
+      expect(tags.apply(undefined, [, , 3, 4])).toBe("first|second|3|4");
+      expect(tags.bind(undefined).apply(undefined, [, ,])).toBe("first|second");
+      expect(Reflect.apply(tags, undefined, [, ,])).toBe("first|second");
+
+      class Box {
+        constructor(...args) {
+          this.tag = tags(...args);
+        }
+      }
+
+      expect(Reflect.construct(Box, [, ,]).tag).toBe("first|second");
+      expect(new Box(...[, ,]).tag).toBe("first|second");
+    } finally {
+      delete Array.prototype[0];
+      delete Array.prototype[1];
+    }
+  });
 });


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Sparse arrays passed as apply-style argument lists now behave per spec in both modes. Two defects, one shared fix:
  - `Function.prototype.apply`'s 1–3-element fast path passed dense elements verbatim, leaking the engine's hole sentinel to the callee — the reported mode divergence (`fn.apply(null, [1,,3])` gave `1,,3` interpreted vs the spec-correct `1,undefined,3` in bytecode), also reachable in bytecode through a bound function or detached `Function.prototype.apply.call`.
  - `CreateListFromArrayLike`'s array fast path mapped holes to `undefined` without performing a `Get`, so inherited index accessors (`Array.prototype[1]` getters) were invisible to `apply`, `Reflect.apply`, and `Reflect.construct` in **both** modes. ES2026 §7.3.19 step 6b requires a `Get` — a hole resolves through the prototype chain.
- Both sites now read holes through a shared prototype-aware element helper, in ascending index order so observable getter invocation order matches the spec. Dense arrays keep the fast path (no per-element `Get` when there are no holes). Spread calls and the VM's own apply fast path were already correct and are untouched.
- Verified clauses via the project tc39 MCP: §20.2.3.1, §28.1.1/§28.1.2, §7.3.19, §10.1.8.1.
- The review pass hardened the design: the small-array fast paths are now gated to dense, hole-free, length-matching arrays so no guest code can ever run inside them — closing a GC use-after-free (getter results in unrooted locals), fixing the VM arm's descending getter-invocation order, restoring `LengthOfArrayLike` semantics for grown-length arrays (5-arg case passes with proto resolution; 2M-length throws the same RangeError as a plain array-like), and removing a second latent bytecode crash in the ≥4-argument register arm. Everything that can run guest code takes the rooted, ascending, length-honoring `CreateListFromArrayLike` path in both modes.

## Testing

- [x] Verified no regressions and confirmed the fixes in end-to-end tests — full suite green in both modes; `p-callintrinsics` differential suite extended to 20p/0f across interp/bytecode/bun with zero divergence; repo tests cover holes at every position, all-holes, `=== undefined` identity, bound/detached apply, `Reflect.apply`, `Reflect.construct`, inherited-accessor observability with getter counts and invocation ORDER, truncating getters, grown/huge lengths, and GC survival of argument elements when a getter collects (`tests/built-ins/callback-gc-roots.js`)
- [x] Documentation not impacted beyond corrected stale spec-clause numbers in comments
- [x] Mutation-checked three ways: reverting the hole fix yields an explicit mode-parity split; un-gating the fast path faults the GC test in both modes; restoring the VM's right-to-left reads fails the order tests bytecode-only
- [x] Perf-neutral for dense arrays (fast paths preserved)

Fixes the sparse-array divergence surfaced during the call/apply intrinsic-identity review one layer down.
