### PR TITLE
fix(interpreter): let the GC own pattern-matching scopes and root match temporaries

### DIFF
--- a/source/units/Goccia.Evaluator.PatternMatching.pas
+++ b/source/units/Goccia.Evaluator.PatternMatching.pas
@@ -62,24 +62,45 @@ uses
   Goccia.Values.SymbolValue,
   Goccia.Values.ToPrimitive;
 
+// Scopes created for a pattern match are ordinary GC-managed lexical
+// environments, and the garbage collector owns their lifetime. A clause body
+// or an `is`-guard body may hand a scope to something that outlives the match
+// — a closure keeps it in TGocciaFunctionValue.Closure, a class keeps it in
+// TGocciaClassValue.DefinitionScope — so the evaluator must never free one
+// itself. It only holds a temporary GC root for the window in which the scope
+// is reachable from Pascal locals alone, the same protocol EvaluateBlock uses
+// for ordinary block scopes.
 function CreatePatternChildContext(const AContext: TGocciaEvaluationContext;
   const ALabel: string): TGocciaEvaluationContext;
+var
+  GC: TGarbageCollector;
 begin
   Result := AContext;
   Result.Scope := AContext.Scope.CreateChild(skBlock, ALabel);
+  GC := TGarbageCollector.Instance;
+  if Assigned(GC) then
+    GC.AddTempRoot(Result.Scope);
 end;
 
+// Drops the temporary roots taken by CreatePatternChildContext for every scope
+// between the match context and its enclosing context (exclusive). Whatever the
+// clause body let escape stays reachable through whoever captured it; whatever
+// did not escape becomes unreachable and is reclaimed by the next collection.
 procedure ReleaseMatchContext(const AMatchContext,
   AParentContext: TGocciaEvaluationContext);
 var
   CurrentScope, ParentScope, StopScope: TGocciaScope;
+  GC: TGarbageCollector;
 begin
+  GC := TGarbageCollector.Instance;
+  if not Assigned(GC) then
+    Exit;
   StopScope := AParentContext.Scope;
   CurrentScope := AMatchContext.Scope;
   while Assigned(CurrentScope) and (CurrentScope <> StopScope) do
   begin
     ParentScope := CurrentScope.Parent;
-    CurrentScope.Free;
+    GC.RemoveTempRoot(CurrentScope);
     CurrentScope := ParentScope;
   end;
 end;
@@ -851,7 +872,7 @@ begin
         ReleaseMatchContext(BranchContext, AContext);
         raise;
       end;
-      BranchContext.Scope.Free;
+      ReleaseMatchContext(BranchContext, AContext);
     end;
     Exit(False);
   end;
@@ -869,8 +890,8 @@ begin
     end;
     if InnerMatched then
       ReleaseMatchContext(NextContext, AContext)
-    else if Assigned(BranchContext.Scope) then
-      BranchContext.Scope.Free;
+    else
+      ReleaseMatchContext(BranchContext, AContext);
     Result := not InnerMatched;
     Exit;
   end;
@@ -899,13 +920,13 @@ begin
   try
     Result := TryMatchPatternInternal(ASubject, APattern, ScratchContext, AMatchContext);
   except
-    ScratchContext.Scope.Free;
+    ReleaseMatchContext(ScratchContext, AContext);
     AMatchContext := AContext;
     raise;
   end;
   if not Result then
   begin
-    ScratchContext.Scope.Free;
+    ReleaseMatchContext(ScratchContext, AContext);
     AMatchContext := AContext;
   end;
 end;
