### PR TITLE
fix(runtime): reject async promises with the thrown value across the executor boundary

### DIFF
--- a/scripts/differential/l-modulefndecl.test.js
+++ b/scripts/differential/l-modulefndecl.test.js
@@ -19,9 +19,12 @@ import {
   arrowClosureRead,
   arrowConstruct,
   arrowFieldRead,
+  arrowThrowAfterAwait,
+  asyncFailure,
   derivedTickCount,
   fnDeclArrowConstruct,
   fnDeclBoundConstruct,
+  fnDeclCatchAfterAwait,
   fnDeclClosureRead,
   fnDeclConstruct,
   fnDeclDerivedConstruct,
@@ -33,6 +36,8 @@ import {
   fnDeclNestedConstruct,
   fnDeclOverriddenLeafConstruct,
   fnDeclSpreadConstruct,
+  fnDeclThrowAfterAwait,
+  fnDeclThrowBeforeAwait,
   implicitTickCount,
 } from "./mods/fndecl.js";
 
@@ -270,5 +275,37 @@ describe("construction from module function declarations", () => {
 
   test("entry file: an all-implicit chain over a returning base still overrides", () => {
     expect(Object.keys(new OverriddenMiddle())).toEqual(["tag", "b"]);
+  });
+
+  // A module's async function declarations are linked, not compiled with the
+  // module body, so the callee's throw crosses machinery on its way out. Once
+  // the declaration has suspended at an await, the crossing happens on the
+  // resumed body — a different path from the one the pre-await throw takes.
+  test("an async module function declaration rejects with a callee's throw", async () => {
+    const settled = [];
+    for (const start of [
+      fnDeclThrowAfterAwait,
+      fnDeclThrowBeforeAwait,
+      arrowThrowAfterAwait,
+    ]) {
+      try {
+        await start();
+        settled.push("resolved");
+      } catch (error) {
+        settled.push(error);
+      }
+    }
+    expect(settled).toEqual([asyncFailure, asyncFailure, asyncFailure]);
+    for (const error of settled) {
+      expect(error.name).toBe("AsyncFailure");
+      expect(error.message).toBe("id-async");
+    }
+  });
+
+  test("catch in a resumed async declaration binds the thrown value itself", async () => {
+    const caught = await fnDeclCatchAfterAwait();
+    expect(caught).toBe(asyncFailure);
+    expect(caught.name).toBe("AsyncFailure");
+    expect(caught.message).toBe("id-async");
   });
 });

--- a/scripts/differential/mods/fndecl.js
+++ b/scripts/differential/mods/fndecl.js
@@ -232,3 +232,46 @@ export class Factory {
     return PREFIX + ORIGIN.x;
   }
 }
+
+// Async declarations whose body throws through a callee. A module's function
+// declarations are created at link time while `raiseAsyncFailure` next to them
+// is compiled with the module body, so in bytecode mode the throw crosses from
+// one machinery into the other — and it crosses back only once the async
+// function has already suspended at an await.
+export class AsyncFailure extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "AsyncFailure";
+  }
+}
+
+export const asyncFailure = new AsyncFailure(PREFIX + "async");
+
+const raiseAsyncFailure = () => {
+  throw asyncFailure;
+};
+
+export async function fnDeclThrowAfterAwait() {
+  await Promise.resolve(1);
+  raiseAsyncFailure();
+}
+
+export async function fnDeclThrowBeforeAwait() {
+  raiseAsyncFailure();
+  await Promise.resolve(1);
+}
+
+export async function fnDeclCatchAfterAwait() {
+  await Promise.resolve(1);
+  try {
+    raiseAsyncFailure();
+    return null;
+  } catch (error) {
+    return error;
+  }
+}
+
+export const arrowThrowAfterAwait = async () => {
+  await Promise.resolve(1);
+  raiseAsyncFailure();
+};

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -244,7 +244,8 @@ uses
   Goccia.Values.SymbolValue,
   Goccia.Values.ToObject,
   Goccia.Values.ToPrimitive,
