### PR TITLE
fix(interpreter): run instance elements when classes are constructed reflectively

### DIFF
--- a/docs/differential-testing.md
+++ b/docs/differential-testing.md
@@ -103,7 +103,20 @@ initializers live outside the constructor body, so a path that only runs the
 body produces an instance that looks plausible and is missing every declared
 field. Interpreted mode did exactly that until the shared Construct operation
 was routed into the same instantiation `new` uses, and the suite pins the
-newTarget, override-return, and `extends`-a-built-in shapes alongside it.
+newTarget and override-return shapes alongside it.
+
+Two shapes are deliberately absent. A class whose superclass chain reaches a
+built-in (`extends Array`, `extends Promise`) is a known interpreted-mode gap —
+the shared Construct operation declines it and builds it without instance
+elements, while `new` initializes them — so gating on bun would report a gap
+already tracked elsewhere. It is pinned in
+`tests/built-ins/Reflect/construct/native-chain-instance-elements.js`, which
+asserts that all the Construct routes agree with each other so that a partial
+fix cannot land unnoticed. `new.target` inside a field initializer is absent for
+the opposite reason: node, bun and goccia all agree it is `undefined` as a
+script, but under `bun test` 1.4.0 the same class body reports it defined, so
+gating would report bun's transpile as a goccia divergence. It is covered
+against node in `tests/built-ins/Reflect/construct/instance-elements.js`.
 
 `h-modulemock.test.js` and `i-modulemock-isolation.test.js` are a pair: the
 first mocks `./mods/mockable.js` with a `vi.mock` factory, the second mocks

--- a/docs/differential-testing.md
+++ b/docs/differential-testing.md
@@ -68,6 +68,7 @@ oracle instead of inheriting a default.
 | `n-nodemods.goccia.test.js` | language | skip | skip |
 | `o-asynccontext.test.js` | language | skip | gate |
 | `p-callintrinsics.test.js` | language | skip | gate |
+| `q-reflectconstruct.test.js` | language | skip | gate |
 
 `o-asynccontext.test.js` covers `node:async_hooks` propagation only, and stops
 there on purpose. Bun 1.3.14 does not honour the `defaultValue` or `name`
@@ -93,6 +94,16 @@ bytecode VM routes `.call`/`.apply`/`.bind` on a function receiver through call
 fast paths, and while those matched on the callee's *name* a user-defined member
 was silently redirected into the intrinsic in bytecode mode only. The suite fails
 in whichever mode stops distinguishing the two.
+
+`q-reflectconstruct.test.js` covers construction that does not go through the
+`new` operator — `Reflect.construct`, a proxy without a construct trap, a bound
+class — paired with the `new` spelling of the same class. Instance elements are
+what a second construction path drops: fields, private fields, and method
+initializers live outside the constructor body, so a path that only runs the
+body produces an instance that looks plausible and is missing every declared
+field. Interpreted mode did exactly that until the shared Construct operation
+was routed into the same instantiation `new` uses, and the suite pins the
+newTarget, override-return, and `extends`-a-built-in shapes alongside it.
 
 `h-modulemock.test.js` and `i-modulemock-isolation.test.js` are a pair: the
 first mocks `./mods/mockable.js` with a `vi.mock` factory, the second mocks