@@ -915,11 +936,21 @@ function EvaluateIsExpression(const AExpression: TGocciaIsExpression;
 var
   Subject: TGocciaValue;
   MatchContext: TGocciaEvaluationContext;
+  SubjectRoot: TGocciaTempRoot;
 begin
   Subject := EvaluateExpression(AExpression.Subject, AContext);
-  Result := TGocciaBooleanLiteralValue.FromBoolean(
-    TryEvaluateMatchPattern(Subject, AExpression.Pattern, AContext,
-    MatchContext));
+  // Patterns run arbitrary user code (computed keys, guards, custom matchers),
+  // any of which is a collecting safe point. Until a binding pattern stores the
+  // subject in the match scope it is reachable from this local alone.
+  InitializeTempRoot(SubjectRoot);
+  AddTempRootIfNeeded(SubjectRoot, Subject);
+  try
+    Result := TGocciaBooleanLiteralValue.FromBoolean(
+      TryEvaluateMatchPattern(Subject, AExpression.Pattern, AContext,
+      MatchContext));
+  finally
+    RemoveTempRootIfNeeded(SubjectRoot);
+  end;
   if TGocciaBooleanLiteralValue(Result).Value then
     ReleaseMatchContext(MatchContext, AContext);
 end;
@@ -930,27 +961,36 @@ var
   Subject: TGocciaValue;
   MatchContext: TGocciaEvaluationContext;
   I: Integer;
+  SubjectRoot: TGocciaTempRoot;
 begin
   Subject := EvaluateExpression(AExpression.Subject, AContext);
 
-  for I := 0 to AExpression.Clauses.Count - 1 do
-  begin
-    if TryEvaluateMatchPattern(Subject, AExpression.Clauses[I].Pattern,
-       AContext, MatchContext) then
+  // The subject outlives every clause attempt but is reachable from this local
+  // alone, and each attempt can run user code at a collecting safe point.
+  InitializeTempRoot(SubjectRoot);
+  AddTempRootIfNeeded(SubjectRoot, Subject);
+  try
+    for I := 0 to AExpression.Clauses.Count - 1 do
     begin
-      try
-        Exit(EvaluateExpression(AExpression.Clauses[I].Expression, MatchContext));
-      finally
-        ReleaseMatchContext(MatchContext, AContext);
+      if TryEvaluateMatchPattern(Subject, AExpression.Clauses[I].Pattern,
+         AContext, MatchContext) then
+      begin
+        try
+          Exit(EvaluateExpression(AExpression.Clauses[I].Expression, MatchContext));
+        finally
+          ReleaseMatchContext(MatchContext, AContext);
+        end;
       end;
     end;
+
+    if Assigned(AExpression.DefaultExpression) then
+      Exit(EvaluateExpression(AExpression.DefaultExpression, AContext));
+
+    ThrowNoMatchingPattern;
+    Result := TGocciaUndefinedLiteralValue.UndefinedValue;
+  finally
+    RemoveTempRootIfNeeded(SubjectRoot);
   end;
-
-  if Assigned(AExpression.DefaultExpression) then
-    Exit(EvaluateExpression(AExpression.DefaultExpression, AContext));
-
-  ThrowNoMatchingPattern;
-  Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
 
 function EvaluateConditionWithPatternBindings(const ACondition: TGocciaExpression;
@@ -963,6 +1003,7 @@ var
   LeftHandled, RightHandled: Boolean;
   LeftResult, RightResult: Boolean;
   LeftContext, RightContext: TGocciaEvaluationContext;
+  SubjectRoot: TGocciaTempRoot;
 begin
   AHandled := False;
   ABodyContext := AContext;
@@ -972,8 +1013,16 @@ begin
     AHandled := True;
     IsExpression := TGocciaIsExpression(ACondition);
     Subject := EvaluateExpression(IsExpression.Subject, AContext);
-    Result := TryEvaluateMatchPattern(Subject, IsExpression.Pattern, AContext,
-      ABodyContext);
+    // See EvaluateIsExpression: the subject is reachable from this local alone
+    // while the pattern runs user code.
+    InitializeTempRoot(SubjectRoot);
+    AddTempRootIfNeeded(SubjectRoot, Subject);
+    try
+      Result := TryEvaluateMatchPattern(Subject, IsExpression.Pattern, AContext,
+        ABodyContext);
+    finally
+      RemoveTempRootIfNeeded(SubjectRoot);
+    end;
     if not Result then
       ABodyContext := AContext;
     Exit;

--- a/source/units/Goccia.Evaluator.PatternMatching.pas
+++ b/source/units/Goccia.Evaluator.PatternMatching.pas
@@ -885,7 +885,10 @@ begin
       InnerMatched := TryMatchPatternInternal(ASubject,
         TGocciaNotMatchPattern(APattern).Pattern, BranchContext, NextContext);
     except
-      ReleaseMatchContext(NextContext, AContext);
+      // BranchContext, not NextContext: the inner match's own handler has
+      // already released everything deeper than the branch scope, and its
+      // advanced NextContext may point at a scope it just un-rooted.
+      ReleaseMatchContext(BranchContext, AContext);
       raise;
     end;
     if InnerMatched then

--- a/source/units/Goccia.PatternMatching.pas
+++ b/source/units/Goccia.PatternMatching.pas
@@ -66,7 +66,10 @@ end;
 destructor TGocciaMatchEnvironment.Destroy;
 begin
   FBindings.Free;
-  FScope.Free;
+  // FScope is GC-managed: closures and classes created while matching can
+  // capture it and outlive this environment, so the collector — not this
+  // destructor — decides when it dies.
+  FScope := nil;
   inherited;
 end;
 

--- a/source/units/Goccia.PatternMatching.pas
+++ b/source/units/Goccia.PatternMatching.pas
@@ -28,19 +28,6 @@ type
 
   TGocciaPatternBindingList = TList<TGocciaPatternBinding>;
 
-  TGocciaMatchEnvironment = class
-  private
-    FScope: TGocciaScope;
-    FBindings: TGocciaPatternBindingList;
-  public
-    constructor Create(const AParentScope: TGocciaScope);
-    destructor Destroy; override;
-    procedure Bind(const AName: string; const AValue: TGocciaValue;
-      const ADeclarationType: TGocciaDeclarationType);
-    property Scope: TGocciaScope read FScope;
-    property Bindings: TGocciaPatternBindingList read FBindings;
-  end;
-
 function MatchValueEquals(const ASubject, ACandidate: TGocciaValue): Boolean;
 function GetCustomMatcher(const AMatcher: TGocciaValue): TGocciaValue;
 procedure ThrowNoMatchingPattern;
@@ -53,37 +40,6 @@ uses
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectValue,
   Goccia.Values.SymbolValue;
-
-{ TGocciaMatchEnvironment }
-
-constructor TGocciaMatchEnvironment.Create(const AParentScope: TGocciaScope);
-begin
-  inherited Create;
-  FScope := AParentScope.CreateChild(skBlock, 'PatternMatchScope');
-  FBindings := TGocciaPatternBindingList.Create;
-end;
-
-destructor TGocciaMatchEnvironment.Destroy;
-begin
-  FBindings.Free;
-  // FScope is GC-managed: closures and classes created while matching can
-  // capture it and outlive this environment, so the collector — not this
-  // destructor — decides when it dies.
-  FScope := nil;
-  inherited;
-end;
-
-procedure TGocciaMatchEnvironment.Bind(const AName: string; const AValue: TGocciaValue;
-  const ADeclarationType: TGocciaDeclarationType);
-var
-  Binding: TGocciaPatternBinding;
-begin
-  FScope.DefineLexicalBinding(AName, AValue, ADeclarationType);
-  Binding.Name := AName;
-  Binding.Value := AValue;
-  Binding.DeclarationType := ADeclarationType;
-  FBindings.Add(Binding);
-end;
 
 // TC39 Pattern Matching: primitive/value patterns use SameValue, except bare
 // zero patterns which the parser marks for SameValueZero handling.

--- a/tests/language/pattern-matching/gc.js
+++ b/tests/language/pattern-matching/gc.js
@@ -1,0 +1,142 @@
+/*---
+description: Pattern matching keeps scopes and subjects alive across collections
+features: [pattern-matching, Goccia]
+---*/
+
+const hasGoccia = typeof Goccia !== "undefined";
+
+describe.runIf(hasGoccia)("pattern matching GC safety", () => {
+  test("a closure escaping a match clause survives collection", () => {
+    const make = (value) =>
+      match (value) {
+        { x: const x }: () => x;
+        default: () => -1;
+      };
+
+    const escaped = make({ x: 42 });
+    Goccia.gc();
+    Goccia.gc();
+
+    expect(escaped()).toBe(42);
+  });
+
+  test("a class escaping a match clause keeps its definition scope", () => {
+    const makeClass = (value) =>
+      match (value) {
+        { x: const x }: class {
+          field = x;
+          read() {
+            return x;
+          }
+        };
+        default: null;
+      };
+
+    const Escaped = makeClass({ x: 7 });
+    Goccia.gc();
+    Goccia.gc();
+
+    const instance = new Escaped();
+    expect(instance.field).toBe(7);
+    expect(instance.read()).toBe(7);
+  });
+
+  test("a closure escaping an is-guard body survives collection", () => {
+    const value = { y: 11 };
+    let escaped = null;
+
+    if (value is { y: const y }) {
+      escaped = () => y;
+    }
+    Goccia.gc();
+    Goccia.gc();
+
+    expect(escaped()).toBe(11);
+  });
+
+  test("a closure escaping an or-branch binding survives collection", () => {
+    const make = (value) =>
+      match (value) {
+        { a: const bound } or { b: const bound }: () => bound;
+        default: () => -1;
+      };
+
+    const escaped = make({ b: 5 });
+    Goccia.gc();
+    Goccia.gc();
+
+    expect(escaped()).toBe(5);
+  });
+
+  test("a closure escaping a catch pattern body survives collection", () => {
+    let escaped = null;
+
+    try {
+      throw { code: 3 };
+    } catch (error is { code: const code }) {
+      escaped = () => code;
+    }
+    Goccia.gc();
+    Goccia.gc();
+
+    expect(escaped()).toBe(3);
+  });
+
+  test("collecting inside a custom matcher leaves the match intact", () => {
+    class Positive {
+      static [Symbol.customMatcher](subject) {
+        Goccia.gc();
+        return subject > 0;
+      }
+    }
+
+    const result = match (5) {
+      Positive: "positive";
+      default: "other";
+    };
+
+    expect(result).toBe("positive");
+  });
+
+  test("collecting inside a computed pattern key keeps the subject alive", () => {
+    const key = () => {
+      Goccia.gc();
+      return "x";
+    };
+
+    const result = match ({ x: 1, z: 2 }) {
+      { [key()]: const x, z: const z }: x + z;
+      default: -1;
+    };
+
+    expect(result).toBe(3);
+  });
+
+  test("collecting inside a pattern guard keeps the subject alive", () => {
+    const check = (value) => {
+      Goccia.gc();
+      return value > 0;
+    };
+
+    const result = match ({ x: 1 }) {
+      { x: const x } if (check(x)): x;
+      default: -1;
+    };
+
+    expect(result).toBe(1);
+  });
+
+  test("collecting inside an is-expression pattern keeps the subject alive", () => {
+    const key = () => {
+      Goccia.gc();
+      return "x";
+    };
+    let result = 0;
+
+    if ({ x: 9 } is { [key()]: const x }) {
+      result = x;
+    }
+
+    expect(result).toBe(9);
+  });
+});


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Fixes three live interpreter crash classes in pattern matching, all one ownership mistake: the unit treated GC-managed scopes as manually-owned.
  - A closure — or a class, whose definition scope the field-initializer layer below made explicit — escaping a match clause or `is`-guard body referenced a scope the match machinery had explicitly freed: `EObjectCheck` on first use after a collection.
  - The match scratch scope was never GC-rooted at all, so a collection inside a `Symbol.customMatcher` or computed pattern key swept it mid-match and the later explicit `Free` double-freed: `EBusError`.
  - The match subject itself sat in an unrooted Pascal local across guest re-entry (computed keys, guards, custom matchers): a temporary subject was collected mid-match, `EAccessViolation`.
- The fix makes the unit consistent with every other evaluator path: scopes are created rooted (`AddTempRoot`), released not freed (`ReleaseMatchContext` walks the same chain removing roots, as the single choke point the or-branch/not-branch/exception sites route through), and the subject is temp-rooted at the three entry points. Escaping values keep their scopes alive through their own references; everything else is reclaimed on the next cycle. Pattern matching compiles separately in bytecode mode, which was unaffected throughout.
- Leak discipline verified with heaptrc A/B builds over match-heavy stress scripts: unfreed block counts byte-identical before and after (the sole byte-level delta is one fixed-size structure, constant across 5× iterations — not a scaling leak).

## Testing

- [x] Verified no regressions and confirmed the fixes in end-to-end tests — full suite green in both modes; new `tests/language/pattern-matching/gc.js` (9 tests: escaping closures/classes/or-branch/catch-pattern bindings, and forced collections inside custom matchers, computed keys, guards, and `is` patterns) — every one crashes the base binary
- [x] Documentation not impacted (internal ownership change)
- [x] heaptrc before/after comparison attached in the review trail: no leak regression
- [x] Not benchmark-relevant (roots added only within match evaluation windows)
- [x] Review follow-through: the dead `TGocciaMatchEnvironment` class (which created a scope nobody owned) is deleted rather than patched, and the not-branch exception path releases the branch scope directly instead of an advanced context the inner handler may already have un-rooted

Fixes the dangling-scope hazard surfaced by the field-initializer review one layer group down (where `TGocciaClassValue.DefinitionScope` widened the pre-existing closure-scope exposure).
