### PR TITLE
fix(modules): classify stripped source by UTF-16 code units for bare-specifier detection

### DIFF
--- a/docs/module-resolution.md
+++ b/docs/module-resolution.md
@@ -205,7 +205,7 @@ trusting `"type"` is what makes the `module`-field deviation above work at all,
 since those ES module builds routinely sit in packages that declare no type.
 
 Before the markers are looked for, a lexical pass replaces every comment,
-string body, template body, and regular expression literal with a single space,
+string body, template body, and regular expression literal with a placeholder,
 so a keyword the file only mentions counts for nothing. Every esbuild
 `__toCommonJS` bundle depends on that pass: it ends with the banner comment
 `// Annotate the CommonJS export names for ESM import in node:`, whose bare
@@ -214,21 +214,37 @@ bundle was loaded and then failed at its first `require`, with an
 `Undefined variable: require` reference error instead of the package-relative
 message below.
 
-The pass is lexical, not a parse, and it approximates in two places:
+The placeholder is chosen for what stood there. A string, template, or regular
+expression is an operand, so it collapses to a value; a comment is not, so it
+collapses to a space the scan looks past. That distinction is what keeps
+`var a = "p" / 2` dividing rather than opening a literal at the slash.
 
-- A `/` is read as a regular expression or as division from the last
-  significant character before it. That is right in every operand position and
-  wrong only for a literal opening straight after a block's closing brace,
-  which is then scanned as ordinary code — harmless unless its body holds a
-  quote. A literal that does not close on its own line was division after all,
-  and the slash is kept as code.
-- A source the pass cannot finish — an unterminated block comment or template
-  literal — is classified on its raw text instead, which restores the old
-  behaviour for that one file.
+The pass is lexical, not a parse, and it decides one thing by approximation:
+whether a `/` opens a regular expression or divides, read from the last
+significant character before it. Division needs a value in front, so an
+identifier — including a non-ASCII one such as `café` — a number, a closing
+bracket, a postfix `++`, or a collapsed literal all mean division, and every
+other punctuator leaves an operand position where a slash opens a literal. Two
+shapes still come out wrong:
 
-What survives is a marker the file builds at runtime, `["exp" + "ort"]` or a
-keyword it only ever names in data. That remains a false *negative*, and it is
-the deliberate direction of the asymmetry: the file is loaded rather than
+- A literal opening straight after a block's closing brace or a condition's
+  `)`, as in `if (ok) /re/.test(x)`, is read as division, and its body is then
+  scanned as ordinary code. A quote inside the body can open a string scan that
+  runs to the next quote on the line.
+- A division after an identifier that spells one of the keywords a literal may
+  follow, as in `const of = 4; of / 2`, is read as a literal.
+
+The second is the damaging one. If a second `/` follows on the line, the bogus
+literal closes and everything between the two is discarded along with any
+marker in it — enough, in principle, to turn a genuine ES module into a
+CommonJS refusal. Only when no second `/` follows is the slash kept as code and
+nothing lost. A source the pass cannot finish at all — an unterminated block
+comment or template literal — is classified on its raw text instead, which
+restores the pre-pass behaviour for that one file.
+
+What survives the pass is a marker the file builds at runtime, `["exp" + "ort"]`
+or a keyword it only ever names in data. That remains a false *negative*, and it
+is the deliberate direction of the asymmetry: the file is loaded rather than
 refused, and removing the last of them would cost a parse of every resolved
 package entry.
 

--- a/docs/module-resolution.md
+++ b/docs/module-resolution.md
@@ -204,15 +204,33 @@ neither is inert and loads either way. Reading the file text rather than
 trusting `"type"` is what makes the `module`-field deviation above work at all,
 since those ES module builds routinely sit in packages that declare no type.
 
-The scan matches raw text and does not tokenize, so it does not skip comments
-or string literals: a CommonJS bundle whose banner comment mentions `import` or
-`export` carries an ES module marker as far as the classifier is concerned and
-is not refused here. Such a file is loaded and then fails at its first
-`require`, with an `Undefined variable: require` reference error rather than the
-package-relative CommonJS message below. That is the deliberate direction of
-the asymmetry — a false *negative* costs a worse diagnostic, while tokenizing
-every candidate file to remove it would cost a parse of every resolved package
-entry.
+Before the markers are looked for, a lexical pass replaces every comment,
+string body, template body, and regular expression literal with a single space,
+so a keyword the file only mentions counts for nothing. Every esbuild
+`__toCommonJS` bundle depends on that pass: it ends with the banner comment
+`// Annotate the CommonJS export names for ESM import in node:`, whose bare
+`export` and `import` words used to carry the whole file past the check. Such a
+bundle was loaded and then failed at its first `require`, with an
+`Undefined variable: require` reference error instead of the package-relative
+message below.
+
+The pass is lexical, not a parse, and it approximates in two places:
+
+- A `/` is read as a regular expression or as division from the last
+  significant character before it. That is right in every operand position and
+  wrong only for a literal opening straight after a block's closing brace,
+  which is then scanned as ordinary code — harmless unless its body holds a
+  quote. A literal that does not close on its own line was division after all,
+  and the slash is kept as code.
+- A source the pass cannot finish — an unterminated block comment or template
+  literal — is classified on its raw text instead, which restores the old
+  behaviour for that one file.
+
+What survives is a marker the file builds at runtime, `["exp" + "ort"]` or a
+keyword it only ever names in data. That remains a false *negative*, and it is
+the deliberate direction of the asymmetry: the file is loaded rather than
+refused, and removing the last of them would cost a parse of every resolved
+package entry.
 
 A file classified as CommonJS raises:
 

--- a/scripts/differential/mods/nodemods/goccia-entry.js
+++ b/scripts/differential/mods/nodemods/goccia-entry.js
@@ -7,3 +7,5 @@
 export { modfieldLabel } from "modfield";
 
 export const importCommonJSOnlyPackage = () => import("cjsonly");
+
+export const importEsbuildBundledPackage = () => import("esbuildcjs");

--- a/scripts/differential/mods/nodemods/node_modules/esbuildcjs/index.js
+++ b/scripts/differential/mods/nodemods/node_modules/esbuildcjs/index.js
@@ -1,0 +1,45 @@
+// A trimmed esbuild __toCommonJS bundle. The banner comment near the bottom is
+// emitted verbatim by esbuild for every CommonJS output, and its bare "export"
+// and "import" words are the reason this file used to pass the source scan as
+// an ES module — it was loaded and then failed at `require` instead of being
+// refused by name.
+"use strict";
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if ((from && typeof from === "object") || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, {
+          get: () => from[key],
+          enumerable:
+            !(desc = __getOwnPropDesc(from, key)) || desc.enumerable,
+        });
+  }
+  return to;
+};
+var __toCommonJS = (mod) =>
+  __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+
+var index_exports = {};
+__export(index_exports, {
+  getToken: () => getToken,
+});
+module.exports = __toCommonJS(index_exports);
+
+var os = require("node:os");
+
+function getToken() {
+  return `token:${typeof os}`;
+}
+// Annotate the CommonJS export names for ESM import in node:
+0 &&
+  (module.exports = {
+    getToken,
+  });