--- a/scripts/differential/q-reflectconstruct.test.js
+++ b/scripts/differential/q-reflectconstruct.test.js
@@ -1,0 +1,405 @@
+// `Reflect.construct` (and every other entry into the abstract Construct
+// operation: a proxy without a construct trap, a bound class, `new` through a
+// proxy) has to build the same instance the `new` operator does — instance
+// elements included. Field initializers, private fields, and method
+// initializers are the half that a second construction path is most likely to
+// skip, because they live outside the constructor body.
+//
+// Bun gates: this is ECMAScript class construction semantics, and the testing
+// API is incidental. Vitest is skipped for the same reason as the other
+// language suites. See the CLASSIFICATION entry in
+// scripts/test-cli-differential.ts.
+//
+// `new.target` inside a field initializer is left out even though node, bun and
+// goccia all agree on it as a script: under `bun test` 1.4.0 the same class
+// body reports a defined `new.target`, so gating on it would report bun's
+// transpile as a goccia divergence. It is covered against node in
+// tests/built-ins/Reflect/construct/instance-elements.js instead.
+
+const outerBinding = 7;
+
+describe("Reflect.construct initializes instance elements", () => {
+  test("base class fields", () => {
+    class Base {
+      a = 1;
+    }
+
+    expect(Reflect.construct(Base, []).a).toBe(1);
+  });
+
+  test("derived class fields land after the base class fields", () => {
+    class Base {
+      a = 1;
+    }
+    class Derived extends Base {
+      b = 2;
+    }
+
+    const instance = Reflect.construct(Derived, []);
+    expect(Object.keys(instance)).toEqual(["a", "b"]);
+    expect(instance.a).toBe(1);
+    expect(instance.b).toBe(2);
+  });
+
+  test("three levels of fields", () => {
+    class A {
+      a = 1;
+    }
+    class B extends A {
+      b = 2;
+    }
+    class C extends B {
+      c = 3;
+    }
+
+    expect(Object.keys(Reflect.construct(C, []))).toEqual(["a", "b", "c"]);
+  });
+
+  test("fields run before the constructor body", () => {
+    const order = [];
+    class Base {
+      a = (order.push("field"), 1);
+
+      constructor() {
+        order.push("body");
+      }
+    }
+
+    Reflect.construct(Base, []);
+    expect(order).toEqual(["field", "body"]);
+  });
+
+  test("a derived constructor sees only the base fields before super() returns", () => {
+    const order = [];
+    class Base {
+      a = (order.push("base-field"), 1);
+
+      constructor() {
+        order.push("base-body");
+      }
+    }
+    class Derived extends Base {
+      b = (order.push("derived-field"), 2);
+
+      constructor() {
+        order.push("before-super");
+        super();
+        order.push("after-super");
+      }
+    }
+
+    Reflect.construct(Derived, []);
+    expect(order).toEqual([
+      "before-super",
+      "base-field",
+      "base-body",
+      "derived-field",
+      "after-super",
+    ]);
+  });
+
+  test("an implicit derived constructor still initializes its own fields", () => {
+    class Base {
+      constructor() {
+        this.seenBeforeOwnFields = this.b;
+      }
+    }
+    class Derived extends Base {
+      b = 2;
+    }
+
+    const instance = Reflect.construct(Derived, []);
+    expect(instance.seenBeforeOwnFields).toBe(undefined);
+    expect(instance.b).toBe(2);
+  });
+
+  test("arguments reach an inherited constructor", () => {
+    class Base {
+      constructor(x) {
+        this.x = x;
+      }
+    }
+    class Derived extends Base {
+      b = 2;
+    }
+
+    const instance = Reflect.construct(Derived, [7]);
+    expect(instance.x).toBe(7);
+    expect(instance.b).toBe(2);
+  });
+
+  test("field initializers read the class definition environment", () => {
+    class Base {
+      v = outerBinding;
+    }
+
+    expect(Reflect.construct(Base, []).v).toBe(7);
+  });
+
+  test("a class expression closes over its factory's parameter", () => {
+    const make = (n) => class {
+      v = n;
+    };
+
+    expect(Reflect.construct(make(3), []).v).toBe(3);
+  });
+
+  test("computed field keys", () => {
+    const key = "dyn";
+    class Base {
+      [key] = 4;
+    }
+
+    expect(Reflect.construct(Base, []).dyn).toBe(4);
+  });
+
+  test("private fields", () => {
+    class Base {
+      #secret = 5;
+
+      reveal() {
+        return this.#secret;
+      }
+    }
+
+    expect(Reflect.construct(Base, []).reveal()).toBe(5);
+  });
+
+  test("private fields on both halves of a derived class", () => {
+    class Base {
+      #base = 5;
+
+      revealBase() {
+        return this.#base;
+      }
+    }
+    class Derived extends Base {
+      #derived = 6;
+
+      revealDerived() {
+        return this.#derived;
+      }
+    }
+
+    const instance = Reflect.construct(Derived, []);
+    expect(instance.revealBase()).toBe(5);
+    expect(instance.revealDerived()).toBe(6);
+  });
+
+  test("accessors see the initialized fields", () => {
+    class Base {
+      a = 1;
+
+      get double() {
+        return this.a * 2;
+      }
+    }
+
+    expect(Reflect.construct(Base, []).double).toBe(2);
+  });
+});
+
+describe("Reflect.construct with an explicit newTarget", () => {
+  test("newTarget supplies the prototype and the fields still run", () => {
+    class Base {
+      a = 1;
+    }
+    class Other {}
+
+    const instance = Reflect.construct(Base, [], Other);
+    expect(instance.a).toBe(1);
+    expect(Object.getPrototypeOf(instance)).toBe(Other.prototype);
+    expect(instance instanceof Other).toBe(true);
+    expect(instance instanceof Base).toBe(false);
+  });
+
+  test("a derived target keeps both halves of its fields under a foreign newTarget", () => {
+    class Base {
+      a = 1;
+    }
+    class Derived extends Base {
+      b = 2;
+    }
+    class Other {}
+
+    const instance = Reflect.construct(Derived, [], Other);
+    expect(Object.keys(instance)).toEqual(["a", "b"]);
+    expect(Object.getPrototypeOf(instance)).toBe(Other.prototype);
+  });
+
+  test("a subclass as newTarget for its own base", () => {
+    class Base {
+      a = 1;
+    }
+    class Derived extends Base {
+      b = 2;
+    }
+
+    const instance = Reflect.construct(Base, [], Derived);
+    expect(instance.a).toBe(1);
+    expect(instance.b).toBe(undefined);
+    expect(Object.getPrototypeOf(instance)).toBe(Derived.prototype);
+  });
+
+  test("an ordinary function as newTarget", () => {
+    class Base {
+      a = 1;
+    }
+    const marker = { tag: "F" };
+    function NewTarget() {}
+    NewTarget.prototype = marker;
+
+    const instance = Reflect.construct(Base, [], NewTarget);
+    expect(instance.a).toBe(1);
+    expect(Object.getPrototypeOf(instance)).toBe(marker);
+  });
+
+  test("a newTarget whose prototype is not an object falls back to Object.prototype", () => {
+    class Base {
+      a = 1;
+    }
+    function NewTarget() {}
+    NewTarget.prototype = 42;
+
+    const instance = Reflect.construct(Base, [], NewTarget);
+    expect(instance.a).toBe(1);
+    expect(Object.getPrototypeOf(instance)).toBe(Object.prototype);
+  });
+});
+
+describe("Reflect.construct override returns", () => {
+  test("a base constructor returning an object discards the initialized receiver", () => {
+    class Base {
+      a = 1;
+
+      constructor() {
+        return { x: 9 };
+      }
+    }
+
+    const instance = Reflect.construct(Base, []);
+    expect(instance.x).toBe(9);
+    expect(instance.a).toBe(undefined);
+    expect(instance instanceof Base).toBe(false);
+  });
+
+  test("a derived constructor returning an object discards both halves", () => {
+    class Base {
+      a = 1;
+    }
+    class Derived extends Base {
+      b = 2;
+
+      constructor() {
+        super();
+        return { x: 9 };
+      }
+    }
+
+    const instance = Reflect.construct(Derived, []);
+    expect(instance.x).toBe(9);
+    expect(instance.a).toBe(undefined);
+    expect(instance.b).toBe(undefined);
+  });
+
+  test("an override return keeps Object.prototype even under a newTarget", () => {
+    class Base {
+      constructor() {
+        return { x: 9 };
+      }
+    }
+    class Other {}
+
+    const instance = Reflect.construct(Base, [], Other);
+    expect(Object.getPrototypeOf(instance)).toBe(Object.prototype);
+  });
+
+  test("a base constructor's primitive return is ignored", () => {
+    class Base {
+      a = 1;
+
+      constructor() {
+        return 42;
+      }
+    }
+
+    expect(Reflect.construct(Base, []).a).toBe(1);
+  });
+
+  test("a derived constructor's primitive return throws", () => {
+    class Base {}
+    class Derived extends Base {
+      constructor() {
+        super();
+        return 42;
+      }
+    }
+
+    expect(() => Reflect.construct(Derived, [])).toThrow(TypeError);
+  });
+});
+
+describe("other entries into Construct build the same instance", () => {
+  test("a proxy without a construct trap forwards to the target", () => {
+    class Base {
+      a = 1;
+    }
+    class Derived extends Base {
+      b = 2;
+    }
+
+    const instance = Reflect.construct(new Proxy(Derived, {}), []);
+    expect(Object.keys(instance)).toEqual(["a", "b"]);
+  });
+
+  test("a construct trap that forwards through Reflect.construct", () => {
+    class Base {
+      a = 1;
+    }
+    const proxy = new Proxy(Base, {
+      construct(target, args, newTarget) {
+        return Reflect.construct(target, args, newTarget);
+      },
+    });
+
+    expect(new proxy().a).toBe(1);
+  });
+
+  test("a bound class merges bound arguments and keeps the fields", () => {
+    class Base {
+      a = 1;
+
+      constructor(x) {
+        this.x = x;
+      }
+    }
+    const Bound = Base.bind(null, 5);
+
+    const instance = Reflect.construct(Bound, []);
+    expect(instance.a).toBe(1);
+    expect(instance.x).toBe(5);
+    expect(instance instanceof Base).toBe(true);
+  });
+
+  test("`new` and Reflect.construct agree shape for shape", () => {
+    class Base {
+      a = 1;
+      #p = 2;
+
+      reveal() {
+        return this.#p;
+      }
+    }
+    class Derived extends Base {
+      b = 3;
+    }
+
+    const built = new Derived();
+    const reflected = Reflect.construct(Derived, []);
+    expect(Object.keys(reflected)).toEqual(Object.keys(built));
+    expect(reflected.a).toBe(built.a);
+    expect(reflected.b).toBe(built.b);
+    expect(reflected.reveal()).toBe(built.reveal());
+    expect(Object.getPrototypeOf(reflected)).toBe(Object.getPrototypeOf(built));
+  });
+});