-  Goccia.Values.TypedArrayValue;
+  Goccia.Values.TypedArrayValue,
+  Goccia.VM.Exception;
 
 procedure RunClassInstanceInitializers(const AClassValue: TGocciaClassValue;
   const AInstance: TGocciaObjectValue;
@@ -7725,7 +7726,13 @@ end;
 
 function PascalExceptionToErrorObject(const E: Exception): TGocciaValue;
 begin
-  if E is TGocciaTypeError then
+  { A JS throw that left the bytecode VM already carries the guest's completion
+    value. Synthesizing a fresh Error from the Pascal message would hand `catch`
+    a different object whose `message` is EGocciaBytecodeThrow's "Name: message"
+    rendering; the thrown value itself is what ES2026 §14.15.3 binds. }
+  if E is EGocciaBytecodeThrow then
+    Result := EGocciaBytecodeThrow(E).ThrownValue
+  else if E is TGocciaTypeError then
     Result := CreateErrorObject(TYPE_ERROR_NAME, E.Message)
   else if E is TGocciaReferenceError then
     Result := CreateErrorObject(REFERENCE_ERROR_NAME, E.Message)

--- a/source/units/Goccia.Values.FunctionValue.pas
+++ b/source/units/Goccia.Values.FunctionValue.pas
@@ -139,7 +139,8 @@ uses
   Goccia.Values.NativeFunction,
   Goccia.Values.ObjectValue,
   Goccia.Values.PromiseValue,
-  Goccia.Values.ToObject;
+  Goccia.Values.ToObject,
+  Goccia.VM.Exception;
 
 type
   TGocciaAsyncFunctionEvaluation = class(TGocciaObjectValue)
@@ -186,7 +187,16 @@ function TryRejectAsyncPromiseWithException(
   const AException: Exception): Boolean;
 begin
   Result := True;
-  if AException is TGocciaThrowValue then
+  { A hoisted module-level `async function` is an interpreter closure even
+    under the bytecode executor (the module loader creates it during linking),
+    so its body can call a compiled function whose JS throw leaves the VM as
+    EGocciaBytecodeThrow. That is a guest completion carrying the thrown value,
+    exactly like TGocciaThrowValue; without this branch the resume path treated
+    it as an engine fault, re-raised it into the microtask queue, and left the
+    async function's promise forever pending. }
+  if AException is EGocciaBytecodeThrow then
+    APromise.Reject(EGocciaBytecodeThrow(AException).ThrownValue)
+  else if AException is TGocciaThrowValue then
     APromise.Reject(TGocciaThrowValue(AException).Value)
   else if AException is TGocciaTypeError then
     APromise.Reject(CreateErrorObject(TYPE_ERROR_NAME, AException.Message))

--- a/tests/language/modules/hoisted-function-import-capture/async-callee-throw.js
+++ b/tests/language/modules/hoisted-function-import-capture/async-callee-throw.js
@@ -1,0 +1,43 @@
+/*---
+description: Hoisted async function declarations propagate a callee's throw after resuming from await
+features: [modules, compat-function]
+---*/
+
+import {
+  boom,
+  catchesAfterAwait,
+  throwsAfterAwait,
+  throwsBeforeAwait,
+} from "./helpers/hoisted-async-throw.js";
+
+describe("hoisted async function declarations propagate callee throws", () => {
+  test("rejects with the thrown value when the throw follows an await", async () => {
+    let caught = null;
+    try {
+      await throwsAfterAwait();
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBe(boom);
+    expect(caught.name).toBe("Boom");
+    expect(caught.message).toBe("boom");
+  });
+
+  test("rejects with the thrown value when the throw precedes any await", async () => {
+    let caught = null;
+    try {
+      await throwsBeforeAwait();
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBe(boom);
+    expect(caught.message).toBe("boom");
+  });
+
+  test("catch inside the resumed body binds the thrown value itself", async () => {
+    const caught = await catchesAfterAwait();
+    expect(caught).toBe(boom);
+    expect(caught.name).toBe("Boom");
+    expect(caught.message).toBe("boom");
+  });
+});

--- a/tests/language/modules/hoisted-function-import-capture/helpers/hoisted-async-throw.js
+++ b/tests/language/modules/hoisted-function-import-capture/helpers/hoisted-async-throw.js
@@ -1,0 +1,32 @@
+export class Boom extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "Boom";
+  }
+}
+
+export const boom = new Boom("boom");
+
+const raise = () => {
+  throw boom;
+};
+
+export async function throwsAfterAwait() {
+  await Promise.resolve(1);
+  raise();
+}
+
+export async function catchesAfterAwait() {
+  await Promise.resolve(1);
+  try {
+    raise();
+    return null;
+  } catch (error) {
+    return error;
+  }
+}
+
+export async function throwsBeforeAwait() {
+  raise();
+  await Promise.resolve(1);
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- A compiled callee's `throw` crosses the interpreter/bytecode executor boundary as the Pascal exception `EGocciaBytecodeThrow`, but the async-promise rejection path and `PascalExceptionToErrorObject` only recognized `TGocciaThrowValue` — so an exported module-level `async` function rejecting from compiled code produced a synthesized `Error("Name: message")` in bytecode mode instead of the actual thrown value.
- Both boundary handlers now unwrap `EGocciaBytecodeThrow`, preserving the thrown value's identity across the boundary and restoring interpreter/bytecode parity for async rejections.

## Testing

- [x] Full suite in both modes; differential zero divergence under bun 1.4.0 and CI-pinned 1.3.14
- [x] Regression test: an exported async function rejecting from compiled code preserves the thrown value in both modes
- [x] `./format.pas --check`, markdownlint, and doc-link checks clean