--- a/scripts/differential/mods/nodemods/node_modules/esbuildcjs/package.json
+++ b/scripts/differential/mods/nodemods/node_modules/esbuildcjs/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "esbuildcjs",
+  "version": "1.0.0",
+  "main": "./index.js"
+}

--- a/scripts/differential/n-nodemods.goccia.test.js
+++ b/scripts/differential/n-nodemods.goccia.test.js
@@ -5,6 +5,7 @@
 // classified `skip` for both. Mode parity is still checked.
 import {
   importCommonJSOnlyPackage,
+  importEsbuildBundledPackage,
   modfieldLabel,
 } from "./mods/nodemods/goccia-entry.js";
 
@@ -26,6 +27,24 @@ describe("node_modules resolution: goccia-specific behaviour", () => {
 
     expect(message).toBe(
       'Package "cjsonly" resolved to a CommonJS file (index.js); GocciaScript loads only ES modules',
+    );
+  });
+
+  test("an esbuild CommonJS bundle is refused by name despite its banner", async () => {
+    // esbuild ends every CommonJS output with "// Annotate the CommonJS export
+    // names for ESM import in node:". The source scan strips comments before
+    // looking for module markers, so those two words no longer make the bundle
+    // look like an ES module — without the strip this failed at `require`
+    // instead, with a ReferenceError naming an undefined variable.
+    let message = "";
+    try {
+      await importEsbuildBundledPackage();
+    } catch (error) {
+      message = error.message;
+    }
+
+    expect(message).toBe(
+      'Package "esbuildcjs" resolved to a CommonJS file (index.js); GocciaScript loads only ES modules',
     );
   });
 });

--- a/source/units/Goccia.Modules.NodeResolution.Test.pas
+++ b/source/units/Goccia.Modules.NodeResolution.Test.pas
@@ -55,6 +55,14 @@ type
     procedure TestMixedSourceIsReadAsESModule;
     procedure TestInertSourceIsNotCommonJS;
     procedure TestIdentifierEndingInRequireIsNotACall;
+
+    procedure TestEsbuildBannerIsNotAnESModuleMarker;
+    procedure TestStringLiteralMarkerIsNotAnESModuleMarker;
+    procedure TestBlockCommentSpanningLinesIsStripped;
+    procedure TestTemplateBodyIsStrippedButSubstitutionsAreNot;
+    procedure TestCommentedESModuleStaysAnESModule;
+    procedure TestRegExpLiteralDoesNotSwallowCode;
+    procedure TestUnterminatedCommentFallsBackToTheRawScan;
   public
     procedure SetupTests; override;
   end;
@@ -129,6 +137,21 @@ begin
   Test('inert source is not CommonJS', TestInertSourceIsNotCommonJS);
   Test('an identifier ending in require is not a require call',
     TestIdentifierEndingInRequireIsNotACall);
+
+  Test('an esbuild banner comment is not an ES module marker',
+    TestEsbuildBannerIsNotAnESModuleMarker);
+  Test('a marker inside a string literal does not count',
+    TestStringLiteralMarkerIsNotAnESModuleMarker);
+  Test('a block comment spanning lines is stripped',
+    TestBlockCommentSpanningLinesIsStripped);
+  Test('a template body is stripped but its substitutions are not',
+    TestTemplateBodyIsStrippedButSubstitutionsAreNot);
+  Test('a commented ES module stays an ES module',
+    TestCommentedESModuleStaysAnESModule);
+  Test('a regular expression literal does not swallow the code after it',
+    TestRegExpLiteralDoesNotSwallowCode);
+  Test('an unterminated comment falls back to the raw scan',
+    TestUnterminatedCommentFallsBackToTheRawScan);
 end;
 
 { ── Specifier splitting ────────────────────────────────────── }
@@ -633,6 +656,87 @@ procedure TNodeResolutionTests.TestIdentifierEndingInRequireIsNotACall;
 begin
   Expect<Boolean>(LooksLikeCommonJSSource(
     'const value = createRequire(import.meta.url);')).ToBe(False);
+end;
+
+{ ── Comment and literal stripping ──────────────────────────── }
+
+procedure TNodeResolutionTests.TestEsbuildBannerIsNotAnESModuleMarker;
+begin
+  { The banner every esbuild __toCommonJS bundle carries. Its bare "export" and
+    "import" words used to make the bundle pass as an ES module, so it was
+    loaded instead of refused and failed at its first require. }
+  Expect<Boolean>(LooksLikeCommonJSSource(
+    'var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", ' +
+      '{ value: true }), mod);' + sLineBreak +
+    'var index_exports = {};' + sLineBreak +
+    'module.exports = __toCommonJS(index_exports);' + sLineBreak +
+    '// Annotate the CommonJS export names for ESM import in node:' +
+      sLineBreak +
+    '0 && (module.exports = {' + sLineBreak +
+    '  getToken' + sLineBreak +
+    '});')).ToBe(True);
+end;
+
+procedure TNodeResolutionTests.TestStringLiteralMarkerIsNotAnESModuleMarker;
+begin
+  Expect<Boolean>(LooksLikeCommonJSSource(
+    'const hint = "run: import x from ''y''";' + sLineBreak +
+    'module.exports = { hint };')).ToBe(True);
+end;
+
+procedure TNodeResolutionTests.TestBlockCommentSpanningLinesIsStripped;
+begin
+  Expect<Boolean>(LooksLikeCommonJSSource(
+    '/*' + sLineBreak +
+    ' * Historic note: this file used to read' + sLineBreak +
+    ' *   export const value = 1;' + sLineBreak +
+    ' */' + sLineBreak +
+    'module.exports = { value: 1 };')).ToBe(True);
+end;
+
+procedure TNodeResolutionTests.TestTemplateBodyIsStrippedButSubstitutionsAreNot;
+begin
+  Expect<Boolean>(LooksLikeCommonJSSource(
+    'module.exports = {' + sLineBreak +
+    '  banner: `' + sLineBreak +
+    '    import { x } from "y";' + sLineBreak +
+    '    export const z = x;' + sLineBreak +
+    '  `,' + sLineBreak +
+    '};')).ToBe(True);
+  { A substitution holds real code, so what is inside it still counts. }
+  Expect<Boolean>(LooksLikeCommonJSSource(
+    'const label = `name: ${exports.name}`;')).ToBe(True);
+end;
+
+procedure TNodeResolutionTests.TestCommentedESModuleStaysAnESModule;
+begin
+  { The strip may not eat code: the require before the comments and the export
+    after them are both real, and a file carrying both is an ES module. }
+  Expect<Boolean>(LooksLikeCommonJSSource(
+    'const legacy = require("./legacy.cjs");' + sLineBreak +
+    '/* interop shim for the legacy build */' + sLineBreak +
+    '// exports.legacy = legacy;' + sLineBreak +
+    'export const value = legacy;')).ToBe(False);
+end;
+
+procedure TNodeResolutionTests.TestRegExpLiteralDoesNotSwallowCode;
+begin
+  { The quotes and the escaped slash pair inside the literal must not be read
+    as a string or a comment; the export after it decides the file. }
+  Expect<Boolean>(LooksLikeCommonJSSource(
+    'const legacy = require("./legacy.cjs");' + sLineBreak +
+    'const pattern = /["'']\/\//g;' + sLineBreak +
+    'export const value = legacy.replace(pattern, "");')).ToBe(False);
+end;
+
+procedure TNodeResolutionTests.TestUnterminatedCommentFallsBackToTheRawScan;
+begin
+  { A source the scan cannot finish is classified on its raw text, so the words
+    inside the unclosed comment count again. The file is loaded rather than
+    refused, which is the safe direction of the asymmetry. }
+  Expect<Boolean>(LooksLikeCommonJSSource(
+    'module.exports = { value: 1 };' + sLineBreak +
+    '/* export * from "./value.js";')).ToBe(False);
 end;
 
 begin