--- a/scripts/test-cli-differential.ts
+++ b/scripts/test-cli-differential.ts
@@ -187,6 +187,15 @@ const CLASSIFICATION: Record<string, Classification> = {
   // and the testing API is incidental. Vitest is skipped for the same reason as
   // the other language suites.
   "p-callintrinsics.test.js": { kind: "language", bun: "gate", vitest: "skip" },
+  // Construction through the abstract Construct operation rather than through
+  // `new` — Reflect.construct, a proxy without a construct trap, a bound class
+  // — where the instance elements are the half a second construction path
+  // drops: every field, private field, and method initializer went missing in
+  // interpreted mode until that path was routed into the same instantiation
+  // `new` uses. Bun gates: this is ECMAScript class construction semantics,
+  // and the testing API is incidental. Vitest is skipped for the same reason as
+  // the other language suites.
+  "q-reflectconstruct.test.js": { kind: "language", bun: "gate", vitest: "skip" },
 };
 
 type Verdict = {

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -215,6 +215,7 @@ uses
   Goccia.Intrinsics.FunctionObjects,
   Goccia.Keywords.Reserved,
   Goccia.MemoryLimit,
+  Goccia.Realm,
   Goccia.SourcePipeline,
   Goccia.StackLimit,
   Goccia.Timeout,
@@ -8031,6 +8032,32 @@ begin
     Result := AFallbackScope;
 end;
 
+// The scope is not the only thing a field initializer inherits from the class
+// definition rather than from the construction site. `import()` resolves its
+// specifier against, and `import.meta.url` reports, the module the code was
+// written in — TGocciaFunctionValue gets that from its own FSourceFilePath
+// rather than from its caller, and a class body is code outside any method,
+// so it needs the same treatment. Constructing a class exported by another
+// module otherwise resolved its field initializers' imports against the
+// importing file.
+procedure ApplyClassDefinitionSourceContext(
+  const AClassValue: TGocciaClassValue;
+  var AContext: TGocciaEvaluationContext);
+begin
+  if not Assigned(AClassValue) then
+    Exit;
+  if AClassValue.DefinitionSourcePath <> '' then
+    AContext.CurrentFilePath := AClassValue.DefinitionSourcePath;
+  if Assigned(AClassValue.DefinitionScope) then
+  begin
+    AContext.LoadModule := AClassValue.DefinitionScope.LoadModule;
+    AContext.LoadModuleSource := AClassValue.DefinitionScope.LoadModuleSource;
+    AContext.LoadDeferredModule :=
+      AClassValue.DefinitionScope.LoadDeferredModule;
+    AContext.ResolveModuleURL := AClassValue.DefinitionScope.ResolveModuleURL;
+  end;
+end;
+
 procedure InitializeInstanceProperties(const AInstance: TGocciaInstanceValue; const AClassValue: TGocciaClassValue; const AContext: TGocciaEvaluationContext);
 var
   PropertyValue: TGocciaValue;
@@ -8046,6 +8073,7 @@ begin
     ClassInitializerScopeParent(AClassValue, AContext.Scope), AClassValue);
   LocalScope.ThisValue := AInstance;
   LocalContext.Scope := LocalScope;
+  ApplyClassDefinitionSourceContext(AClassValue, LocalContext);
 
   { ES2026 §7.3.33 InitializeInstanceElements only ever defines the fields of
     the one class it is handed. A superclass initializes its own fields inside
@@ -9432,6 +9460,11 @@ begin
     named class), so remember it: the initializers must see it later, no
     matter which scope calls `new`. }
   ClassValue.DefinitionScope := AContext.Scope;
+  { And the defining file alongside it, for the same reason a function value
+    keeps FSourceFilePath: `import()` and `import.meta` in a field initializer
+    resolve against the file the class was written in, not against whatever
+    file is running the construction. }
+  ClassValue.DefinitionSourcePath := AContext.CurrentFilePath;
   ClassRoots.Add(ClassValue);
   if not AContext.HideFunctionSourceText then
     ClassValue.SetSourceText(AClassDef.SourceText);
@@ -11120,6 +11153,7 @@ begin
     ClassInitializerScopeParent(AClassValue, AContext.Scope), AClassValue);
   InitScope.ThisValue := AInstance;
   InitContext.Scope := InitScope;