--- a/source/units/Goccia.Modules.NodeResolution.Test.pas
+++ b/source/units/Goccia.Modules.NodeResolution.Test.pas
@@ -63,6 +63,14 @@ type
     procedure TestCommentedESModuleStaysAnESModule;
     procedure TestRegExpLiteralDoesNotSwallowCode;
     procedure TestUnterminatedCommentFallsBackToTheRawScan;
+
+    procedure TestNonASCIIIdentifierBeforeASlashDivides;
+    procedure TestStringBeforeASlashDivides;
+    procedure TestLineSeparatorEndsALineComment;
+    procedure TestCarriageReturnEndsALineComment;
+    procedure TestSubstitutionBracesAreTrackedByDepth;
+    procedure TestNestedTemplateLiteralsAreTracked;
+    procedure TestUnterminatedTemplateFallsBackToTheRawScan;
   public
     procedure SetupTests; override;
   end;
@@ -152,6 +160,19 @@ begin
     TestRegExpLiteralDoesNotSwallowCode);
   Test('an unterminated comment falls back to the raw scan',
     TestUnterminatedCommentFallsBackToTheRawScan);
+
+  Test('a slash after a non-ASCII identifier divides',
+    TestNonASCIIIdentifierBeforeASlashDivides);
+  Test('a slash after a string literal divides', TestStringBeforeASlashDivides);
+  Test('U+2028 ends a line comment', TestLineSeparatorEndsALineComment);
+  Test('a carriage return ends a line comment',
+    TestCarriageReturnEndsALineComment);
+  Test('substitution braces are told apart by depth',
+    TestSubstitutionBracesAreTrackedByDepth);
+  Test('nested template literals are tracked',
+    TestNestedTemplateLiteralsAreTracked);
+  Test('an unterminated template falls back to the raw scan',
+    TestUnterminatedTemplateFallsBackToTheRawScan);
 end;
 
 { ── Specifier splitting ────────────────────────────────────── }
@@ -737,6 +758,70 @@ begin
   Expect<Boolean>(LooksLikeCommonJSSource(
     'module.exports = { value: 1 };' + sLineBreak +
     '/* export * from "./value.js";')).ToBe(False);
+end;
+
+procedure TNodeResolutionTests.TestNonASCIIIdentifierBeforeASlashDivides;
+begin
+  { `café` is a value, so the slash after it divides. Reading it as an operand
+    position would open a regular expression that closes on the next slash on
+    the line, taking the export with it and refusing a genuine ES module. }
+  Expect<Boolean>(LooksLikeCommonJSSource(
+    'const café = 4; const x = café/2; export const v = 1; ' +
+    'const y = 6/3; module.exports = x;')).ToBe(False);
+end;
+
+procedure TNodeResolutionTests.TestStringBeforeASlashDivides;
+begin
+  { A stripped literal leaves a value behind, so the slash after it divides for
+    the same reason. On a placeholder the scan could see past, the literal
+    opened here would run to the slash in `1/2` and swallow the export. }
+  Expect<Boolean>(LooksLikeCommonJSSource(
+    'var a = "p"/2;export { a };var b = 1/2;module.exports = b;')).ToBe(False);
+end;
+
+procedure TNodeResolutionTests.TestLineSeparatorEndsALineComment;
+begin
+  { U+2028 is an ECMAScript line terminator, so the banner comment ends there
+    and the code on the next line is still code. }
+  Expect<Boolean>(LooksLikeCommonJSSource(
+    '// Annotate the CommonJS export names for ESM import in node:' +
+    #$2028 + 'module.exports = { value: 1 };')).ToBe(True);
+end;
+
+procedure TNodeResolutionTests.TestCarriageReturnEndsALineComment;
+begin
+  Expect<Boolean>(LooksLikeCommonJSSource(
+    '// Annotate the CommonJS export names for ESM import in node:' +
+    #13#10 + 'module.exports = { value: 1 };')).ToBe(True);
+end;
+
+procedure TNodeResolutionTests.TestSubstitutionBracesAreTrackedByDepth;
+begin
+  { The closing brace of the object literal is not the one that ends the
+    substitution. Counting templates instead of brace depth ends it early, and
+    the rest of the substitution — the only CommonJS marker here — is read as
+    template text and stripped. }
+  Expect<Boolean>(LooksLikeCommonJSSource(
+    'const label = `${ format({ width: 2 }, exports.name) } ready`;'))
+    .ToBe(True);
+end;
+
+procedure TNodeResolutionTests.TestNestedTemplateLiteralsAreTracked;
+begin
+  { A substitution inside a substitution is still code. }
+  Expect<Boolean>(LooksLikeCommonJSSource(
+    'const label = `outer ${ wrap(`inner ${ exports.name }`) } done`;'))
+    .ToBe(True);
+  { The body of the nested template is text, so the marker in it is not one. }
+  Expect<Boolean>(LooksLikeCommonJSSource(
+    'module.exports = `a ${ wrap(`export const b = 1;`) } c`;')).ToBe(True);
+end;
+
+procedure TNodeResolutionTests.TestUnterminatedTemplateFallsBackToTheRawScan;
+begin
+  Expect<Boolean>(LooksLikeCommonJSSource(
+    'module.exports = { value: 1 };' + sLineBreak +
+    'const banner = `export * from "./value.js";')).ToBe(False);
 end;
 
 begin

--- a/source/units/Goccia.Modules.NodeResolution.pas
+++ b/source/units/Goccia.Modules.NodeResolution.pas
@@ -155,11 +155,24 @@ function IsPathInsideDirectory(const APath, ADirectory: string): Boolean;
   deliberate: a file with both is being read as an ES module by every other
   toolchain, and a file with neither is inert and loads fine either way.
 
-  The scan matches raw text and does not tokenize, so an `import` or `export`
-  keyword inside a comment or a string literal counts as an ES module marker.
-  That direction is the safe one: the file is loaded rather than refused, and
-  fails on its own terms at the first `require`. Removing the false negative
-  would cost a parse of every resolved package entry. }
+  Comments, string and template bodies, and regular expression literals are
+  replaced with a space before the markers are looked for, so the words inside
+  them count for nothing. Every esbuild CommonJS bundle depends on this: its
+  banner comment reads "Annotate the CommonJS export names for ESM import in
+  node:", and on a raw scan those two words alone made the file pass as an ES
+  module.
+
+  The strip is a lexical pass, not a parse. Its one approximation is the
+  `/`: whether it opens a regular expression or divides is decided from the
+  last significant character, which is right everywhere except a literal
+  opening straight after a block's closing brace. Anything the pass cannot
+  finish — an
+  unterminated block comment or template literal — falls back to scanning the
+  raw text.
+
+  The remaining false negative is a marker built at runtime, `["exp" + "ort"]`
+  or a keyword the file only ever names in data. Removing that one would cost a
+  parse of every resolved package entry. }
 function LooksLikeCommonJSSource(const ASource: string): Boolean;
 
 { Whether a resolved file inside a package must be refused as CommonJS.
@@ -208,6 +221,21 @@ const
   COMMONJS_EXPORTS_NAME = 'exports';
   ESM_IMPORT_KEYWORD = 'import';
   ESM_EXPORT_KEYWORD = 'export';
+  ESCAPE_CHARACTER = '\';
+  BLOCK_COMMENT_CLOSE = '*/';
+  SOURCE_WHITESPACE_CHARACTERS = [' ', #9, #13, #10];
+  LINE_TERMINATOR_CHARACTERS = [#13, #10];
+  { Punctuators that close a value, so a `/` after one is division. The closing
+    brace is counted here because an object literal is by far the more common
+    thing to precede a slash; a regular expression opening right after a
+    block's closing brace is scanned as division instead, which only matters if
+    its body holds a quote or a slash pair. }
+  VALUE_CLOSING_CHARACTERS = [')', ']', '}'];
+  { The keywords a regular expression literal may legally follow. After any
+    other identifier the slash divides the value that identifier names. }
+  REGEXP_PRECEDING_KEYWORDS: array[0..13] of string = (
+    'await', 'case', 'delete', 'do', 'else', 'in', 'instanceof', 'new',
+    'of', 'return', 'throw', 'typeof', 'void', 'yield');
 
 type
   { SAX handler that keeps the four scalar fields the resolver reads and
@@ -898,22 +926,294 @@ begin
   Result := ContainsKeywordBefore(ASource, AObjectName, ['.', '[']);
 end;
 
+{ Whether a quoted string starting at AStart closes on its own line.
+
+  ANextIndex comes back as the position just past the closing quote. A string
+  that runs into a line terminator is not a string at all — the quote was a
+  character inside something this scan misread — so the caller keeps it as
+  ordinary code rather than swallowing the rest of the file. }
+function TrySkipQuotedString(const ASource: string; const AStart: Integer;
+  out ANextIndex: Integer): Boolean;
+var
+  Index, SourceLength: Integer;
+  Quote: Char;
+begin
+  Quote := ASource[AStart];
+  SourceLength := Length(ASource);
+  Index := AStart + 1;
+  while Index <= SourceLength do
+  begin
+    if ASource[Index] = ESCAPE_CHARACTER then
+    begin
+      { Also carries a line continuation past the terminator below. }
+      Inc(Index, 2);
+      Continue;
+    end;
+    if ASource[Index] = Quote then
+    begin
+      ANextIndex := Index + 1;
+      Exit(True);
+    end;
+    if ASource[Index] in LINE_TERMINATOR_CHARACTERS then
+      Break;
+    Inc(Index);
+  end;
+  ANextIndex := AStart;
+  Result := False;
+end;
+
+{ Whether a regular expression literal starting at AStart closes on its own
+  line. `[...]` is tracked because a `/` inside a character class does not end
+  the literal. Failing to close means the slash was division after all, which
+  is how an ambiguous `/` recovers without discarding any source. }
+function TrySkipRegExpLiteral(const ASource: string; const AStart: Integer;
+  out ANextIndex: Integer): Boolean;
+var
+  Index, SourceLength: Integer;
+  InCharacterClass: Boolean;
+begin
+  SourceLength := Length(ASource);
+  Index := AStart + 1;
+  InCharacterClass := False;
+  while Index <= SourceLength do
+  begin
+    if ASource[Index] = ESCAPE_CHARACTER then
+    begin
+      Inc(Index, 2);
+      Continue;
+    end;
+    if ASource[Index] in LINE_TERMINATOR_CHARACTERS then
+      Break;
+    if InCharacterClass then
+    begin
+      if ASource[Index] = ']' then
+        InCharacterClass := False;
+    end
+    else if ASource[Index] = '[' then
+      InCharacterClass := True
+    else if ASource[Index] = '/' then
+    begin
+      ANextIndex := Index + 1;
+      Exit(True);
+    end;
+    Inc(Index);
+  end;
+  ANextIndex := AStart;
+  Result := False;
+end;
+
+function IsRegExpPrecedingKeyword(const AWord: string): Boolean;
+var
+  Index: Integer;
+begin
+  for Index := Low(REGEXP_PRECEDING_KEYWORDS)
+    to High(REGEXP_PRECEDING_KEYWORDS) do
+    if AWord = REGEXP_PRECEDING_KEYWORDS[Index] then
+      Exit(True);
+  Result := False;
+end;
+
+{ Whether a `/` following the code emitted so far opens a regular expression
+  literal rather than dividing. The decision is made from the last significant
+  character instead of a token stream, which is the one place this scan
+  approximates: it is right for every operand-position slash and wrong only for
+  a literal that opens straight after a block's closing brace. }
+function SlashOpensRegExpLiteral(const ACode: string;
+  const ALength: Integer): Boolean;
+var
+  Scan, WordStart: Integer;
+begin
+  Scan := ALength;
+  while (Scan >= 1) and (ACode[Scan] in SOURCE_WHITESPACE_CHARACTERS) do
+    Dec(Scan);
+  if Scan < 1 then
+    Exit(True);
+
+  if not IsIdentifierPartCharacter(ACode[Scan]) then
+  begin
+    { `count++ / 2` divides; every other operator leaves an operand position. }
+    if (ACode[Scan] in ['+', '-']) and (Scan > 1) and
+       (ACode[Scan - 1] = ACode[Scan]) then
+      Exit(False);
+    Exit(not (ACode[Scan] in VALUE_CLOSING_CHARACTERS));
+  end;
+
+  WordStart := Scan;
+  while (WordStart >= 1) and IsIdentifierPartCharacter(ACode[WordStart]) do
+    Dec(WordStart);
+  Result := IsRegExpPrecedingKeyword(
+    Copy(ACode, WordStart + 1, Scan - WordStart));
+end;
+
+{ Replaces every comment, string body, template body, and regular expression
+  literal in ASource with a single space, leaving the code around them.
+
+  The space matters: it keeps the marker scan from gluing the two halves of
+  `imp/*x*/ort` into a keyword. Template substitutions stay as code, since
+  a substitution holds a real expression; the brace stack is what tells the
+  closing brace that ends one from the closing brace of an object literal
+  inside it.
+
+  Returns False when the scan cannot finish — an unterminated block comment or
+  template literal — so the caller can fall back to the raw text instead of
+  acting on a source it only half understood. }
+function StripCommentsAndLiterals(const ASource: string;
+  out AStripped: string): Boolean;
+var
+  Buffer: string;
+  BraceDepth, BufferLength, Index, NextIndex, SourceLength: Integer;
+  TemplateBraceDepths: array of Integer;
+  TemplateDepth: Integer;
+  InTemplateBody: Boolean;
+  Character: Char;
+
+  procedure EmitCharacter(const AValue: Char);
+  begin
+    Inc(BufferLength);
+    Buffer[BufferLength] := AValue;
+  end;
+
+begin
+  AStripped := '';
+  SourceLength := Length(ASource);
+  { Every branch consumes at least as many characters as it emits, so the
+    stripped text never outgrows the source. }
+  SetLength(Buffer, SourceLength);
+  BufferLength := 0;
+  BraceDepth := 0;
+  TemplateDepth := 0;
+  SetLength(TemplateBraceDepths, 0);
+  InTemplateBody := False;
+  Index := 1;
+
+  while Index <= SourceLength do
+  begin
+    Character := ASource[Index];
+
+    if InTemplateBody then
+    begin
+      if Character = ESCAPE_CHARACTER then
+        Inc(Index, 2)
+      else if Character = '`' then
+      begin
+        InTemplateBody := False;
+        Inc(Index);
+        EmitCharacter(' ');
+      end
+      else if (Character = '$') and (Index < SourceLength) and
+              (ASource[Index + 1] = '{') then
+      begin
+        InTemplateBody := False;
+        Inc(TemplateDepth);
+        if TemplateDepth > Length(TemplateBraceDepths) then
+          SetLength(TemplateBraceDepths, TemplateDepth);
+        TemplateBraceDepths[TemplateDepth - 1] := BraceDepth;
+        Inc(Index, 2);
+        EmitCharacter(' ');
+      end
+      else
+        Inc(Index);
+      Continue;
+    end;
+
+    if Character = '/' then
+    begin
+      if (Index < SourceLength) and (ASource[Index + 1] = '/') then
+      begin
+        Inc(Index, 2);
+        while (Index <= SourceLength) and
+              not (ASource[Index] in LINE_TERMINATOR_CHARACTERS) do
+          Inc(Index);
+        EmitCharacter(' ');
+        Continue;
+      end;
+
+      if (Index < SourceLength) and (ASource[Index + 1] = '*') then
+      begin
+        NextIndex := PosEx(BLOCK_COMMENT_CLOSE, ASource, Index + 2);
+        if NextIndex = 0 then
+          Exit(False);
+        Index := NextIndex + Length(BLOCK_COMMENT_CLOSE);
+        EmitCharacter(' ');
+        Continue;
+      end;
+
+      if SlashOpensRegExpLiteral(Buffer, BufferLength) and
+         TrySkipRegExpLiteral(ASource, Index, NextIndex) then
+      begin
+        Index := NextIndex;
+        EmitCharacter(' ');
+        Continue;
+      end;
+    end
+    else if (Character = '''') or (Character = '"') then
+    begin
+      if TrySkipQuotedString(ASource, Index, NextIndex) then
+      begin
+        Index := NextIndex;
+        EmitCharacter(' ');
+        Continue;
+      end;
+    end
+    else if Character = '`' then
+    begin
+      InTemplateBody := True;
+      Inc(Index);
+      EmitCharacter(' ');
+      Continue;
+    end
+    else if Character = '{' then
+      Inc(BraceDepth)
+    else if Character = '}' then
+    begin
+      if (TemplateDepth > 0) and
+         (BraceDepth = TemplateBraceDepths[TemplateDepth - 1]) then
+      begin
+        Dec(TemplateDepth);
+        InTemplateBody := True;
+        Inc(Index);
+        EmitCharacter(' ');
+        Continue;
+      end;
+      if BraceDepth > 0 then
+        Dec(BraceDepth);
+    end;
+
+    EmitCharacter(Character);
+    Inc(Index);
+  end;
+
+  if InTemplateBody then
+    Exit(False);
+
+  SetLength(Buffer, BufferLength);
+  AStripped := Buffer;
+  Result := True;
+end;
+
 function LooksLikeESModuleSource(const ASource: string): Boolean;
 begin
   { `import(` is dynamic import, which CommonJS files use too, so a bare '('
     after the keyword is not evidence either way. }
   Result := ContainsKeywordBefore(ASource, ESM_IMPORT_KEYWORD,
-      [' ', #9, #13, #10, '{', '*', '"', '''']) or
+      SOURCE_WHITESPACE_CHARACTERS + ['{', '*', '"', '''']) or
     ContainsKeywordBefore(ASource, ESM_EXPORT_KEYWORD,
-      [' ', #9, #13, #10, '{', '*']);
+      SOURCE_WHITESPACE_CHARACTERS + ['{', '*']);
 end;
 
 function LooksLikeCommonJSSource(const ASource: string): Boolean;
+var
+  Code: string;
 begin
-  Result := (ContainsCallTo(ASource, COMMONJS_REQUIRE_NAME) or
-    (Pos(COMMONJS_MODULE_EXPORTS, ASource) > 0) or
-    ContainsMemberAccess(ASource, COMMONJS_EXPORTS_NAME)) and
-    (not LooksLikeESModuleSource(ASource));
+  { A file that cannot be scanned cleanly is classified on its raw text, which
+    is what this function did for every file before the scan existed. }
+  if not StripCommentsAndLiterals(ASource, Code) then
+    Code := ASource;
+
+  Result := (ContainsCallTo(Code, COMMONJS_REQUIRE_NAME) or
+    (Pos(COMMONJS_MODULE_EXPORTS, Code) > 0) or
+    ContainsMemberAccess(Code, COMMONJS_EXPORTS_NAME)) and
+    (not LooksLikeESModuleSource(Code));
 end;
 
 function IsCommonJSModuleFile(const AManifest: TGocciaPackageManifest;

--- a/source/units/Goccia.Modules.NodeResolution.pas
+++ b/source/units/Goccia.Modules.NodeResolution.pas
@@ -156,23 +156,23 @@ function IsPathInsideDirectory(const APath, ADirectory: string): Boolean;
   toolchain, and a file with neither is inert and loads fine either way.
 
   Comments, string and template bodies, and regular expression literals are
-  replaced with a space before the markers are looked for, so the words inside
-  them count for nothing. Every esbuild CommonJS bundle depends on this: its
-  banner comment reads "Annotate the CommonJS export names for ESM import in
-  node:", and on a raw scan those two words alone made the file pass as an ES
-  module.
+  replaced with a placeholder before the markers are looked for, so the words
+  inside them count for nothing. Every esbuild CommonJS bundle depends on this:
+  its banner comment reads "Annotate the CommonJS export names for ESM import
+  in node:", and on a raw scan those two words alone made the file pass as an
+  ES module.
 
-  The strip is a lexical pass, not a parse. Its one approximation is the
-  `/`: whether it opens a regular expression or divides is decided from the
-  last significant character, which is right everywhere except a literal
-  opening straight after a block's closing brace. Anything the pass cannot
-  finish — an
-  unterminated block comment or template literal — falls back to scanning the
-  raw text.
+  The strip is a lexical pass, not a parse, and it approximates in one place:
+  whether a `/` opens a regular expression or divides is read from the last
+  significant character. SlashOpensRegExpLiteral documents the two shapes that
+  come out wrong and which way each fails; a source the pass cannot finish at
+  all — an unterminated block comment or template literal — is classified on
+  its raw text instead, which is the behavior every file had before the pass
+  existed.
 
-  The remaining false negative is a marker built at runtime, `["exp" + "ort"]`
-  or a keyword the file only ever names in data. Removing that one would cost a
-  parse of every resolved package entry. }
+  What survives is a marker the file builds at runtime, `["exp" + "ort"]` or a
+  keyword it only ever names in data. Removing that would cost a parse of every
+  resolved package entry. }
 function LooksLikeCommonJSSource(const ASource: string): Boolean;
 
 { Whether a resolved file inside a package must be refused as CommonJS.
@@ -223,8 +223,41 @@ const
   ESM_EXPORT_KEYWORD = 'export';
   ESCAPE_CHARACTER = '\';
   BLOCK_COMMENT_CLOSE = '*/';
-  SOURCE_WHITESPACE_CHARACTERS = [' ', #9, #13, #10];
-  LINE_TERMINATOR_CHARACTERS = [#13, #10];
+  { Source text reaches this unit already decoded — the unit compiles as
+    delphiunicode, so a `string` is UTF-16 and every character ECMAScript names
+    below is one Char. The set literals stay ASCII because FPC's `in` only
+    reaches code unit 255; anything above it is compared directly. }
+  TAB_CHARACTER = #9;
+  LINE_FEED_CHARACTER = #10;
+  VERTICAL_TAB_CHARACTER = #11;
+  FORM_FEED_CHARACTER = #12;
+  CARRIAGE_RETURN_CHARACTER = #13;
+  SPACE_CHARACTER = ' ';
+  { ECMAScript WhiteSpace beyond ASCII, and both non-ASCII LineTerminators. A
+    `//` comment and a string literal end at U+2028 or U+2029 exactly as they
+    end at a newline. }
+  NO_BREAK_SPACE_CHARACTER = #$00A0;
+  OGHAM_SPACE_MARK_CHARACTER = #$1680;
+  FIRST_PUNCTUATION_SPACE_CHARACTER = #$2000;
+  LAST_PUNCTUATION_SPACE_CHARACTER = #$200A;
+  LINE_SEPARATOR_CHARACTER = #$2028;
+  PARAGRAPH_SEPARATOR_CHARACTER = #$2029;
+  NARROW_NO_BREAK_SPACE_CHARACTER = #$202F;
+  MEDIUM_MATHEMATICAL_SPACE_CHARACTER = #$205F;
+  IDEOGRAPHIC_SPACE_CHARACTER = #$3000;
+  ZERO_WIDTH_NO_BREAK_SPACE_CHARACTER = #$FEFF;
+  { Everything at or above this is outside ASCII, where identifier characters
+    vastly outnumber everything else that is not a separator. }
+  FIRST_NON_ASCII_CHARACTER = #$0080;
+  { What stripped text leaves behind. A string, template, or regular expression
+    is an operand, so it collapses to a value-closing punctuator and the slash
+    after it reads as division; the inside of a template collapses to an
+    operand-opening one, because a slash there opens a literal. A comment is
+    neither, so it collapses to a space and the scan looks straight past it.
+    None of the three is a character any marker can be spelled with. }
+  STRIPPED_VALUE_PLACEHOLDER = ')';
+  STRIPPED_OPERAND_PLACEHOLDER = ',';
+  STRIPPED_COMMENT_PLACEHOLDER = ' ';
   { Punctuators that close a value, so a `/` after one is division. The closing
     brace is counted here because an object literal is by far the more common
     thing to precede a slash; a regular expression opening right after a
@@ -274,9 +307,44 @@ type
     function Parse(const AText: string): TGocciaPackageManifest;
   end;
 
+{ The four characters ECMAScript ends a line at. A `//` comment and a quoted
+  string both stop here, U+2028 and U+2029 included. }
+function IsSourceLineTerminator(const ACharacter: Char): Boolean;
+begin
+  Result := (ACharacter = LINE_FEED_CHARACTER) or
+    (ACharacter = CARRIAGE_RETURN_CHARACTER) or
+    (ACharacter = LINE_SEPARATOR_CHARACTER) or
+    (ACharacter = PARAGRAPH_SEPARATOR_CHARACTER);
+end;
+
+{ Everything ECMAScript counts as WhiteSpace or LineTerminator — what may sit
+  between two tokens without being either of them. }
+function IsSourceSeparator(const ACharacter: Char): Boolean;
+begin
+  Result := IsSourceLineTerminator(ACharacter) or
+    (ACharacter in [TAB_CHARACTER, VERTICAL_TAB_CHARACTER,
+      FORM_FEED_CHARACTER, SPACE_CHARACTER]) or
+    (ACharacter = NO_BREAK_SPACE_CHARACTER) or
+    (ACharacter = OGHAM_SPACE_MARK_CHARACTER) or
+    ((ACharacter >= FIRST_PUNCTUATION_SPACE_CHARACTER) and
+     (ACharacter <= LAST_PUNCTUATION_SPACE_CHARACTER)) or
+    (ACharacter = NARROW_NO_BREAK_SPACE_CHARACTER) or
+    (ACharacter = MEDIUM_MATHEMATICAL_SPACE_CHARACTER) or
+    (ACharacter = IDEOGRAPHIC_SPACE_CHARACTER) or
+    (ACharacter = ZERO_WIDTH_NO_BREAK_SPACE_CHARACTER);
+end;
+
 function IsIdentifierPartCharacter(const ACharacter: Char): Boolean;
 begin
-  Result := (ACharacter in ['A'..'Z', 'a'..'z', '0'..'9', '_', '$']);
+  { Outside ASCII, a character in source text spells an identifier far more
+    often than anything else — `café` is a name, so the `/` after it divides.
+    Counting the whole non-ASCII range as identifier parts is what keeps such a
+    name from reading as an operand position, where the slash after it would
+    open a regular expression and blank out the rest of the line. The exception
+    is the separators, which are exactly what an identifier is not. }
+  Result := (ACharacter in ['A'..'Z', 'a'..'z', '0'..'9', '_', '$']) or
+    ((ACharacter >= FIRST_NON_ASCII_CHARACTER) and
+     (not IsSourceSeparator(ACharacter)));
 end;
 
 { ── Manifest parsing ───────────────────────────────────────── }
@@ -880,9 +948,17 @@ end;
 
 { ── CommonJS refusal ───────────────────────────────────────── }
 
+{ Whether AKeyword appears as a whole word followed by one of AFollowers.
+
+  ASeparatorFollows widens the follower set to every ECMAScript whitespace and
+  line terminator, which the ASCII set cannot spell: a keyword held apart from
+  its clause by U+00A0 or U+2028 is still that keyword. A member-access probe
+  passes False, because whitespace before a `.` is not what it is looking for. }
 function ContainsKeywordBefore(const ASource, AKeyword: string;
-  const AFollowers: TSysCharSet): Boolean;
+  const AFollowers: TSysCharSet;
+  const ASeparatorFollows: Boolean = False): Boolean;
 var
+  Follower: Char;
   Index, KeywordLength, SourceLength: Integer;
 begin
   KeywordLength := Length(AKeyword);
@@ -891,9 +967,13 @@ begin
   while Index > 0 do
   begin
     if ((Index = 1) or (not IsIdentifierPartCharacter(ASource[Index - 1]))) and
-       (Index + KeywordLength <= SourceLength) and
-       (ASource[Index + KeywordLength] in AFollowers) then
-      Exit(True);
+       (Index + KeywordLength <= SourceLength) then
+    begin
+      Follower := ASource[Index + KeywordLength];
+      if (Follower in AFollowers) or
+         (ASeparatorFollows and IsSourceSeparator(Follower)) then
+        Exit(True);
+    end;
     Index := PosEx(AKeyword, ASource, Index + 1);
   end;
   Result := False;
@@ -911,7 +991,7 @@ begin
     if (Index = 1) or (not IsIdentifierPartCharacter(ASource[Index - 1])) then
     begin
       Scan := Index + NameLength;
-      while (Scan <= SourceLength) and (ASource[Scan] in [' ', #9, #13, #10]) do
+      while (Scan <= SourceLength) and IsSourceSeparator(ASource[Scan]) do
         Inc(Scan);
       if (Scan <= SourceLength) and (ASource[Scan] = '(') then
         Exit(True);
@@ -945,8 +1025,14 @@ begin
   begin
     if ASource[Index] = ESCAPE_CHARACTER then
     begin
-      { Also carries a line continuation past the terminator below. }
-      Inc(Index, 2);
+      { A backslash carries a line continuation past the terminator below, and
+        CRLF is one terminator rather than two. }
+      Inc(Index);
+      if (Index < SourceLength) and
+         (ASource[Index] = CARRIAGE_RETURN_CHARACTER) and
+         (ASource[Index + 1] = LINE_FEED_CHARACTER) then
+        Inc(Index);
+      Inc(Index);
       Continue;
     end;
     if ASource[Index] = Quote then
@@ -954,7 +1040,7 @@ begin
       ANextIndex := Index + 1;
       Exit(True);
     end;
-    if ASource[Index] in LINE_TERMINATOR_CHARACTERS then
+    if IsSourceLineTerminator(ASource[Index]) then
       Break;
     Inc(Index);
   end;
@@ -982,7 +1068,7 @@ begin
       Inc(Index, 2);
       Continue;
     end;
-    if ASource[Index] in LINE_TERMINATOR_CHARACTERS then
+    if IsSourceLineTerminator(ASource[Index]) then
       Break;
     if InCharacterClass then
     begin
@@ -1014,17 +1100,34 @@ begin
 end;
 
 { Whether a `/` following the code emitted so far opens a regular expression
-  literal rather than dividing. The decision is made from the last significant
-  character instead of a token stream, which is the one place this scan
-  approximates: it is right for every operand-position slash and wrong only for
-  a literal that opens straight after a block's closing brace. }
+  literal rather than dividing.
+
+  The decision comes from the last significant character rather than a token
+  stream, and that is where this scan approximates. Division needs a value in
+  front of it, so anything that closes one — an identifier, a number, a closing
+  bracket, a postfix `++`, or the placeholder a stripped literal left behind —
+  means division, and every other punctuator leaves an operand position where a
+  slash opens a literal. Two shapes still read wrong, both rare:
+
+  - A literal opening straight after a block's closing brace or a condition's
+    `)` (`if (ok) /re/.test(x)`) is taken for division, so its body is scanned
+    as code. A quote inside it can then open a string scan that runs to the
+    next quote on the line.
+  - A division after an identifier that spells one of the keywords below
+    (`const of = 4; of / 2`) is taken for a literal.
+
+  The second shape is the damaging one. When the bogus literal finds a second
+  `/` on the line, everything between the two is discarded along with any
+  marker in it, which can turn a genuine ES module into a CommonJS refusal. It
+  is only when no second `/` follows that the slash is kept as code and nothing
+  is lost. }
 function SlashOpensRegExpLiteral(const ACode: string;
   const ALength: Integer): Boolean;
 var
   Scan, WordStart: Integer;
 begin
   Scan := ALength;
-  while (Scan >= 1) and (ACode[Scan] in SOURCE_WHITESPACE_CHARACTERS) do
+  while (Scan >= 1) and IsSourceSeparator(ACode[Scan]) do
     Dec(Scan);
   if Scan < 1 then
     Exit(True);
@@ -1046,13 +1149,15 @@ begin
 end;
 
 { Replaces every comment, string body, template body, and regular expression
-  literal in ASource with a single space, leaving the code around them.
+  literal in ASource with a placeholder, leaving the code around them.
 
-  The space matters: it keeps the marker scan from gluing the two halves of
-  `imp/*x*/ort` into a keyword. Template substitutions stay as code, since
-  a substitution holds a real expression; the brace stack is what tells the
-  closing brace that ends one from the closing brace of an object literal
-  inside it.
+  The placeholder matters twice over. It keeps the marker scan from gluing the
+  two halves of `imp/*x*/ort` into a keyword, and its choice tells the slash
+  scan above what stood there: a literal collapses to a value, so `var a = "p"
+  / 2` still divides, while a comment collapses to a space it can see past.
+  Template substitutions stay as code, since a substitution holds a real
+  expression; the brace stack is what tells the closing brace that ends one
+  from the closing brace of an object literal inside it.
 
   Returns False when the scan cannot finish — an unterminated block comment or
   template literal — so the caller can fall back to the raw text instead of
@@ -1098,7 +1203,7 @@ begin
       begin
         InTemplateBody := False;
         Inc(Index);
-        EmitCharacter(' ');
+        EmitCharacter(STRIPPED_VALUE_PLACEHOLDER);
       end
       else if (Character = '$') and (Index < SourceLength) and
               (ASource[Index + 1] = '{') then
@@ -1109,7 +1214,7 @@ begin
           SetLength(TemplateBraceDepths, TemplateDepth);
         TemplateBraceDepths[TemplateDepth - 1] := BraceDepth;
         Inc(Index, 2);
-        EmitCharacter(' ');
+        EmitCharacter(STRIPPED_OPERAND_PLACEHOLDER);
       end
       else
         Inc(Index);
@@ -1122,9 +1227,9 @@ begin
       begin
         Inc(Index, 2);
         while (Index <= SourceLength) and
-              not (ASource[Index] in LINE_TERMINATOR_CHARACTERS) do
+              (not IsSourceLineTerminator(ASource[Index])) do
           Inc(Index);
-        EmitCharacter(' ');
+        EmitCharacter(STRIPPED_COMMENT_PLACEHOLDER);
         Continue;
       end;
 
@@ -1134,7 +1239,7 @@ begin
         if NextIndex = 0 then
           Exit(False);
         Index := NextIndex + Length(BLOCK_COMMENT_CLOSE);
-        EmitCharacter(' ');
+        EmitCharacter(STRIPPED_COMMENT_PLACEHOLDER);
         Continue;
       end;
 
@@ -1142,7 +1247,7 @@ begin
          TrySkipRegExpLiteral(ASource, Index, NextIndex) then
       begin
         Index := NextIndex;
-        EmitCharacter(' ');
+        EmitCharacter(STRIPPED_VALUE_PLACEHOLDER);
         Continue;
       end;
     end
@@ -1151,7 +1256,7 @@ begin
       if TrySkipQuotedString(ASource, Index, NextIndex) then
       begin
         Index := NextIndex;
-        EmitCharacter(' ');
+        EmitCharacter(STRIPPED_VALUE_PLACEHOLDER);
         Continue;
       end;
     end
@@ -1159,7 +1264,7 @@ begin
     begin
       InTemplateBody := True;
       Inc(Index);
-      EmitCharacter(' ');
+      EmitCharacter(STRIPPED_OPERAND_PLACEHOLDER);
       Continue;
     end
     else if Character = '{' then
@@ -1172,7 +1277,7 @@ begin
         Dec(TemplateDepth);
         InTemplateBody := True;
         Inc(Index);
-        EmitCharacter(' ');
+        EmitCharacter(STRIPPED_VALUE_PLACEHOLDER);
         Continue;
       end;
       if BraceDepth > 0 then
@@ -1194,11 +1299,11 @@ end;
 function LooksLikeESModuleSource(const ASource: string): Boolean;
 begin
   { `import(` is dynamic import, which CommonJS files use too, so a bare '('
-    after the keyword is not evidence either way. }
+    after the keyword is not evidence either way. Whitespace counts as a
+    follower in its own right, so the sets name only the punctuation. }
   Result := ContainsKeywordBefore(ASource, ESM_IMPORT_KEYWORD,
-      SOURCE_WHITESPACE_CHARACTERS + ['{', '*', '"', '''']) or
-    ContainsKeywordBefore(ASource, ESM_EXPORT_KEYWORD,
-      SOURCE_WHITESPACE_CHARACTERS + ['{', '*']);
+      ['{', '*', '"', ''''], True) or
+    ContainsKeywordBefore(ASource, ESM_EXPORT_KEYWORD, ['{', '*'], True);
 end;
 
 function LooksLikeCommonJSSource(const ASource: string): Boolean;


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- The CommonJS-vs-ESM source detector misclassified modules under `{$mode delphiunicode}`: `IsIdentifierPartCharacter` treated bytes ≥ `#$80` as non-identifier, so a bare specifier in a source using non-ASCII identifiers could be read as CommonJS and wrongly refused (or an ESM file mis-detected). Identifier classification now follows UTF-16 code units, and the comment/literal stripper uses value sentinels that cannot collide with real source tokens.
- Impact: bare-specifier resolution and the CommonJS-refusal path now classify non-ASCII sources correctly in both execution modes.

## Testing

- [x] Full suite in both modes; differential zero divergence under bun 1.4.0 and CI-pinned 1.3.14
- [x] Node-resolution Pascal unit tests cover the identifier-boundary and sentinel cases
- [x] `./format.pas --check`, markdownlint, and doc-link checks clean