+  ApplyClassDefinitionSourceContext(AClassValue, InitContext);
 
   { Field initializers are arbitrary guest code and they run against this
     scope, which binds `this` to the instance and is pointed at by nothing —
@@ -11413,6 +11447,13 @@ end;
 // Reports whether constructing this class ends up allocating a built-in
 // receiver: a native intrinsic prototype or a linked native super constructor
 // anywhere up the superclass chain.
+//
+// The walk reads FSuperClass, which is resolved once at
+// ClassDefinitionEvaluation time. A later Object.setPrototypeOf on the
+// constructor therefore does not move this answer — deliberately: FSuperClass
+// is also what Instantiate and InstantiateClass drive construction from, so a
+// guard that disagreed with them would route a class into a path that then
+// built it from the other chain.
 function ClassChainReachesNativeConstruction(
   const AClassValue: TGocciaClassValue): Boolean;
 var
@@ -11448,15 +11489,35 @@ end;
 // the `new` operator applies, so both entry points agree on which classes
 // InstantiateClass may drive.
 //
+// TGocciaVM.ConstructValue makes this same decision for bytecode `new`, with a
+// guard that differs on three axes — eligibility, how far up the chain native
+// markers are looked for, and which environment the context is anchored to.
+// They are documented at that hook, together with the measurement showing why
+// tightening it to match this one would make bytecode worse rather than
+// better.
+//
 // A chain that reaches a built-in constructor stays on Instantiate, which is
 // what TGocciaVM.ConstructValue already does for the same shapes. Only
 // Instantiate implements the §10.1.13 GetPrototypeFromConstructor ordering
 // those constructors need — ArrayBuffer, SharedArrayBuffer and DataView
 // validate their arguments before newTarget.prototype may be observed — and
 // only Instantiate builds the native receiver exactly once for a derived class
-// whose constructor calls super() explicitly. Such a class's own fields are
-// still skipped here; that gap belongs to the native construction path, which
-// drops them for `new` as well, and not to this redirect.
+// whose constructor calls super() explicitly, which is a live bug in
+// InstantiateClass (the receiver is pre-created by the WalkClass loop and then
+// built again by super(), running a Promise executor twice).
+//
+// The cost of declining is precise, and larger than "Reflect.construct is
+// imperfect": such a class's instance elements are skipped by EVERY route
+// through ConstructValue, in interpreted mode only. `new` is NOT affected —
+// EvaluateNewExpression calls InstantiateClass directly and initializes them
+// — so the gap is reachable without writing Reflect at all, through any
+// species construction: SubclassOfArray.from(...) / .map(...) and
+// SubclassOfPromise.resolve(...).then(...) all hand back an instance whose own
+// fields are undefined. Bytecode mode is correct for all of them, so this is
+// also a mode divergence. Closing it means fixing InstantiateClass's two gaps
+// above, not widening this guard; the current behaviour is pinned in
+// tests/built-ins/Reflect/construct/native-chain-instance-elements.js
+// so that a partial fix cannot land unnoticed.
 function RedirectEvaluatorClassConstruct(const ATarget: TGocciaValue;
   const AArguments: TGocciaArgumentsCollection;
   const ANewTarget: TGocciaValue;
@@ -11465,6 +11526,8 @@ var
   ClassValue: TGocciaClassValue;
   DefinitionScope: TGocciaScope;
   EvalContext: TGocciaEvaluationContext;
+  PreviousRealm: TGocciaRealm;
+  SwapRealm: Boolean;
 begin
   Result := False;
   AResult := nil;
@@ -11485,18 +11548,51 @@ begin
   { The class environment is the only context this construction can be
     anchored to — the caller is a native function with none of its own — and
     it is the one §15.7.10 ClassFieldDefinitionEvaluation step 2b names as the
-    initializers' [[Environment]] anyway. }
+    initializers' [[Environment]] anyway. Every field is filled the way
+    TGocciaFunctionValue builds a call context out of its closure: a field
+    initializer is guest code, so a context missing a host callback is not a
+    degraded context but a crashing one — TGocciaImportCallExpression calls
+    AContext.LoadModule with no assigned-check, and CurrentFilePath is what
+    `import()` and `import.meta` resolve against and what coverage and
+    call-stack frames are attributed to.
+
+    ApplyClassDefinitionSourceContext repairs the same four callbacks and the
+    file path again around each initializer run, so removing either half alone
+    leaves the tests passing — the crash needs both gone. Neither is therefore
+    dead code to be tidied away: this one covers everything InstantiateClass
+    does with the context outside an initializer run, and that one covers a
+    superclass initialized from a context this function never built. }
   EvalContext := Default(TGocciaEvaluationContext);
   EvalContext.Realm := ClassValue.CreationRealm;
   EvalContext.Scope := DefinitionScope;
   EvalContext.OnError := DefinitionScope.OnError;
+  EvalContext.LoadModule := DefinitionScope.LoadModule;
+  EvalContext.LoadModuleSource := DefinitionScope.LoadModuleSource;
+  EvalContext.LoadDeferredModule := DefinitionScope.LoadDeferredModule;
+  EvalContext.ResolveModuleURL := DefinitionScope.ResolveModuleURL;
+  EvalContext.CurrentFilePath := ClassValue.DefinitionSourcePath;
   EvalContext.CoverageEnabled := (TGocciaCoverageTracker.Instance <> nil) and
     TGocciaCoverageTracker.Instance.Enabled;
   EvalContext.StrictTypes := DefinitionScope.EffectiveStrictTypes;
   EvalContext.NonStrictMode := DefinitionScope.EffectiveNonStrictMode;
   EvalContext.CompatibilityNonStrictMode := EvalContext.NonStrictMode;
 
-  AResult := InstantiateClass(ClassValue, AArguments, EvalContext, ANewTarget);
+  { Same realm discipline as TGocciaClassValue.Instantiate: the intrinsics a
+    field initializer allocates (object and array literals, errors) come from
+    the realm the class was defined in, not from whichever realm called
+    Reflect.construct. }
+  PreviousRealm := CurrentRealm;
+  SwapRealm := Assigned(ClassValue.CreationRealm) and
+    (ClassValue.CreationRealm <> PreviousRealm);
+  if SwapRealm then
+    SetCurrentRealm(ClassValue.CreationRealm);
+  try
+    AResult := InstantiateClass(ClassValue, AArguments, EvalContext,
+      ANewTarget);
+  finally
+    if SwapRealm then
+      SetCurrentRealm(PreviousRealm);
+  end;
   Result := True;
 end;
 

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -11410,6 +11410,96 @@ begin
   Result := Instance;
 end;
 
+// Reports whether constructing this class ends up allocating a built-in
+// receiver: a native intrinsic prototype or a linked native super constructor
+// anywhere up the superclass chain.
+function ClassChainReachesNativeConstruction(
+  const AClassValue: TGocciaClassValue): Boolean;
+var
+  WalkClass: TGocciaClassValue;
+begin
+  WalkClass := AClassValue;
+  while Assigned(WalkClass) do
+  begin
+    if Assigned(WalkClass.NativeInstanceDefaultPrototype) or
+       Assigned(WalkClass.NativeSuperConstructor) then
+      Exit(True);
+    WalkClass := WalkClass.SuperClass;
+  end;
+  Result := False;
+end;
+
+// ES2026 §7.3.14 Construct(F, argumentsList, newTarget) for a class the
+// tree-walk evaluator built. Reflect.construct (§28.1.2), the proxy
+// [[Construct]] fallback (§10.5.13), construction through a bound wrapper
+// (§10.4.1.2), and species construction all funnel through the shared
+// ConstructValue, which cannot reach the AST field tables that §7.3.33
+// InitializeInstanceElements needs — it has no evaluation context to run them
+// in. Left alone they land on TGocciaClassValue.Instantiate, which runs the
+// constructor body and nothing else, so every field, private field, and
+// method initializer is dropped. Redirect them into the same InstantiateClass
+// the `new` operator uses, which initializes instance elements at the §10.2.2
+// step 5b (base) and §13.3.7.1 step 11 (derived) points.
+//
+// DefinitionScope selects exactly the evaluator-built classes: §15.7.14
+// ClassDefinitionEvaluation records the class environment there, and nothing
+// else does — built-in class values and bytecode class values carry none, so
+// they keep their own [[Construct]]. UsesOwnInstantiation is the same guard
+// the `new` operator applies, so both entry points agree on which classes
+// InstantiateClass may drive.
+//
+// A chain that reaches a built-in constructor stays on Instantiate, which is
+// what TGocciaVM.ConstructValue already does for the same shapes. Only
+// Instantiate implements the §10.1.13 GetPrototypeFromConstructor ordering
+// those constructors need — ArrayBuffer, SharedArrayBuffer and DataView
+// validate their arguments before newTarget.prototype may be observed — and
+// only Instantiate builds the native receiver exactly once for a derived class
+// whose constructor calls super() explicitly. Such a class's own fields are
+// still skipped here; that gap belongs to the native construction path, which
+// drops them for `new` as well, and not to this redirect.
+function RedirectEvaluatorClassConstruct(const ATarget: TGocciaValue;
+  const AArguments: TGocciaArgumentsCollection;
+  const ANewTarget: TGocciaValue;
+  out AResult: TGocciaValue): Boolean;
+var
+  ClassValue: TGocciaClassValue;
+  DefinitionScope: TGocciaScope;
+  EvalContext: TGocciaEvaluationContext;
+begin
+  Result := False;
+  AResult := nil;
+
+  if not (ATarget is TGocciaClassValue) then
+    Exit;
+
+  ClassValue := TGocciaClassValue(ATarget);
+  if ClassValue.UsesOwnInstantiation then
+    Exit;
+  if ClassChainReachesNativeConstruction(ClassValue) then
+    Exit;
+
+  DefinitionScope := ClassValue.DefinitionScope;
+  if not Assigned(DefinitionScope) then
+    Exit;
+
+  { The class environment is the only context this construction can be
+    anchored to — the caller is a native function with none of its own — and
+    it is the one §15.7.10 ClassFieldDefinitionEvaluation step 2b names as the
+    initializers' [[Environment]] anyway. }
+  EvalContext := Default(TGocciaEvaluationContext);
+  EvalContext.Realm := ClassValue.CreationRealm;
+  EvalContext.Scope := DefinitionScope;
+  EvalContext.OnError := DefinitionScope.OnError;
+  EvalContext.CoverageEnabled := (TGocciaCoverageTracker.Instance <> nil) and
+    TGocciaCoverageTracker.Instance.Enabled;
+  EvalContext.StrictTypes := DefinitionScope.EffectiveStrictTypes;
+  EvalContext.NonStrictMode := DefinitionScope.EffectiveNonStrictMode;
+  EvalContext.CompatibilityNonStrictMode := EvalContext.NonStrictMode;
+
+  AResult := InstantiateClass(ClassValue, AArguments, EvalContext, ANewTarget);
+  Result := True;
+end;
+
 // Template literals without real interpolations are returned as static strings.
 // The parser pre-segments templates with interpolations into
 // TGocciaTemplateWithInterpolationExpression, so this function only handles
@@ -13052,5 +13142,8 @@ begin
     end;
   end;
 end;
+
+initialization
+  RegisterClassConstructRedirectHook(RedirectEvaluatorClassConstruct);
 
 end.

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -9369,6 +9369,35 @@ begin
     Exit;
   end;
 
+  // A plain class value reaching the VM was built by the tree-walk evaluator
+  // (a bytecode class is TGocciaVMClassValue, handled above), so it has to be
+  // constructed by InstantiateClass. RedirectEvaluatorClassConstruct in
+  // Goccia.Evaluator.pas makes the same decision for the shared ConstructValue
+  // that Reflect.construct and species construction use. The two guards are
+  // deliberately NOT identical, on three axes:
+  //
+  //  1. Eligibility. Here: SourceText <> ''. There: DefinitionScope assigned.
+  //     Both mean "written in source and built by the evaluator", but source
+  //     text is suppressed for shim modules (Goccia.Shims.pas sets
+  //     HideFunctionSourceText), so a shim-defined class is declined here and
+  //     admitted there.
+  //  2. Native chain. Here: only this class's own native markers. There: a
+  //     walk of the whole superclass chain. This guard is the laxer one, and
+  //     measurably so — for `class A extends Promise {...}; class B extends A
+  //     {...}`, B carries no native marker of its own, so it lands in
+  //     InstantiateClass and loses A's fields. Tightening this to the chain
+  //     walk does NOT fix that: Instantiate runs no instance elements at all
+  //     for an implicit constructor, so B would lose its own fields too. The
+  //     fix belongs in InstantiateClass (see the redirect's comment), which is
+  //     why this guard is left as it is rather than harmonized.
+  //  3. Anchor. Here: the running VM scope and the VM's own module callbacks
+  //     and current module path — the calling environment. There: the class's
+  //     DefinitionScope and defining file, because a native caller has no
+  //     environment of its own to offer. §15.7.10 step 2b wants the defining
+  //     one, and ClassInitializerScopeParent already prefers DefinitionScope
+  //     for the initializer scope either way; what is left is the host
+  //     callbacks, which the bytecode executor swaps per module while linking
+  //     and which therefore have to come from the VM here.
   if AConstructor is TGocciaClassValue then
   begin
     ClassConstructor := TGocciaClassValue(AConstructor);

--- a/source/units/Goccia.Values.ClassValue.pas
+++ b/source/units/Goccia.Values.ClassValue.pas
@@ -78,6 +78,14 @@ type
     // whose [[Environment]] is that environment, not the environment of
     // whatever scope happens to run `new`.
     FDefinitionScope: TGocciaScope;
+    // The script or module path that was current when this class was
+    // evaluated. TGocciaFunctionValue keeps the same thing as
+    // FSourceFilePath, for the same reasons: `import()` and `import.meta`
+    // resolve against the *defining* file, and coverage and call-stack frames
+    // are attributed to it. A class body runs code — field initializers and
+    // static blocks — outside any of its own methods, so the class value has
+    // to carry it too.
+    FDefinitionSourcePath: string;
     function GetPropertyGetter(const AName: string): TGocciaFunctionBase; {$IFDEF FPC}inline;{$ENDIF}
     function GetPropertySetter(const AName: string): TGocciaFunctionBase; {$IFDEF FPC}inline;{$ENDIF}
     function GetStaticPropertyGetter(const AName: string): TGocciaFunctionBase; {$IFDEF FPC}inline;{$ENDIF}
@@ -191,6 +199,8 @@ type
     property Name: string read FName;
     property DefinitionScope: TGocciaScope read FDefinitionScope
       write FDefinitionScope;
+    property DefinitionSourcePath: string read FDefinitionSourcePath
+      write FDefinitionSourcePath;
     property SourceText: string read FSourceText write FSourceText;
     property CreationRealm: TGocciaRealm read FCreationRealm;
     property PrivateBrandToken: string read FPrivateBrandToken;
@@ -782,6 +792,7 @@ begin
   FNameDeleted := False;
   FLengthDeleted := False;
   FDefinitionScope := nil;
+  FDefinitionSourcePath := '';
   if Assigned(FSuperClass) then
     FClassPrototype.Prototype := FSuperClass.Prototype
   else if TGocciaObjectValue.SharedObjectPrototype <> nil then

--- a/source/units/Goccia.Values.FunctionBase.pas
+++ b/source/units/Goccia.Values.FunctionBase.pas
@@ -198,6 +198,16 @@ procedure RegisterProxyDispatchHooks(
   const AGetFunctionRealm: TGocciaProxyGetFunctionRealmHook);
 procedure RegisterFunctionConstructRedirectHook(
   const AHook: TGocciaFunctionConstructRedirectHook);
+// A class value built by the tree-walk evaluator keeps its instance elements
+// as AST field tables that only the evaluator can run, so its [[Construct]]
+// needs an evaluation context that TGocciaClassValue.Instantiate has no way
+// to produce. The evaluator registers this redirect so that every
+// Construct(F, args, newTarget) entry point — Reflect.construct, the proxy
+// [[Construct]] fallback, species construction — reaches the same
+// InstantiateClass the `new` operator does, instead of the initializer-less
+// fallback.
+procedure RegisterClassConstructRedirectHook(
+  const AHook: TGocciaFunctionConstructRedirectHook);
 
 // ES2026 §10.2.9 SetFunctionName property-key formatting shared by
 // interpreter and bytecode named-evaluation paths.
@@ -241,6 +251,7 @@ var
   GProxyGetPrototypeHook: TGocciaProxyGetPrototypeHook;
   GProxyGetFunctionRealmHook: TGocciaProxyGetFunctionRealmHook;
   GFunctionConstructRedirectHook: TGocciaFunctionConstructRedirectHook;
+  GClassConstructRedirectHook: TGocciaFunctionConstructRedirectHook;
 
 procedure RegisterProxyDispatchHooks(
   const APredicate: TGocciaProxyPredicate;
@@ -260,6 +271,12 @@ procedure RegisterFunctionConstructRedirectHook(
   const AHook: TGocciaFunctionConstructRedirectHook);
 begin
   GFunctionConstructRedirectHook := AHook;
+end;
+
+procedure RegisterClassConstructRedirectHook(
+  const AHook: TGocciaFunctionConstructRedirectHook);
+begin
+  GClassConstructRedirectHook := AHook;
 end;
 
 function IsRegisteredProxyValue(const AValue: TGocciaValue): Boolean; {$IFDEF FPC}inline;{$ENDIF}
@@ -450,8 +467,19 @@ begin
       Result := GProxyConstructHook(EffectiveTarget, WorkingArgs,
         EffectiveNewTarget)
     else if EffectiveTarget is TGocciaClassValue then
-      Result := TGocciaClassValue(EffectiveTarget).Instantiate(WorkingArgs,
-        EffectiveNewTarget)
+    begin
+      // ES2026 §10.2.2 step 5b / §7.3.33 InitializeInstanceElements: the
+      // instance elements of a class defined in source have to be
+      // initialized here, and only the evaluator can run them. Without the
+      // redirect this fell through to an Instantiate that runs the
+      // constructor body alone, so every field, private field, and method
+      // initializer was silently dropped.
+      if not (Assigned(GClassConstructRedirectHook) and
+              GClassConstructRedirectHook(EffectiveTarget, WorkingArgs,
+                EffectiveNewTarget, Result)) then
+        Result := TGocciaClassValue(EffectiveTarget).Instantiate(WorkingArgs,
+          EffectiveNewTarget);
+    end
     else if EffectiveTarget is TGocciaNativeFunctionValue then
       Result := TGocciaNativeFunctionValue(EffectiveTarget).Construct(WorkingArgs,
         EffectiveNewTarget)

--- a/tests/built-ins/Reflect/construct/instance-elements.js
+++ b/tests/built-ins/Reflect/construct/instance-elements.js
@@ -1,0 +1,317 @@
+/*---
+description: Reflect.construct runs InitializeInstanceElements per ES2026 §10.2.2 step 5b and §13.3.7.1 step 11
+features: [Reflect]
+---*/
+
+const outerBinding = 7;
+
+describe("Reflect.construct initializes instance elements", () => {
+  test("base class fields", () => {
+    class Base {
+      a = 1;
+    }
+    expect(Reflect.construct(Base, []).a).toBe(1);
+  });
+
+  test("derived class fields land after the base class fields", () => {
+    class Base {
+      a = 1;
+    }
+    class Derived extends Base {
+      b = 2;
+    }
+    const instance = Reflect.construct(Derived, []);
+    expect(Object.keys(instance)).toEqual(["a", "b"]);
+  });
+
+  test("three levels of fields", () => {
+    class A {
+      a = 1;
+    }
+    class B extends A {
+      b = 2;
+    }
+    class C extends B {
+      c = 3;
+    }
+    expect(Object.keys(Reflect.construct(C, []))).toEqual(["a", "b", "c"]);
+  });
+
+  test("fields run before the constructor body", () => {
+    const order = [];
+    class Base {
+      a = (order.push("field"), 1);
+      constructor() {
+        order.push("body");
+      }
+    }
+    Reflect.construct(Base, []);
+    expect(order).toEqual(["field", "body"]);
+  });
+
+  test("a derived constructor sees only the base fields before super() returns", () => {
+    const order = [];
+    class Base {
+      a = (order.push("base-field"), 1);
+      constructor() {
+        order.push("base-body");
+      }
+    }
+    class Derived extends Base {
+      b = (order.push("derived-field"), 2);
+      constructor() {
+        order.push("before-super");
+        super();
+        order.push("after-super");
+      }
+    }
+    Reflect.construct(Derived, []);
+    expect(order).toEqual([
+      "before-super",
+      "base-field",
+      "base-body",
+      "derived-field",
+      "after-super",
+    ]);
+  });
+
+  test("an implicit derived constructor still initializes its own fields", () => {
+    class Base {
+      constructor() {
+        this.seenBeforeOwnFields = this.b;
+      }
+    }
+    class Derived extends Base {
+      b = 2;
+    }
+    const instance = Reflect.construct(Derived, []);
+    expect(instance.seenBeforeOwnFields).toBe(undefined);
+    expect(instance.b).toBe(2);
+  });
+
+  test("arguments reach an inherited constructor", () => {
+    class Base {
+      constructor(x) {
+        this.x = x;
+      }
+    }
+    class Derived extends Base {
+      b = 2;
+    }
+    const instance = Reflect.construct(Derived, [7]);
+    expect(instance.x).toBe(7);
+    expect(instance.b).toBe(2);
+  });
+
+  test("field initializers read the class definition environment", () => {
+    class Base {
+      v = outerBinding;
+    }
+    expect(Reflect.construct(Base, []).v).toBe(7);
+  });
+
+  test("a class expression closes over its factory's parameter", () => {
+    const make = (n) =>
+      class {
+        v = n;
+      };
+    expect(Reflect.construct(make(3), []).v).toBe(3);
+  });
+
+  test("computed field keys", () => {
+    const key = "dyn";
+    class Base {
+      [key] = 4;
+    }
+    expect(Reflect.construct(Base, []).dyn).toBe(4);
+  });
+
+  test("private fields", () => {
+    class Base {
+      #secret = 5;
+      reveal() {
+        return this.#secret;
+      }
+    }
+    expect(Reflect.construct(Base, []).reveal()).toBe(5);
+  });
+
+  test("private fields on both halves of a derived class", () => {
+    class Base {
+      #base = 5;
+      revealBase() {
+        return this.#base;
+      }
+    }
+    class Derived extends Base {
+      #derived = 6;
+      revealDerived() {
+        return this.#derived;
+      }
+    }
+    const instance = Reflect.construct(Derived, []);
+    expect(instance.revealBase()).toBe(5);
+    expect(instance.revealDerived()).toBe(6);
+  });
+
+  test("accessors see the initialized fields", () => {
+    class Base {
+      a = 1;
+      get double() {
+        return this.a * 2;
+      }
+    }
+    expect(Reflect.construct(Base, []).double).toBe(2);
+  });
+});
+
+describe("Reflect.construct with an explicit newTarget", () => {
+  test("newTarget supplies the prototype and the fields still run", () => {
+    class Base {
+      a = 1;
+    }
+    class Other {}
+    const instance = Reflect.construct(Base, [], Other);
+    expect(instance.a).toBe(1);
+    expect(Object.getPrototypeOf(instance)).toBe(Other.prototype);
+    expect(instance instanceof Other).toBe(true);
+    expect(instance instanceof Base).toBe(false);
+  });
+
+  test("a derived target keeps both halves of its fields under a foreign newTarget", () => {
+    class Base {
+      a = 1;
+    }
+    class Derived extends Base {
+      b = 2;
+    }
+    class Other {}
+    const instance = Reflect.construct(Derived, [], Other);
+    expect(Object.keys(instance)).toEqual(["a", "b"]);
+    expect(Object.getPrototypeOf(instance)).toBe(Other.prototype);
+  });
+
+  test("a subclass as newTarget for its own base", () => {
+    class Base {
+      a = 1;
+    }
+    class Derived extends Base {
+      b = 2;
+    }
+    const instance = Reflect.construct(Base, [], Derived);
+    expect(instance.a).toBe(1);
+    expect(instance.b).toBe(undefined);
+    expect(Object.getPrototypeOf(instance)).toBe(Derived.prototype);
+  });
+
+  test("new.target inside a field initializer is undefined", () => {
+    class Base {
+      t = new.target;
+    }
+    expect(Reflect.construct(Base, []).t).toBe(undefined);
+  });
+});
+
+describe("Reflect.construct override returns discard the initialized receiver", () => {
+  test("base class", () => {
+    class Base {
+      a = 1;
+      constructor() {
+        return { x: 9 };
+      }
+    }
+    const instance = Reflect.construct(Base, []);
+    expect(instance.x).toBe(9);
+    expect(instance.a).toBe(undefined);
+  });
+
+  test("derived class discards both halves", () => {
+    class Base {
+      a = 1;
+    }
+    class Derived extends Base {
+      b = 2;
+      constructor() {
+        super();
+        return { x: 9 };
+      }
+    }
+    const instance = Reflect.construct(Derived, []);
+    expect(instance.x).toBe(9);
+    expect(instance.a).toBe(undefined);
+    expect(instance.b).toBe(undefined);
+  });
+
+  test("an override return keeps Object.prototype even under a newTarget", () => {
+    class Base {
+      constructor() {
+        return { x: 9 };
+      }
+    }
+    class Other {}
+    expect(Object.getPrototypeOf(Reflect.construct(Base, [], Other))).toBe(
+      Object.prototype,
+    );
+  });
+});
+
+describe("other entries into Construct build the same instance", () => {
+  test("a proxy without a construct trap forwards to the target", () => {
+    class Base {
+      a = 1;
+    }
+    class Derived extends Base {
+      b = 2;
+    }
+    expect(Object.keys(Reflect.construct(new Proxy(Derived, {}), []))).toEqual([
+      "a",
+      "b",
+    ]);
+  });
+
+  test("a construct trap that forwards through Reflect.construct", () => {
+    class Base {
+      a = 1;
+    }
+    const proxy = new Proxy(Base, {
+      construct(target, args, newTarget) {
+        return Reflect.construct(target, args, newTarget);
+      },
+    });
+    expect(new proxy().a).toBe(1);
+  });
+
+  test("a bound class merges bound arguments and keeps the fields", () => {
+    class Base {
+      a = 1;
+      constructor(x) {
+        this.x = x;
+      }
+    }
+    const Bound = Base.bind(null, 5);
+    const instance = Reflect.construct(Bound, []);
+    expect(instance.a).toBe(1);
+    expect(instance.x).toBe(5);
+    expect(instance instanceof Base).toBe(true);
+  });
+
+  test("`new` and Reflect.construct agree shape for shape", () => {
+    class Base {
+      a = 1;
+      #p = 2;
+      reveal() {
+        return this.#p;
+      }
+    }
+    class Derived extends Base {
+      b = 3;
+    }
+    const built = new Derived();
+    const reflected = Reflect.construct(Derived, []);
+    expect(Object.keys(reflected)).toEqual(Object.keys(built));
+    expect(reflected.a).toBe(built.a);
+    expect(reflected.b).toBe(built.b);
+    expect(reflected.reveal()).toBe(built.reveal());
+    expect(Object.getPrototypeOf(reflected)).toBe(Object.getPrototypeOf(built));
+  });
+});

--- a/tests/built-ins/Reflect/construct/native-chain-instance-elements.js
+++ b/tests/built-ins/Reflect/construct/native-chain-instance-elements.js
@@ -1,0 +1,136 @@
+/*---
+description: Every route through the abstract Construct operation treats a class whose chain reaches a built-in identically (known gap, see below)
+features: [Reflect]
+---*/
+
+/*
+  KNOWN GAP, pinned deliberately.
+
+  A class whose superclass chain reaches a built-in constructor is declined by
+  RedirectEvaluatorClassConstruct (Goccia.Evaluator.pas) and built by
+  TGocciaClassValue.Instantiate instead, which runs no instance elements. In
+  interpreted mode that means every route through the abstract Construct
+  operation — Reflect.construct, a proxy without a construct trap, a bound
+  class, and every species construction (Array.from, Array.prototype.map,
+  Promise.prototype.then, ...) — hands back an instance whose declared fields
+  are undefined. `new` is unaffected: it calls InstantiateClass directly.
+  Bytecode mode is correct throughout, so this is also a mode divergence.
+
+  The guard cannot simply be widened: InstantiateClass resolves
+  newTarget.prototype before ArrayBuffer/SharedArrayBuffer/DataView validate
+  their arguments, and it builds the native receiver twice for a derived class
+  whose constructor calls super() explicitly (a Promise executor runs twice).
+  Both have to be fixed there first.
+
+  So these tests do not assert a value that differs per mode. They assert the
+  property that must survive any fix, partial or complete: all the Construct
+  routes agree with each other, and the answer is either "the field is
+  initialized" (fixed, and what `new` already does) or "no route initializes
+  it" (today's gap). A fix that reaches Reflect.construct but leaves species
+  construction behind — or the reverse — fails here.
+*/
+
+const routeResults = (makeSubclass, read) => {
+  const Direct = makeSubclass();
+  const Proxied = makeSubclass();
+  const Bound = makeSubclass();
+  return {
+    reflect: read(Reflect.construct(Direct, [])),
+    proxy: read(Reflect.construct(new Proxy(Proxied, {}), [])),
+    bound: read(Reflect.construct(Bound.bind(null), [])),
+  };
+};
+
+const allAgree = (values) => values.every((v) => v === values[0]);
+
+describe("Array subclass instance elements across Construct routes", () => {
+  const makeArraySubclass = () =>
+    class Tagged extends Array {
+      tag = "t";
+    };
+
+  test("`new` initializes the field in both modes", () => {
+    const Tagged = makeArraySubclass();
+    expect(new Tagged().tag).toBe("t");
+    expect(Array.isArray(new Tagged())).toBe(true);
+  });
+
+  test("Reflect.construct, proxy and bound routes agree with each other", () => {
+    const results = routeResults(makeArraySubclass, (o) => o.tag);
+    const values = [results.reflect, results.proxy, results.bound];
+    expect(allAgree(values)).toBe(true);
+    // Either all initialized (fixed) or none (the pinned gap).
+    expect(values[0] === "t" || values[0] === undefined).toBe(true);
+  });
+
+  test("species construction agrees with the other Construct routes", () => {
+    const Tagged = makeArraySubclass();
+    const fromTag = Tagged.from([1, 2]).tag;
+    const ofTag = Tagged.of(1, 2).tag;
+    const mapTag = Tagged.from([1, 2]).map((x) => x).tag;
+    const reflectTag = Reflect.construct(Tagged, []).tag;
+
+    expect(allAgree([fromTag, ofTag, mapTag, reflectTag])).toBe(true);
+    expect(reflectTag === "t" || reflectTag === undefined).toBe(true);
+  });
+
+  test("the built-in half of the instance is correct on every route", () => {
+    const Tagged = makeArraySubclass();
+    expect(Array.isArray(Reflect.construct(Tagged, []))).toBe(true);
+    expect(Tagged.from([1, 2]).length).toBe(2);
+    expect(Tagged.of(1, 2)[1]).toBe(2);
+    expect(Tagged.from([1, 2]).map((x) => x * 2)[0]).toBe(2);
+  });
+});
+
+describe("Promise subclass instance elements across Construct routes", () => {
+  const makePromiseSubclass = () =>
+    class Tagged extends Promise {
+      tag = "t";
+    };
+
+  test("`new` initializes the field and runs the executor once", () => {
+    const Tagged = makePromiseSubclass();
+    let runs = 0;
+    const instance = new Tagged((resolve) => {
+      runs += 1;
+      resolve(1);
+    });
+    expect(instance.tag).toBe("t");
+    expect(runs).toBe(1);
+  });
+
+  test("species construction agrees with Reflect.construct", () => {
+    const Tagged = makePromiseSubclass();
+    const resolveTag = Tagged.resolve(1).tag;
+    const thenTag = Tagged.resolve(1).then((v) => v).tag;
+    const reflectTag = Reflect.construct(Tagged, [(resolve) => resolve(1)]).tag;
+
+    expect(allAgree([resolveTag, thenTag, reflectTag])).toBe(true);
+    expect(reflectTag === "t" || reflectTag === undefined).toBe(true);
+  });
+
+  test("the promise half of the instance still settles on every route", () => {
+    const Tagged = makePromiseSubclass();
+    return Promise.all([
+      Tagged.resolve(7),
+      Tagged.resolve(7).then((v) => v + 1),
+      Reflect.construct(Tagged, [(resolve) => resolve(9)]),
+    ]).then((values) => {
+      expect(values).toEqual([7, 8, 9]);
+    });
+  });
+});
+
+describe("a plain class is unaffected by the native-chain gap", () => {
+  test("every Construct route initializes instance elements", () => {
+    const makePlain = () =>
+      class Plain {
+        tag = "t";
+      };
+    const results = routeResults(makePlain, (o) => o.tag);
+    expect(results.reflect).toBe("t");
+    expect(results.proxy).toBe("t");
+    expect(results.bound).toBe("t");
+  });
+});

--- a/tests/language/modules/class-field-initializer-module-context.js
+++ b/tests/language/modules/class-field-initializer-module-context.js
@@ -1,0 +1,85 @@
+/*---
+description: Class field initializers keep the defining module's host context on every route into the abstract Construct operation
+features: [Reflect, dynamic-import, import-meta]
+---*/
+
+import {
+  DefinitionContext,
+  definingUrl,
+} from "./helpers/class-definition-context.js";
+
+// A field initializer is guest code, so constructing a class hands it the
+// running module's `import()`, `import.meta` and file path. `new` gets those
+// from the evaluation context it is already running in; Reflect.construct, a
+// proxy without a construct trap, and a bound class reach the engine through
+// the abstract Construct operation, where the caller is a native function with
+// no context of its own. The context synthesized there must carry the same
+// host services, sourced from the module the class was *defined* in — a
+// missing module loader is not a degraded context but a crashing one, and a
+// wrong file path silently resolves `import()` and `import.meta.url` against
+// the wrong module.
+
+const construct = {
+  new: () => new DefinitionContext(),
+  reflect: () => Reflect.construct(DefinitionContext, []),
+  proxy: () => Reflect.construct(new Proxy(DefinitionContext, {}), []),
+  bound: () => Reflect.construct(DefinitionContext.bind(null), []),
+};
+
+describe("import.meta in a class field initializer", () => {
+  test("`new` resolves it against the defining module", () => {
+    expect(construct.new().meta).toBe(definingUrl);
+  });
+
+  test("Reflect.construct resolves it against the defining module", () => {
+    expect(construct.reflect().meta).toBe(definingUrl);
+  });
+
+  test("a proxy without a construct trap resolves it the same way", () => {
+    expect(construct.proxy().meta).toBe(definingUrl);
+  });
+
+  test("a bound class resolves it the same way", () => {
+    expect(construct.bound().meta).toBe(definingUrl);
+  });
+
+  test("it is the defining module's URL, not the constructing module's", () => {
+    expect(definingUrl).not.toBe(import.meta.url);
+    expect(definingUrl.endsWith("class-definition-context.js")).toBe(true);
+    expect(construct.reflect().meta).not.toBe(import.meta.url);
+  });
+});
+
+describe("dynamic import() in a class field initializer", () => {
+  test("`new` resolves the specifier against the defining module", async () => {
+    const mod = await construct.new().dep;
+    expect(mod.add(2, 3)).toBe(5);
+  });
+
+  test("Reflect.construct resolves the specifier the same way", async () => {
+    const mod = await construct.reflect().dep;
+    expect(mod.add(2, 3)).toBe(5);
+  });
+
+  test("a proxy without a construct trap resolves it the same way", async () => {
+    const mod = await construct.proxy().dep;
+    expect(mod.multiply(3, 4)).toBe(12);
+  });
+
+  test("a bound class resolves it the same way", async () => {
+    const mod = await construct.bound().dep;
+    expect(mod.PI).toBe(3.14159);
+  });
+
+  test("every route reaches the same module instance", async () => {
+    const mods = await Promise.all([
+      construct.new().dep,
+      construct.reflect().dep,
+      construct.proxy().dep,
+      construct.bound().dep,
+    ]);
+    expect(mods[1]).toBe(mods[0]);
+    expect(mods[2]).toBe(mods[0]);
+    expect(mods[3]).toBe(mods[0]);
+  });
+});

--- a/tests/language/modules/helpers/class-definition-context.js
+++ b/tests/language/modules/helpers/class-definition-context.js
@@ -1,0 +1,11 @@
+// A class whose field initializers reach for module-level host services. It
+// lives here rather than in the importing test so that the defining file and
+// the constructing file differ: `import()` and `import.meta` in a field
+// initializer must resolve against this file, whichever module runs the
+// construction and by whichever route.
+export class DefinitionContext {
+  meta = import.meta.url;
+  dep = import("./math-utils.js");
+}
+
+export const definingUrl = import.meta.url;


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Reflective construction now runs class instance elements in interpreted mode. `Reflect.construct`, bound classes, and Proxy construct traps reached `TGocciaClassValue.Instantiate`, which ran only the constructor body — every field, private field, computed-key field, and method initializer was silently skipped (27 of 30 Node-A/B probe shapes diverged; bytecode was already correct after the field-initializer layer below).
- The shared `ConstructValue` gains a class-construct redirect hook (mirroring its existing bytecode-function seam). The evaluator registers a redirect that claims a class only when it is evaluator-built (has a recorded definition scope), does not carry its own `[[Construct]]`, and has no built-in in its superclass chain; it synthesizes a context anchored on the class's definition scope and realm and calls the same `InstantiateClass` path the `new` operator runs — so newTarget prototypes, override returns, private brands, and derived-of-derived ordering all match `new`.
- Chains reaching native construction deliberately keep the old path: redirecting them regressed `ArrayBuffer`/`DataView` newTarget-ordering (their argument validation must precede prototype resolution) and exposed a pre-existing interpreter bug where a `Promise` subclass's executor runs twice. Both are documented follow-ups; the guard is mutation-checked as load-bearing. Cost: `Reflect.construct` of a class extending a native built-in still drops own fields in interpreted mode — a pre-existing gap, now characterized.
- Verified clauses via the project tc39 MCP: §28.1.2, §10.2.2 (steps 3a/5b/12/14), §7.3.33, §13.3.7.1, §15.7.10/§15.7.14.

- The review pass hardened the synthesized context: it now carries the module callbacks and the class's defining source path, so `import()` inside a field initializer no longer calls a nil host callback (a hard process crash under `Reflect.construct` or a trap-less Proxy), and `import.meta` resolves against the *defining* module on every construction route — fixing, along the way, a pre-existing bug where plain `new` resolved initializer imports against the constructing module. The two redirect hooks' deliberately different guard rules are cross-referenced in place (harmonizing them was measured to make bytecode worse on two-level native chains); `CurrentRealm` is swapped with the same discipline as `Instantiate`; and the residual native-chain gap is characterized by tests that assert all Construct routes agree, so any partial future fix fails loudly.

## Testing

- [x] Verified no regressions and confirmed the fix in end-to-end tests — full suite 12476/12476 in both modes; new `q-reflectconstruct.test.js` differential suite 27p/0f across interp/bytecode/bun with zero divergence; 28 repo tests under `tests/built-ins/Reflect/construct/`; 30-shape Node A/B went from 3/30 to 27/30 matching in interpreted mode (the 3 remaining are the characterized native-chain gap)
- [x] Updated documentation (`docs/differential-testing.md` suite row and rationale)
- [x] Mutation-checked: disabling the hook fails 19 new tests interpreted-only; dropping the native-chain guard breaks ArrayBuffer/DataView ordering tests and faults Promise subclassing
- [x] One differential case (`new.target` in a field initializer) is covered against Node in repo tests instead of the bun-gated suite — bun 1.4.0's `bun test` disagrees with node, `bun run`, and both goccia modes; recorded in the suite header
- [x] The `import()` crash fix is mutation-checked: the two context-population sites are mutually redundant by design (either alone keeps the tests green; both nil reproduces the access-violation crash) — recorded in a comment so neither is tidied away

Follow-ups filed: native-chain instance elements (incl. the `extends Map` field drop) and the pre-existing Promise-subclass double-executor bug.
