### PR TITLE
fix(classes): run the implicit-constructor chain per spec on every construction path

### DIFF
--- a/docs/differential-testing.md
+++ b/docs/differential-testing.md
@@ -105,17 +105,23 @@ field. Interpreted mode did exactly that until the shared Construct operation
 was routed into the same instantiation `new` uses, and the suite pins the
 newTarget and override-return shapes alongside it.
 
-One shape is deliberately absent. A class whose superclass chain reaches a
-built-in (`extends Array`, `extends Promise`) is covered against node instead,
-in `tests/built-ins/Reflect/construct/native-chain-instance-elements.js`: the
-shared Construct operation declines such a class so that the built-in keeps its
-argument-validation ordering, and the instance elements are run afterwards
-against the receiver it allocated. That file asserts every Construct route
-agrees with `new`, so a partial fix cannot land unnoticed, and
-`tests/language/classes/native-chain-implicit-constructors.js` covers the
-intermediate classes in a longer chain. `new.target` inside a field initializer
-is absent for a different reason: node, bun and goccia all agree it is
-`undefined` as a
+It also covers the two ways a chain can stop being what it was declared as. A
+class whose superclass chain reaches a built-in (`extends Array`, `extends
+Promise`) has an implicit constructor for every class in between, and each of
+them owes the receiver its own instance elements; and
+`Object.setPrototypeOf` on a constructor moves where §13.3.7.3
+GetSuperConstructor sends `super()`, which can land on a built-in, on nothing,
+or on an object that is not a constructor at all. Node, bun and goccia agree on
+all of it. The wider matrices — every Construct route against `new`, longer
+chains, private fields — live against node in
+`tests/built-ins/Reflect/construct/native-chain-instance-elements.js`,
+`tests/language/classes/native-chain-implicit-constructors.js` and
+`tests/language/classes/constructor-prototype-retargeting.js`, because the
+shared Construct operation declines a native chain so the built-in keeps its
+argument-validation ordering and those files pin what that costs.
+
+`new.target` inside a field initializer is absent for a different reason: node,
+bun and goccia all agree it is `undefined` as a
 script, but under `bun test` 1.4.0 the same class body reports it defined, so
 gating would report bun's transpile as a goccia divergence. It is covered
 against node in `tests/built-ins/Reflect/construct/instance-elements.js`.

--- a/docs/differential-testing.md
+++ b/docs/differential-testing.md
@@ -105,15 +105,17 @@ field. Interpreted mode did exactly that until the shared Construct operation
 was routed into the same instantiation `new` uses, and the suite pins the
 newTarget and override-return shapes alongside it.
 
-Two shapes are deliberately absent. A class whose superclass chain reaches a
-built-in (`extends Array`, `extends Promise`) is a known interpreted-mode gap —
-the shared Construct operation declines it and builds it without instance
-elements, while `new` initializes them — so gating on bun would report a gap
-already tracked elsewhere. It is pinned in
-`tests/built-ins/Reflect/construct/native-chain-instance-elements.js`, which
-asserts that all the Construct routes agree with each other so that a partial
-fix cannot land unnoticed. `new.target` inside a field initializer is absent for
-the opposite reason: node, bun and goccia all agree it is `undefined` as a
+One shape is deliberately absent. A class whose superclass chain reaches a
+built-in (`extends Array`, `extends Promise`) is covered against node instead,
+in `tests/built-ins/Reflect/construct/native-chain-instance-elements.js`: the
+shared Construct operation declines such a class so that the built-in keeps its
+argument-validation ordering, and the instance elements are run afterwards
+against the receiver it allocated. That file asserts every Construct route
+agrees with `new`, so a partial fix cannot land unnoticed, and
+`tests/language/classes/native-chain-implicit-constructors.js` covers the
+intermediate classes in a longer chain. `new.target` inside a field initializer
+is absent for a different reason: node, bun and goccia all agree it is
+`undefined` as a
 script, but under `bun test` 1.4.0 the same class body reports it defined, so
 gating would report bun's transpile as a goccia divergence. It is covered
 against node in `tests/built-ins/Reflect/construct/instance-elements.js`.

--- a/scripts/differential/q-reflectconstruct.test.js
+++ b/scripts/differential/q-reflectconstruct.test.js
@@ -403,3 +403,164 @@ describe("other entries into Construct build the same instance", () => {
     expect(Object.getPrototypeOf(reflected)).toBe(Object.getPrototypeOf(built));
   });
 });
+
+describe("construction after Object.setPrototypeOf on the constructor", () => {
+  // ES2026 §13.3.7.3 GetSuperConstructor reads the active function object's
+  // [[GetPrototypeOf]] when super() runs, so a retarget moves every hop above
+  // it — and can point super() at something that is not a constructor at all,
+  // which §13.3.7.1 step 3 rejects. Every case here agrees under node, bun and
+  // goccia.
+  const expectSuperTypeError = (build) => {
+    let name = "<no error>";
+    try {
+      build();
+    } catch (error) {
+      name = error.name;
+    }
+    expect(name).toBe("TypeError");
+  };
+
+  test("a plain object is not a super constructor", () => {
+    class Declared {
+      constructor() {
+        this.who = "declared";
+      }
+    }
+    class Sub extends Declared {}
+    Object.setPrototypeOf(Sub, {});
+
+    expectSuperTypeError(() => new Sub());
+    expectSuperTypeError(() => Reflect.construct(Sub, []));
+  });
+
+  test("null leaves nothing to resolve super() through", () => {
+    class Declared {}
+    class Sub extends Declared {}
+    Object.setPrototypeOf(Sub, null);
+
+    expectSuperTypeError(() => new Sub());
+  });
+
+  test("a retarget crossing the declared chain still terminates", () => {
+    // The mutable [[Prototype]] relation and the fixed declared-superclass
+    // relation are each acyclic; a resolver that mixed them walked their union
+    // and could close on itself.
+    class Base {
+      b = 1;
+    }
+    class Middle extends Base {
+      m = 2;
+    }
+    class Leaf extends Middle {
+      l = 3;
+    }
+    Object.setPrototypeOf(Leaf, {});
+    Object.setPrototypeOf(Middle, Leaf);
+
+    expectSuperTypeError(() => new Leaf());
+  });
+
+  test("retargeting onto a built-in runs it and drops the declared super", () => {
+    class Declared {
+      constructor() {
+        this.who = "declared";
+      }
+    }
+    class Sub extends Declared {}
+    Object.setPrototypeOf(Sub, Error);
+
+    const instance = new Sub("boom");
+    expect(instance.message).toBe("boom");
+    expect(instance.who).toBe(undefined);
+  });
+
+  test("a retarget part-way up moves everything above it", () => {
+    class Base {
+      b = "b";
+    }
+    class Middle extends Base {
+      m = "m";
+    }
+    class Leaf extends Middle {
+      l = "l";
+    }
+    class Alt {
+      a = "a";
+    }
+    Object.setPrototypeOf(Middle, Alt);
+
+    expect(Object.keys(new Leaf())).toEqual(["a", "m", "l"]);
+  });
+
+  test("an explicit leaf constructor's super() follows the retarget too", () => {
+    class Base {
+      b = "b";
+    }
+    class Middle extends Base {
+      m = "m";
+    }
+    class Leaf extends Middle {
+      l = "l";
+
+      constructor() {
+        super();
+      }
+    }
+    class Alt {
+      a = "a";
+    }
+    Object.setPrototypeOf(Middle, Alt);
+
+    expect(Object.keys(new Leaf())).toEqual(["a", "m", "l"]);
+  });
+});
+
+describe("implicit constructors over a built-in chain", () => {
+  test("every class between the subclass and the built-in contributes", () => {
+    class Middle extends Array {
+      m = "m";
+    }
+    class Leaf extends Middle {
+      l = "l";
+    }
+
+    expect(Object.keys(new Leaf())).toEqual(["m", "l"]);
+    expect(Object.keys(Reflect.construct(Leaf, []))).toEqual(["m", "l"]);
+  });
+
+  test("a borrowed constructor's super() runs the executor once", () => {
+    class Tagged extends Promise {
+      tag = "t";
+
+      constructor(executor) {
+        super(executor);
+      }
+    }
+    class Borrowing extends Tagged {}
+
+    let runs = 0;
+    const instance = new Borrowing((resolve) => {
+      runs += 1;
+      resolve(1);
+    });
+    expect(runs).toBe(1);
+    expect(instance.tag).toBe("t");
+  });
+
+  test("a foreign newTarget decides where Map looks its adder up", () => {
+    class First extends Map {}
+    class Second extends First {}
+    class Foreign {}
+
+    let name = "<no error>";
+    try {
+      Reflect.construct(Second, [[[1, 2]]], Foreign);
+    } catch (error) {
+      name = error.name;
+    }
+    expect(name).toBe("TypeError");
+
+    const empty = Reflect.construct(Second, [], Foreign);
+    expect(Object.getPrototypeOf(empty)).toBe(Foreign.prototype);
+  });
+});

--- a/scripts/test-cli.ts
+++ b/scripts/test-cli.ts
@@ -860,6 +860,38 @@ console.log("--max-instructions (bytecode)...");
   if (json.error?.type !== "InstructionLimitError") throw new Error(`Expected InstructionLimitError, got ${json.error?.type}`);
 }
 
+// -- super-constructor resolution terminates without the sandbox limits --------
+//
+// ES2026 §13.3.7.3 GetSuperConstructor resolves super() through the
+// constructor's [[Prototype]]. A resolver that fell back to the declared
+// superclass when that hop landed on a non-constructor walked the union of two
+// relations: each is acyclic on its own, their union is not. The union spun
+// forever inside one native call, so neither --timeout nor --max-instructions
+// could interrupt it. It has to terminate on its own.
+
+const retargetCycle =
+  "class Base { b = 1; }\n" +
+  "class Middle extends Base { m = 2; }\n" +
+  "class Leaf extends Middle { l = 3; }\n" +
+  "Object.setPrototypeOf(Leaf, {});\n" +
+  "Object.setPrototypeOf(Middle, Leaf);\n" +
+  "new Leaf();\n";
+
+for (const mode of ["interpreted", "bytecode"] as const) {
+  console.log(`super-constructor cycle terminates (${mode})...`);
+  const modeArgs = mode === "bytecode" ? ["--mode=bytecode"] : [];
+  const { exitCode, json } = runLoaderJson(retargetCycle, modeArgs, { timeout: 20_000 });
+  if (exitCode !== 1) throw new Error(`Retarget cycle exit code should be 1, got ${exitCode} (${mode})`);
+  if (json.error?.type !== "TypeError") {
+    throw new Error(`Expected TypeError for the retarget cycle, got ${json.error?.type} (${mode})`);
+  }
+  // And the sandbox limits stay effective for code that really is unbounded.
+  const bounded = runLoaderJson(retargetCycle, [...modeArgs, "--max-instructions=5000000"], { timeout: 20_000 });
+  if (bounded.json.error?.type !== "TypeError") {
+    throw new Error(`Retarget cycle should still be a TypeError under a limit, got ${bounded.json.error?.type} (${mode})`);
+  }
+}
+
 // -- --max-memory (Loader) ------------------------------------------------------
 
 console.log("--max-memory (default positive)...");

--- a/source/units/Goccia.Compiler.Expressions.pas
+++ b/source/units/Goccia.Compiler.Expressions.pas
@@ -157,6 +157,7 @@ uses
   Goccia.Constants.ConstructorNames,
   Goccia.Constants.ErrorNames,
   Goccia.Constants.PropertyNames,
+  Goccia.Error.Messages,
   Goccia.Keywords.Reserved,
   Goccia.Modules,
   Goccia.Token,
@@ -1761,7 +1762,7 @@ begin
     begin
       OkJump := EmitJumpInstruction(ACtx, OP_JUMP_IF_TRUE, FlagReg);
       EmitReferenceError(ACtx,
-        'Must call super constructor before accessing this');
+        SErrorSuperConstructorNotCalled);
       PatchJumpTarget(ACtx, OkJump);
     end;
   finally

--- a/source/units/Goccia.Error.Messages.pas
+++ b/source/units/Goccia.Error.Messages.pas
@@ -38,6 +38,18 @@ resourcestring
   // Type errors — constructors
   SErrorNotConstructor = '''%s'' is not a constructor';
   SErrorValueNotConstructor = '%s is not a constructor';
+  SErrorSuperNotConstructor = 'Super constructor is not a constructor';
+
+  { ES2026 §10.2.2 [[Construct]] step 13.c and §13.3.7.1 SuperCall: a derived
+    constructor leaves `this` uninitialized until super() returns, and both
+    reading `this` and returning report it. Which of the two fires first is an
+    implementation detail — the interpreter reaches the return check for a body
+    that never touches `this`, the compiler's OP_CHECK_DERIVED_THIS reaches the
+    access check for one that does — so both modes and both checks share this
+    one message rather than describing the route they took. Node v24.0.1 words
+    it the same way for the same reason. }
+  SErrorSuperConstructorNotCalled = 'Must call super constructor in derived ' +
+    'class before accessing ''this'' or returning from derived constructor';
 
   // Type errors — iterables and spread
   SErrorSpreadRequiresIterable = 'Spread syntax requires an iterable';

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -3738,7 +3738,7 @@ begin
   if AClassValue.ConstructorMethod.LastSuperConstructorCalled then
     Exit;
   ThrowReferenceError(
-    'Must call super constructor before returning from derived constructor');
+    SErrorSuperConstructorNotCalled);
 end;
 
 function InvokeConstructableWithReceiver(const AConstructor: TGocciaValue;
@@ -3760,6 +3760,7 @@ var
     NativeInstance: TGocciaObjectValue;
     NativeInstanceRooted: Boolean;
     ReceiverPrototype: TGocciaObjectValue;
+    ImplicitSuper: TGocciaObjectValue;
   begin
     NativeInstance := nil;
     NativeInstanceRooted := False;
@@ -3783,15 +3784,26 @@ var
           TGocciaInstanceValue(NativeInstance).FinalizeNativeFromArguments(AArguments);
         Result := NativeInstance;
       end
-      else if Assigned(ClassConstructor.SuperClass) then
-        Result := InvokeConstructableWithReceiver(ClassConstructor.SuperClass,
-          AArguments, AReceiver, AContext, EffectiveNewTarget)
-      else if Assigned(ClassConstructor.NativeSuperConstructor) then
-        Result := InvokeConstructableWithReceiver(
-          ClassConstructor.NativeSuperConstructor, AArguments, AReceiver,
-          AContext, EffectiveNewTarget)
-      else if AReceiver is TGocciaInstanceValue then
-        TGocciaInstanceValue(AReceiver).InitializeNativeFromArguments(AArguments);
+      else
+      begin
+        { §13.3.7.3 GetSuperConstructor: the implicit constructor's super()
+          resolves through this class's own [[Prototype]] at call time, so a
+          retargeted class forwards to what it now points at rather than to the
+          superclass it was declared with. }
+        if ImplicitSuperConstructorIsAbsent(ClassConstructor) then
+          ThrowTypeError(SErrorSuperNotConstructor, SSuggestNotConstructorType);
+        ImplicitSuper := ImplicitSuperConstructorTarget(ClassConstructor);
+        if Assigned(ImplicitSuper) then
+        begin
+          if (ImplicitSuper = TGocciaFunctionBase.GetSharedPrototype) or
+             (not ImplicitSuper.IsConstructable) then
+            ThrowTypeError(SErrorSuperNotConstructor, SSuggestNotConstructorType);
+          Result := InvokeConstructableWithReceiver(ImplicitSuper,
+            AArguments, AReceiver, AContext, EffectiveNewTarget);
+        end
+        else if AReceiver is TGocciaInstanceValue then
+          TGocciaInstanceValue(AReceiver).InitializeNativeFromArguments(AArguments);
+      end;
 
       ValidateClassConstructorReturn(ClassConstructor, Result);
       if Result is TGocciaObjectValue then
@@ -4099,6 +4111,7 @@ var
   ConstructorThisValue: TGocciaValue;
   CurrentCtorClassValue: TGocciaValue;
   CurrentCtorClass: TGocciaClassValue;
+  ResolvedSuperConstructor: TGocciaObjectValue;
   Roots: TGocciaActiveRootFrame;
   DirectEvalResult: TGocciaValue;
   PreviousCallSite: TGocciaCallSite;
@@ -4173,9 +4186,27 @@ begin
   // Handle super() calls specially
   if ACallExpression.Callee is TGocciaSuperExpression then
   begin
+    ResolvedSuperConstructor := nil;
     SuperClassValue := AContext.Scope.FindSuperConstructor;
     if not Assigned(SuperClassValue) then
       SuperClassValue := EvaluateExpression(ACallExpression.Callee, AContext);
+    { ES2026 §13.3.7.3 GetSuperConstructor reads the active function object's
+      [[GetPrototypeOf]] when super() runs, not the superclass the class was
+      declared with. The scope binding was captured at class-definition time,
+      so an Object.setPrototypeOf on the constructor since then has to be
+      picked up here — otherwise an explicit constructor over a retargeted
+      class calls the old superclass while an implicit one calls the new. }
+    CurrentCtorClassValue := AContext.Scope.FindOwningClass;
+    if CurrentCtorClassValue is TGocciaClassValue then
+    begin
+      if ImplicitSuperConstructorIsAbsent(
+           TGocciaClassValue(CurrentCtorClassValue)) then
+        ThrowTypeError(SErrorSuperNotConstructor, SSuggestNotConstructorType);
+      ResolvedSuperConstructor := ImplicitSuperConstructorTarget(
+        TGocciaClassValue(CurrentCtorClassValue));
+      if Assigned(ResolvedSuperConstructor) then
+        SuperClassValue := ResolvedSuperConstructor;
+    end;
     AddValueRoot(Roots, SuperClassValue);
     if SuperClassValue is TGocciaClassValue then
       SuperClass := TGocciaClassValue(SuperClassValue)
@@ -4184,6 +4215,12 @@ begin
     if (not Assigned(SuperClass)) and
        (not ((SuperClassValue is TGocciaObjectValue) and SuperClassValue.IsConstructable)) then
     begin
+      { §13.3.7.1 SuperCall step 3: a super constructor that is not a
+        constructor is a TypeError, which is what Object.setPrototypeOf onto a
+        plain object produces. A method with no superclass at all never parses
+        to a reachable super() and keeps the older diagnostic. }
+      if Assigned(ResolvedSuperConstructor) then
+        ThrowTypeError(SErrorSuperNotConstructor, SSuggestNotConstructorType);
       AContext.OnError('super() can only be called within a method with a superclass',
         ACallExpression.Line, ACallExpression.Column);
       Result := TGocciaUndefinedLiteralValue.UndefinedValue;
@@ -4609,7 +4646,7 @@ begin
          Assigned(TGocciaMethodCallScope(ScopeCursor).SuperClass) and
          not TGocciaMethodCallScope(ScopeCursor).SuperConstructorCalled then
         ThrowReferenceError(
-          'Must call super constructor before accessing this',
+          SErrorSuperConstructorNotCalled,
           'call super() before reading this or super properties');
       Break;
     end;
@@ -11240,7 +11277,7 @@ var
   ConstructorThisValue: TGocciaValue;
   EffectiveNewTarget: TGocciaValue;
   InstancePrototype: TGocciaObjectValue;
-  CollapsedChain: TGocciaClassChain;
+  Chain: TGocciaImplicitConstructorChain;
   function ConstructNativeSuperInstance(
     const AConstructor: TGocciaObjectValue): TGocciaObjectValue;
   var
@@ -11337,8 +11374,8 @@ var
   var
     Index: Integer;
   begin
-    for Index := High(CollapsedChain) downto 0 do
-      RunClassInstanceInitializers(CollapsedChain[Index], Instance, AContext);
+    for Index := High(Chain.Collapsed) downto 0 do
+      RunClassInstanceInitializers(Chain.Collapsed[Index], Instance, AContext);
   end;
 begin
   CheckExecutionTimeout;
@@ -11367,7 +11404,19 @@ begin
       Exit(AArguments.GetElement(0).Box);
   end;
 
+  { §15.7.14 step 15a: this class runs an implicit constructor, and so does
+    every class between it and the first ancestor that has a constructor body
+    of its own. The chain has to be resolved before the receiver is allocated,
+    because which constructor it selects decides whether allocating one here is
+    right at all. }
+  ResolveImplicitConstructorChain(AClassValue, Chain);
+  ImplicitSuperClass := Chain.HostClass;
+
   NativeInstance := nil;
+  { Only a class-value built-in — Array, Map, Set — is initialized in place by
+    a later super(); the walk pre-creates one because the receiver has to exist
+    before any constructor body runs. Every hop is §13.3.7.3 GetSuperConstructor
+    so that a retargeted constructor allocates from what it now points at. }
   WalkClass := AClassValue;
   while Assigned(WalkClass) do
   begin
@@ -11375,24 +11424,24 @@ begin
     IncrementInstructionCounter;
     CheckInstructionLimit;
     NativeInstance := WalkClass.CreateNativeInstance(AArguments);
-    { A native super *constructor* — a built-in exposed as a function value
-      rather than as a class value, which is what Promise, Error and their
-      subclasses are — is invoked again by an explicit super(), and the
-      receiver it returns replaces this one wholesale. Building it here as
-      well ran the Promise executor twice for every
-      `class P extends Promise` with a constructor of its own. Only the
-      class-value built-ins reached through CreateNativeInstance above are
-      initialized in place by super(), so only those need pre-creating. }
-    if (not Assigned(NativeInstance)) and
-       Assigned(WalkClass.NativeSuperConstructor) and
-       not Assigned(AClassValue.ConstructorMethod) then
-      // The implicit super() path reuses this precreated native receiver.
-      NativeInstance := ConstructNativeSuperInstance(
-        WalkClass.NativeSuperConstructor);
     if Assigned(NativeInstance) then
       Break;
-    WalkClass := WalkClass.SuperClass;
+    WalkClass := ImplicitSuperConstructorClass(WalkClass);
   end;
+
+  { A native super *constructor* — a built-in exposed as a function value,
+    which is what Promise, Error and their subclasses are — is invoked again by
+    an explicit super(), and the receiver it returns replaces this one
+    wholesale. So it may only be pre-created when no constructor body stands
+    between this class and it: Chain.SuperConstructor is set only when the walk
+    reached it without passing one, and this class must not declare one either.
+    Pre-creating regardless ran the Promise executor twice. }
+  if (not Assigned(NativeInstance)) and
+     Assigned(Chain.SuperConstructor) and
+     (not ImplicitSuperConstructorIsUnusable(Chain)) and
+     (not Assigned(AClassValue.ConstructorMethod)) then
+    // The implicit super() path reuses this precreated native receiver.
+    NativeInstance := ConstructNativeSuperInstance(Chain.SuperConstructor);
 
   if Assigned(NativeInstance) then
   begin
@@ -11427,20 +11476,28 @@ begin
          IsUndefinedConstructedValue(ConstructedValue) and
          not AClassValue.ConstructorMethod.LastSuperConstructorCalled then
         ThrowReferenceError(
-          'Must call super constructor before returning from derived constructor');
+          SErrorSuperConstructorNotCalled);
     end
     else
     begin
-      { §15.7.14 step 15a: this class runs an implicit constructor, and so does
-        every class between it and the first ancestor that has a constructor
-        body of its own. CollapsedChain is that stretch — the classes whose
-        instance elements the super construction below is about to step over. }
-      ImplicitSuperClass := ResolveImplicitConstructorChain(AClassValue,
-        CollapsedChain);
+      { §13.3.7.1 SuperCall step 3: super() reaching something that is not a
+        constructor is a TypeError, and Object.setPrototypeOf is the only way
+        to put one there. }
+      if ImplicitSuperConstructorIsUnusable(Chain) then
+        ThrowTypeError(SErrorSuperNotConstructor, SSuggestNotConstructorType);
 
+      { A super constructor Object.setPrototypeOf moved there is not the one
+        the class was declared with, so none of the declared-native branches
+        below apply: §13.3.7.3 sends super() to the new target, and what it
+        returns becomes the receiver. Probed against Node v24.0.1 — retargeting
+        onto Error sets the message and never runs the declared superclass. }
+      if ImplicitSuperConstructorIsRetargeted(Chain) then
+        ApplyReplacementResult(InvokeConstructableWithReceiver(
+          Chain.SuperConstructor, AArguments, Instance, AContext,
+          EffectiveNewTarget))
       // A compiled superclass has no AST ConstructorMethod; it runs its own
       // field initializers and constructor body against the instance.
-      if Assigned(ImplicitSuperClass) and
+      else if Assigned(ImplicitSuperClass) and
          ImplicitSuperClass.TryConstructOnReceiver(AArguments, Instance,
            EffectiveNewTarget, ConstructedValue) then
       begin
@@ -11471,7 +11528,7 @@ begin
       begin
         if AClassValue.NativeSuperConstructor =
            TGocciaFunctionBase.GetSharedPrototype then
-          ThrowTypeError('Super constructor is not a constructor',
+          ThrowTypeError(SErrorSuperNotConstructor,
             SSuggestNotConstructorType);
         ConstructedValue := InvokeConstructableWithReceiver(
           AClassValue.NativeSuperConstructor, AArguments, Instance, AContext,

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -11240,6 +11240,7 @@ var
   ConstructorThisValue: TGocciaValue;
   EffectiveNewTarget: TGocciaValue;
   InstancePrototype: TGocciaObjectValue;
+  CollapsedChain: TGocciaClassChain;
   function ConstructNativeSuperInstance(
     const AConstructor: TGocciaObjectValue): TGocciaObjectValue;
   var
@@ -11332,6 +11333,13 @@ var
   begin
     RunClassInstanceInitializers(AClassValue, Instance, AContext);
   end;
+  procedure RunCollapsedInstanceInitializers;
+  var
+    Index: Integer;
+  begin
+    for Index := High(CollapsedChain) downto 0 do
+      RunClassInstanceInitializers(CollapsedChain[Index], Instance, AContext);
+  end;
 begin
   CheckExecutionTimeout;
   IncrementInstructionCounter;
@@ -11367,9 +11375,18 @@ begin
     IncrementInstructionCounter;
     CheckInstructionLimit;
     NativeInstance := WalkClass.CreateNativeInstance(AArguments);
+    { A native super *constructor* — a built-in exposed as a function value
+      rather than as a class value, which is what Promise, Error and their
+      subclasses are — is invoked again by an explicit super(), and the
+      receiver it returns replaces this one wholesale. Building it here as
+      well ran the Promise executor twice for every
+      `class P extends Promise` with a constructor of its own. Only the
+      class-value built-ins reached through CreateNativeInstance above are
+      initialized in place by super(), so only those need pre-creating. }
     if (not Assigned(NativeInstance)) and
-       Assigned(WalkClass.NativeSuperConstructor) then
-      // The explicit super() path reuses this precreated native receiver.
+       Assigned(WalkClass.NativeSuperConstructor) and
+       not Assigned(AClassValue.ConstructorMethod) then
+      // The implicit super() path reuses this precreated native receiver.
       NativeInstance := ConstructNativeSuperInstance(
         WalkClass.NativeSuperConstructor);
     if Assigned(NativeInstance) then
@@ -11414,9 +11431,12 @@ begin
     end
     else
     begin
-      ImplicitSuperClass := AClassValue.SuperClass;
-      if AClassValue.GetConstructorPrototype is TGocciaClassValue then
-        ImplicitSuperClass := TGocciaClassValue(AClassValue.GetConstructorPrototype);
+      { §15.7.14 step 15a: this class runs an implicit constructor, and so does
+        every class between it and the first ancestor that has a constructor
+        body of its own. CollapsedChain is that stretch — the classes whose
+        instance elements the super construction below is about to step over. }
+      ImplicitSuperClass := ResolveImplicitConstructorChain(AClassValue,
+        CollapsedChain);
 
       // A compiled superclass has no AST ConstructorMethod; it runs its own
       // field initializers and constructor body against the instance.
@@ -11434,6 +11454,12 @@ begin
         ConstructedValue := ImplicitSuperClass.ConstructorMethod.CallWithThisValue(
           AArguments, Instance, ConstructorThisValue, EffectiveNewTarget);
         ValidateClassConstructorReturn(ImplicitSuperClass, ConstructedValue);
+        { §10.2.2 step 13.c applies to the constructor that returned, and the
+          borrowed one is exactly that: a subclass with no constructor of its
+          own, extending a class whose constructor never calls super(), still
+          finishes with `this` uninitialized. }
+        RequireDerivedConstructorThisInitialized(ImplicitSuperClass,
+          ConstructedValue);
         if IsUndefinedConstructedValue(ConstructedValue) then
           ApplyReplacementResult(ConstructorThisValue)
         else
@@ -11468,7 +11494,9 @@ begin
       // The implicit derived constructor (§15.7.14 step 15a) forwards to
       // super and then initializes its instance elements — so they run once
       // the super construction above has completed, against whatever receiver
-      // it left behind.
+      // it left behind. Every class the chain walk collapsed owes the same
+      // step, base-most first, before this class's own fields land.
+      RunCollapsedInstanceInitializers;
       if HasDerivedConstructorReturnRestriction then
         RunInstanceInitializers;
     end;
@@ -11489,20 +11517,13 @@ end;
 //
 // The walk reads FSuperClass, which is resolved once at
 // ClassDefinitionEvaluation time, and deliberately does not follow
-// GetConstructorPrototype. §15.7.14 step 9 fixes [[ConstructorKind]] and the
-// super chain when the class is defined; a later Object.setPrototypeOf on the
-// constructor changes static-method `super` lookups and nothing about
-// [[Construct]], so a guard that moved with it would decline exactly the
-// classes that must keep being redirected. Probed against Node v24.0.1:
-// `class WithMap extends Map {}; class Sub {}` with Sub retargeted onto
-// WithMap constructs an ordinary object with Sub.prototype and no Map
-// internals, which is what this guard's answer produces here.
-//
-// InstantiateClass's implicit-constructor branch does consult
-// GetConstructorPrototype, so the two disagree for a retargeted constructor.
-// That substitution is itself the deviation — it makes a retargeted base class
-// run the other class's constructor, which Node does not — and correcting it
-// belongs with the construction paths, not with this guard.
+// GetConstructorPrototype: this only decides which [[Construct]]
+// implementation runs, and both of them now agree about a retargeted
+// constructor. ResolveImplicitConstructorChain is where §13.3.7.3
+// GetSuperConstructor is applied — a ~derived~ class's super() follows the
+// mutated chain, a ~base~ class has no super() to follow it with — so a guard
+// that moved with the mutation would only decline classes that must keep being
+// redirected.
 function ClassChainReachesNativeConstruction(
   const AClassValue: TGocciaClassValue): Boolean;
 var
@@ -11575,25 +11596,21 @@ end;
 // A chain that reaches a built-in constructor stays on Instantiate, which is
 // what TGocciaVM.ConstructValue already does for the same shapes. Only
 // Instantiate implements the §10.1.13 GetPrototypeFromConstructor ordering
-// those constructors need — ArrayBuffer, SharedArrayBuffer and DataView
-// validate their arguments before newTarget.prototype may be observed — and
-// only Instantiate builds the native receiver exactly once for a derived class
-// whose constructor calls super() explicitly, which is a live bug in
-// InstantiateClass (the receiver is pre-created by the WalkClass loop and then
-// built again by super(), running a Promise executor twice).
+// those constructors need: ArrayBuffer, SharedArrayBuffer and DataView
+// validate their arguments before newTarget.prototype may be observed, which
+// tests/built-ins/ArrayBuffer/constructor.js asserts through exactly this
+// route.
 //
-// The cost of declining is precise, and larger than "Reflect.construct is
-// imperfect": such a class's instance elements are skipped by EVERY route
-// through ConstructValue, in interpreted mode only. `new` is NOT affected —
-// EvaluateNewExpression calls InstantiateClass directly and initializes them
-// — so the gap is reachable without writing Reflect at all, through any
-// species construction: SubclassOfArray.from(...) / .map(...) and
-// SubclassOfPromise.resolve(...).then(...) all hand back an instance whose own
-// fields are undefined. Bytecode mode is correct for all of them, so this is
-// also a mode divergence. Closing it means fixing InstantiateClass's two gaps
-// above, not widening this guard; the current behaviour is pinned in
-// tests/built-ins/Reflect/construct/native-chain-instance-elements.js
-// so that a partial fix cannot land unnoticed.
+// Declining used to cost such a class every instance element on EVERY route
+// through ConstructValue — Reflect.construct, a proxy without a construct
+// trap, a bound class, and every species construction (Array.from,
+// Array.prototype.map, Promise.prototype.then, ...) handed back an instance
+// whose own fields were undefined, while `new` was unaffected. It no longer
+// does: TGocciaClassValue.Instantiate runs those elements itself through the
+// TGocciaClassInstanceElementsHook the evaluator registers, at the §13.3.7.1
+// step 11 point, so declining here now costs nothing observable. The agreement
+// between all of these routes is pinned in
+// tests/built-ins/Reflect/construct/native-chain-instance-elements.js.
 function RedirectEvaluatorClassConstruct(const ATarget: TGocciaValue;
   const AArguments: TGocciaArgumentsCollection;
   const ANewTarget: TGocciaValue;

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -6214,7 +6214,7 @@ var
        IsUndefinedConstructedValue(AValue) and
        not ACalledItsOwnSuper then
       ThrowReferenceError(
-        'Must call super constructor before returning from derived constructor');
+        SErrorSuperConstructorNotCalled);
   end;
   procedure ValidateSuperConstructorResult(const AValue: TGocciaValue);
   begin
@@ -6300,7 +6300,7 @@ begin
   end;
 
   if not (EffectiveSuper is TGocciaClassValue) then
-    ThrowTypeError('Super constructor is not a constructor',
+    ThrowTypeError(SErrorSuperNotConstructor,
       SSuggestNotConstructorType);
 
   SuperClass := TGocciaClassValue(EffectiveSuper);
@@ -6698,7 +6698,7 @@ begin
      ((not Assigned(AResult)) or (AResult is TGocciaUndefinedLiteralValue)) and
      not ConstructorSuperCalled then
     ThrowReferenceError(
-      'Must call super constructor before returning from derived constructor');
+      SErrorSuperConstructorNotCalled);
 
   if FConstructorValue is TGocciaBytecodeFunctionValue then
     ConstructorThisValue := RegisterToValue(FVM.FLastClosureThisValue)
@@ -6739,7 +6739,7 @@ var
   DelayNativePrototypeLookup: Boolean;
   NativeInstanceInitialized: Boolean;
   NativeInstanceConstructedByNativeSuper: Boolean;
-  CollapsedChain: TGocciaClassChain;
+  Chain: TGocciaImplicitConstructorChain;
   PreviousPendingNewTarget: TGocciaValue;
   function IsUndefinedConstructedValue(const AValue: TGocciaValue): Boolean;
   begin
@@ -6818,7 +6818,7 @@ var
        IsUndefinedConstructedValue(AValue) and
        not ConstructorSuperCalled then
       ThrowReferenceError(
-        'Must call super constructor before returning from derived constructor');
+        SErrorSuperConstructorNotCalled);
   end;
   { §10.2.2 step 13.c applies to whichever constructor returned, and for a
     class with none of its own that is the superclass constructor its implicit
@@ -6837,7 +6837,7 @@ var
     if ASuperCalled then
       Exit;
     ThrowReferenceError(
-      'Must call super constructor before returning from derived constructor');
+      SErrorSuperConstructorNotCalled);
   end;
   procedure ApplyReplacementResult(const AValue: TGocciaValue);
   begin
@@ -6853,13 +6853,15 @@ var
   var
     Index: Integer;
   begin
-    for Index := High(CollapsedChain) downto 0 do
-      FVM.RunClassInitializers(CollapsedChain[Index], Instance);
+    for Index := High(Chain.Collapsed) downto 0 do
+      FVM.RunClassInitializers(Chain.Collapsed[Index], Instance);
   end;
 begin
   NativeClass := nil;
   NativeSuperConstructorForPrototype := nil;
   NativeIntrinsicPrototype := nil;
+  { Every hop is §13.3.7.3 GetSuperConstructor, so a retargeted constructor
+    resolves its receiver from what it now points at. }
   WalkClass := Self;
   while Assigned(WalkClass) do
   begin
@@ -6869,17 +6871,16 @@ begin
       NativeClass := WalkClass;
       Break;
     end;
-    if Assigned(WalkClass.NativeSuperConstructor) then
+    NativeSuperConstructorForPrototype := ImplicitSuperConstructorTarget(
+      WalkClass);
+    if Assigned(NativeSuperConstructorForPrototype) and
+       not (NativeSuperConstructorForPrototype is TGocciaClassValue) then
     begin
-      NativeSuperConstructorForPrototype := WalkClass.NativeSuperConstructor;
-      if WalkClass.NativeSuperConstructor is TGocciaClassValue then
-      begin
-        NativeClass := TGocciaClassValue(WalkClass.NativeSuperConstructor);
-        NativeIntrinsicPrototype := NativeClass.NativeInstanceDefaultPrototype;
-      end;
+      NativeIntrinsicPrototype := nil;
       Break;
     end;
-    WalkClass := WalkClass.SuperClass;
+    NativeSuperConstructorForPrototype := nil;
+    WalkClass := ImplicitSuperConstructorClass(WalkClass);
   end;
   DelayNativePrototypeLookup :=
     ShouldDelayNativePrototypeLookup(NativeClass, AArguments) or
@@ -6896,24 +6897,29 @@ begin
   NativeInstanceConstructedByNativeSuper := False;
   { §15.7.14 step 15a: this class runs an implicit constructor, and so does
     every class between it and the first ancestor with a constructor body of
-    its own. CollapsedChain is that stretch — the classes whose instance
+    its own. Chain.Collapsed is that stretch — the classes whose instance
     elements the super construction below would otherwise step over. }
-  ImplicitSuperClass := ResolveImplicitConstructorChain(Self, CollapsedChain);
+  ResolveImplicitConstructorChain(Self, Chain);
+  ImplicitSuperClass := Chain.HostClass;
 
   { Allocating the built-in receiver here short-circuits every constructor
     between this class and the built-in, so it may only reach past this class
     when there is nothing in between: the walk used to climb the whole chain,
     and each class it stepped over lost both halves of its implicit
     constructor. Anything further up is left to the implicit-super recursion
-    below, which allocates at the boundary and hands the receiver back down. }
-  if not (Assigned(FConstructorValue) and HasDerivedConstructorReturnRestriction) then
+    below, which allocates at the boundary and hands the receiver back down.
+    A retargeted super constructor is not pre-created at all — it is not the
+    one CreateNativeInstanceWithNewTarget knows about, and the implicit branch
+    constructs through it instead. }
+  if (not (Assigned(FConstructorValue) and HasDerivedConstructorReturnRestriction)) and
+     (not ImplicitSuperConstructorIsRetargeted(Chain)) then
   begin
     WalkClass := Self;
     NativeInstance := CreateNativeInstanceWithNewTarget(AArguments,
       EffectiveNewTarget);
     NativeInstanceConstructedByNativeSuper := Assigned(NativeInstance) and
       Assigned(NativeSuperConstructor);
-    if (not Assigned(NativeInstance)) and (Length(CollapsedChain) = 0) and
+    if (not Assigned(NativeInstance)) and (Length(Chain.Collapsed) = 0) and
        Assigned(ImplicitSuperClass) and
        (ImplicitSuperClass.NativeInstanceDefaultPrototype <> nil) then
     begin
@@ -7035,6 +7041,18 @@ begin
             end;
           end;
         end
+        else if ImplicitSuperConstructorIsUnusable(Chain) then
+          { §13.3.7.1 SuperCall step 3: super() reaching something that is not
+            a constructor is a TypeError. Object.setPrototypeOf is the only way
+            to put one there. }
+          ThrowTypeError(SErrorSuperNotConstructor, SSuggestNotConstructorType)
+        else if ImplicitSuperConstructorIsRetargeted(Chain) then
+          { A super constructor Object.setPrototypeOf moved there is not the
+            one the class was declared with, so none of the declared-native
+            branches below apply: §13.3.7.3 sends super() to the new target and
+            what it returns becomes the receiver. }
+          ApplyReplacementResult(InvokeConstructableWithReceiver(
+            Chain.SuperConstructor, AArguments, Instance, EffectiveNewTarget))
         else
         begin
           if (ImplicitSuperClass is TGocciaVMClassValue) and
@@ -7111,7 +7129,7 @@ begin
             end
             else if Assigned(NativeSuperConstructor) and
                     (NativeSuperConstructor = TGocciaFunctionBase.GetSharedPrototype) then
-              ThrowTypeError('Super constructor is not a constructor',
+              ThrowTypeError(SErrorSuperNotConstructor,
                 SSuggestNotConstructorType)
             else if Assigned(NativeSuperConstructor) and
                     (NativeSuperConstructor is TGocciaFunctionBase) and
@@ -7124,7 +7142,7 @@ begin
             else if (not Assigned(SuperClass)) and
                     (not Assigned(NativeSuperConstructor)) and
                     (Prototype.Prototype = nil) then
-              ThrowTypeError('Super constructor is not a constructor',
+              ThrowTypeError(SErrorSuperNotConstructor,
                 SSuggestNotConstructorType)
             else if Instance is TGocciaInstanceValue then
             begin
@@ -7180,7 +7198,6 @@ function TGocciaVMClassValue.InstantiateRegisters(
 var
   Instance: TGocciaObjectValue;
   RootedInstance: TGocciaObjectValue;
-  WalkClass: TGocciaClassValue;
   ImplicitSuperClass: TGocciaClassValue;
   NativeInstance: TGocciaObjectValue;
   ConstructorToCall: TGocciaMethodValue;
@@ -7195,7 +7212,7 @@ var
   PreviousConstructorSuperCalled: Boolean;
   ConstructorSuperCalled: Boolean;
   NativeInstanceConstructedByNativeSuper: Boolean;
-  CollapsedChain: TGocciaClassChain;
+  Chain: TGocciaImplicitConstructorChain;
   PreviousPendingNewTarget: TGocciaValue;
   procedure EnsureBoxedArgs;
   begin
@@ -7312,7 +7329,7 @@ var
        IsUndefinedConstructedValue(AValue) and
        not ConstructorSuperCalled then
       ThrowReferenceError(
-        'Must call super constructor before returning from derived constructor');
+        SErrorSuperConstructorNotCalled);
   end;
   procedure RequireDerivedConstructorThisInitializedRegister(
     const AValue: TGocciaRegister);
@@ -7321,7 +7338,7 @@ var
        IsUndefinedConstructedRegister(AValue) and
        not ConstructorSuperCalled then
       ThrowReferenceError(
-        'Must call super constructor before returning from derived constructor');
+        SErrorSuperConstructorNotCalled);
   end;
   { §10.2.2 step 13.c applies to whichever constructor returned, and for a
     class with none of its own that is the superclass constructor its implicit
@@ -7340,14 +7357,14 @@ var
     if ASuperCalled then
       Exit;
     ThrowReferenceError(
-      'Must call super constructor before returning from derived constructor');
+      SErrorSuperConstructorNotCalled);
   end;
   procedure RunCollapsedInstanceInitializers;
   var
     Index: Integer;
   begin
-    for Index := High(CollapsedChain) downto 0 do
-      FVM.RunClassInitializers(CollapsedChain[Index], Instance);
+    for Index := High(Chain.Collapsed) downto 0 do
+      FVM.RunClassInitializers(Chain.Collapsed[Index], Instance);
   end;
   procedure ApplyReplacementResult(const AValue: TGocciaValue);
   begin
@@ -7379,28 +7396,28 @@ begin
     NativeInstanceConstructedByNativeSuper := False;
     { §15.7.14 step 15a: this class runs an implicit constructor, and so does
       every class between it and the first ancestor with a constructor body of
-      its own. CollapsedChain is that stretch. }
-    ImplicitSuperClass := ResolveImplicitConstructorChain(Self, CollapsedChain);
+      its own. Chain.Collapsed is that stretch. }
+    ResolveImplicitConstructorChain(Self, Chain);
+    ImplicitSuperClass := Chain.HostClass;
 
     { The receiver may only be allocated past this class when nothing sits in
       between — see the same walk in Instantiate. Climbing the chain here
       collapsed away the implicit constructor (§15.7.14 step 15a) of every
       class it stepped over. }
-    if not (Assigned(FConstructorValue) and HasDerivedConstructorReturnRestriction) then
+    if (not (Assigned(FConstructorValue) and HasDerivedConstructorReturnRestriction)) and
+       (not ImplicitSuperConstructorIsRetargeted(Chain)) then
     begin
-      WalkClass := Self;
       if Assigned(NativeSuperConstructor) then
       begin
         EnsureBoxedArgs;
         NativeInstance := CreateNativeInstanceWithNewTarget(BoxedArgs, Self);
         NativeInstanceConstructedByNativeSuper := Assigned(NativeInstance);
       end;
-      if (not Assigned(NativeInstance)) and (Length(CollapsedChain) = 0) and
+      if (not Assigned(NativeInstance)) and (Length(Chain.Collapsed) = 0) and
          Assigned(ImplicitSuperClass) and
          (ImplicitSuperClass.NativeInstanceDefaultPrototype <> nil) then
       begin
         EnsureBoxedArgs;
-        WalkClass := ImplicitSuperClass;
         NativeInstance := ImplicitSuperClass.CreateNativeInstance(BoxedArgs);
         NativeInstanceConstructedByNativeSuper := False;
       end;
@@ -7500,6 +7517,18 @@ begin
               TGocciaInstanceValue(Instance).InitializeNativeFromArguments(BoxedArgs);
               TGocciaInstanceValue(Instance).FinalizeNativeFromArguments(BoxedArgs);
             end;
+          end
+          else if ImplicitSuperConstructorIsUnusable(Chain) then
+            { §13.3.7.1 SuperCall step 3: super() reaching something that is
+              not a constructor is a TypeError. }
+            ThrowTypeError(SErrorSuperNotConstructor, SSuggestNotConstructorType)
+          else if ImplicitSuperConstructorIsRetargeted(Chain) then
+          begin
+            { §13.3.7.3 sends super() to whatever Object.setPrototypeOf moved
+              onto the constructor, and what it returns becomes the receiver. }
+            EnsureBoxedArgs;
+            ApplyReplacementResult(InvokeConstructableWithReceiver(
+              Chain.SuperConstructor, BoxedArgs, Instance, Self));
           end
           else
           begin
@@ -7610,7 +7639,7 @@ begin
               end
               else if Assigned(NativeSuperConstructor) and
                       (NativeSuperConstructor = TGocciaFunctionBase.GetSharedPrototype) then
-                ThrowTypeError('Super constructor is not a constructor',
+                ThrowTypeError(SErrorSuperNotConstructor,
                   SSuggestNotConstructorType)
               else if Assigned(NativeSuperConstructor) and
                       (NativeSuperConstructor is TGocciaFunctionBase) and
@@ -7626,7 +7655,7 @@ begin
                 if (not Assigned(SuperClass)) and
                    (not Assigned(NativeSuperConstructor)) and
                    (Prototype.Prototype = nil) then
-                  ThrowTypeError('Super constructor is not a constructor',
+                  ThrowTypeError(SErrorSuperNotConstructor,
                     SSuggestNotConstructorType);
                 EnsureBoxedArgs;
                 if Instance is TGocciaInstanceValue then
@@ -10831,6 +10860,8 @@ var
   TargetInstance: TGocciaValue;
   PreviousConstructorSuperCalled: Boolean;
   ConstructorSuperCalled: Boolean;
+  ImplicitSuperTarget: TGocciaObjectValue;
+  DelayReceiverPrototype: Boolean;
   function EffectiveNewTarget: TGocciaValue;
   begin
     if Assigned(FPendingNewTarget) then
@@ -10881,12 +10912,22 @@ var
     if ASuperCalled then
       Exit;
     ThrowReferenceError(
-      'Must call super constructor before returning from derived constructor');
+      SErrorSuperConstructorNotCalled);
   end;
 begin
   Result := AInstance;
   if not Assigned(AClassValue) then
     Exit;
+
+  { §13.3.7.3 GetSuperConstructor: this class's implicit super() resolves
+    through its own [[Prototype]] at call time, so a retargeted class forwards
+    to whatever Object.setPrototypeOf moved onto it. }
+  ImplicitSuperTarget := ImplicitSuperConstructorTarget(AClassValue);
+  if ImplicitSuperConstructorIsAbsent(AClassValue) or
+     (Assigned(ImplicitSuperTarget) and
+      ((ImplicitSuperTarget = TGocciaFunctionBase.GetSharedPrototype) or
+       (not ImplicitSuperTarget.IsConstructable))) then
+    ThrowTypeError(SErrorSuperNotConstructor, SSuggestNotConstructorType);
 
   if AClassValue.NativeInstanceDefaultPrototype <> nil then
   begin
@@ -10895,6 +10936,17 @@ begin
       ThrowTypeError(
         'Superclass constructor did not return an object',
         SSuggestNotConstructorType);
+    { ES2026 §10.2.2 steps 5-6 put newTarget's prototype on the receiver before
+      the built-in's own steps run, and §24.1.1.1 Map reads its `set` adder off
+      that receiver — so a foreign newTarget whose prototype has no adder has
+      to throw here rather than quietly populating through Map.prototype.
+      The families that validate their arguments before newTarget.prototype may
+      be observed (§10.1.13 ordering) keep the lookup after initialization. }
+    DelayReceiverPrototype := ShouldDelayNativePrototypeLookup(AClassValue,
+      AArguments);
+    if not DelayReceiverPrototype then
+      TGocciaObjectValue(TargetInstance).Prototype :=
+        GetProtoFromConstructor(EffectiveNewTarget);
     if TargetInstance is TGocciaInstanceValue then
     begin
       if AInstance is TGocciaInstanceValue then
@@ -10904,8 +10956,11 @@ begin
         TGocciaInstanceValue(TargetInstance).ClassValue := AClassValue;
       TGocciaInstanceValue(TargetInstance).InitializeNativeFromArguments(AArguments);
     end;
-    ReceiverPrototype := GetProtoFromConstructor(EffectiveNewTarget);
-    TGocciaObjectValue(TargetInstance).Prototype := ReceiverPrototype;
+    if DelayReceiverPrototype then
+    begin
+      ReceiverPrototype := GetProtoFromConstructor(EffectiveNewTarget);
+      TGocciaObjectValue(TargetInstance).Prototype := ReceiverPrototype;
+    end;
     if TargetInstance is TGocciaInstanceValue then
       TGocciaInstanceValue(TargetInstance).FinalizeNativeFromArguments(AArguments);
     Exit(TargetInstance);
@@ -10948,8 +11003,8 @@ begin
     Exit;
   end;
 
-  if (AClassValue is TGocciaVMClassValue) and
-     Assigned(TGocciaVMClassValue(AClassValue).NativeSuperConstructor) then
+  if Assigned(ImplicitSuperTarget) and
+     not (ImplicitSuperTarget is TGocciaClassValue) then
   begin
     // ES2026 §10.2.2 [[Construct]] step 5b: only a ~base~ constructor
     // initializes its instance elements ahead of its body; a ~derived~
@@ -10958,8 +11013,7 @@ begin
       RunClassInitializers(AClassValue, AInstance);
     { §10.2.2 step 5: the built-in allocates from newTarget's prototype, which
       is the class the construction started at — not this intermediate one. }
-    SuperResult := InvokeConstructableWithReceiver(
-      TGocciaVMClassValue(AClassValue).NativeSuperConstructor,
+    SuperResult := InvokeConstructableWithReceiver(ImplicitSuperTarget,
       AArguments, AInstance, EffectiveNewTarget);
     ValidateImplicitSuperResult(SuperResult);
     { §13.3.7.1 step 11: this is the implicit constructor's own super(), not a
@@ -10994,7 +11048,7 @@ begin
   end;
 
   TargetInstance := InvokeImplicitSuperInitialization(
-    AClassValue.SuperClass, AInstance, AArguments);
+    ImplicitSuperConstructorClass(AClassValue), AInstance, AArguments);
   if not Assigned(TargetInstance) then
     TargetInstance := AInstance;
   if not (AClassValue is TGocciaVMClassValue) and
@@ -11017,6 +11071,8 @@ var
   TargetInstance: TGocciaValue;
   PreviousConstructorSuperCalled: Boolean;
   ConstructorSuperCalled: Boolean;
+  ImplicitSuperTarget: TGocciaObjectValue;
+  DelayReceiverPrototype: Boolean;
   function EffectiveNewTarget: TGocciaValue;
   begin
     if Assigned(FPendingNewTarget) then
@@ -11082,12 +11138,22 @@ var
     if ASuperCalled then
       Exit;
     ThrowReferenceError(
-      'Must call super constructor before returning from derived constructor');
+      SErrorSuperConstructorNotCalled);
   end;
 begin
   Result := AInstance;
   if not Assigned(AClassValue) then
     Exit;
+
+  { §13.3.7.3 GetSuperConstructor: this class's implicit super() resolves
+    through its own [[Prototype]] at call time, so a retargeted class forwards
+    to whatever Object.setPrototypeOf moved onto it. }
+  ImplicitSuperTarget := ImplicitSuperConstructorTarget(AClassValue);
+  if ImplicitSuperConstructorIsAbsent(AClassValue) or
+     (Assigned(ImplicitSuperTarget) and
+      ((ImplicitSuperTarget = TGocciaFunctionBase.GetSharedPrototype) or
+       (not ImplicitSuperTarget.IsConstructable))) then
+    ThrowTypeError(SErrorSuperNotConstructor, SSuggestNotConstructorType);
 
   if AClassValue.NativeInstanceDefaultPrototype <> nil then
   begin
@@ -11098,6 +11164,13 @@ begin
         ThrowTypeError(
           'Superclass constructor did not return an object',
           SSuggestNotConstructorType);
+      { §10.2.2 steps 5-6 before the built-in's own steps — see the same
+        ordering in InvokeImplicitSuperInitialization. }
+      DelayReceiverPrototype := ShouldDelayNativePrototypeLookup(AClassValue,
+        BoxedArgs);
+      if not DelayReceiverPrototype then
+        TGocciaObjectValue(TargetInstance).Prototype :=
+          GetProtoFromConstructor(EffectiveNewTarget);
       if TargetInstance is TGocciaInstanceValue then
       begin
         if AInstance is TGocciaInstanceValue then
@@ -11107,8 +11180,11 @@ begin
           TGocciaInstanceValue(TargetInstance).ClassValue := AClassValue;
         TGocciaInstanceValue(TargetInstance).InitializeNativeFromArguments(BoxedArgs);
       end;
-      ReceiverPrototype := GetProtoFromConstructor(EffectiveNewTarget);
-      TGocciaObjectValue(TargetInstance).Prototype := ReceiverPrototype;
+      if DelayReceiverPrototype then
+      begin
+        ReceiverPrototype := GetProtoFromConstructor(EffectiveNewTarget);
+        TGocciaObjectValue(TargetInstance).Prototype := ReceiverPrototype;
+      end;
       if TargetInstance is TGocciaInstanceValue then
         TGocciaInstanceValue(TargetInstance).FinalizeNativeFromArguments(BoxedArgs);
       Exit(TargetInstance);
@@ -11192,8 +11268,8 @@ begin
     Exit;
   end;
 
-  if (AClassValue is TGocciaVMClassValue) and
-     Assigned(TGocciaVMClassValue(AClassValue).NativeSuperConstructor) then
+  if Assigned(ImplicitSuperTarget) and
+     not (ImplicitSuperTarget is TGocciaClassValue) then
   begin
     BoxedArgs := MaterializeArguments(AArguments);
     try
@@ -11205,8 +11281,7 @@ begin
       { §10.2.2 step 5: the built-in allocates from newTarget's prototype,
         which is the class the construction started at — not this intermediate
         one. }
-      SuperResult := InvokeConstructableWithReceiver(
-        TGocciaVMClassValue(AClassValue).NativeSuperConstructor,
+      SuperResult := InvokeConstructableWithReceiver(ImplicitSuperTarget,
         BoxedArgs, AInstance, EffectiveNewTarget);
     finally
       ReleaseArguments(BoxedArgs);
@@ -11249,7 +11324,7 @@ begin
   end;
 
   TargetInstance := InvokeImplicitSuperInitializationRegisters(
-    AClassValue.SuperClass, AInstance, AArguments);
+    ImplicitSuperConstructorClass(AClassValue), AInstance, AArguments);
   if not Assigned(TargetInstance) then
     TargetInstance := AInstance;
   if not (AClassValue is TGocciaVMClassValue) and
@@ -14552,7 +14627,7 @@ begin
       OP_CHECK_DERIVED_THIS:
         if not FCurrentConstructorSuperCalled then
           ThrowReferenceError(
-            'Must call super constructor before accessing this');
+            SErrorSuperConstructorNotCalled);
 
       OP_CREATE_ARGUMENTS:
         SetRegister(A, CreateArgumentsObjectFromCurrentFrame(B <> 0, C));

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -6739,6 +6739,8 @@ var
   DelayNativePrototypeLookup: Boolean;
   NativeInstanceInitialized: Boolean;
   NativeInstanceConstructedByNativeSuper: Boolean;
+  CollapsedChain: TGocciaClassChain;
+  PreviousPendingNewTarget: TGocciaValue;
   function IsUndefinedConstructedValue(const AValue: TGocciaValue): Boolean;
   begin
     Result := (not Assigned(AValue)) or (AValue is TGocciaUndefinedLiteralValue);
@@ -6818,6 +6820,25 @@ var
       ThrowReferenceError(
         'Must call super constructor before returning from derived constructor');
   end;
+  { §10.2.2 step 13.c applies to whichever constructor returned, and for a
+    class with none of its own that is the superclass constructor its implicit
+    constructor forwarded to: a subclass of a class whose constructor never
+    calls super() finishes with `this` uninitialized just the same. }
+  procedure RequireImplicitSuperConstructorInitializedThis(
+    const AHostClass: TGocciaClassValue; const AValue: TGocciaValue;
+    const ASuperCalled: Boolean);
+  begin
+    if not Assigned(AHostClass) then
+      Exit;
+    if not ClassRequiresObjectConstructorReturn(AHostClass) then
+      Exit;
+    if not IsUndefinedConstructedValue(AValue) then
+      Exit;
+    if ASuperCalled then
+      Exit;
+    ThrowReferenceError(
+      'Must call super constructor before returning from derived constructor');
+  end;
   procedure ApplyReplacementResult(const AValue: TGocciaValue);
   begin
     if AValue is TGocciaObjectValue then
@@ -6827,6 +6848,13 @@ var
       SetFinalInstance(TGocciaObjectValue(AValue));
       InitializerReplayReceiver := Instance;
     end;
+  end;
+  procedure RunCollapsedInstanceInitializers;
+  var
+    Index: Integer;
+  begin
+    for Index := High(CollapsedChain) downto 0 do
+      FVM.RunClassInitializers(CollapsedChain[Index], Instance);
   end;
 begin
   NativeClass := nil;
@@ -6866,26 +6894,32 @@ begin
   NativeInstance := nil;
   NativeInstanceInitialized := False;
   NativeInstanceConstructedByNativeSuper := False;
+  { §15.7.14 step 15a: this class runs an implicit constructor, and so does
+    every class between it and the first ancestor with a constructor body of
+    its own. CollapsedChain is that stretch — the classes whose instance
+    elements the super construction below would otherwise step over. }
+  ImplicitSuperClass := ResolveImplicitConstructorChain(Self, CollapsedChain);
+
+  { Allocating the built-in receiver here short-circuits every constructor
+    between this class and the built-in, so it may only reach past this class
+    when there is nothing in between: the walk used to climb the whole chain,
+    and each class it stepped over lost both halves of its implicit
+    constructor. Anything further up is left to the implicit-super recursion
+    below, which allocates at the boundary and hands the receiver back down. }
   if not (Assigned(FConstructorValue) and HasDerivedConstructorReturnRestriction) then
   begin
     WalkClass := Self;
-    while Assigned(WalkClass) do
+    NativeInstance := CreateNativeInstanceWithNewTarget(AArguments,
+      EffectiveNewTarget);
+    NativeInstanceConstructedByNativeSuper := Assigned(NativeInstance) and
+      Assigned(NativeSuperConstructor);
+    if (not Assigned(NativeInstance)) and (Length(CollapsedChain) = 0) and
+       Assigned(ImplicitSuperClass) and
+       (ImplicitSuperClass.NativeInstanceDefaultPrototype <> nil) then
     begin
-      if WalkClass is TGocciaVMClassValue then
-      begin
-        NativeInstance := TGocciaVMClassValue(WalkClass)
-          .CreateNativeInstanceWithNewTarget(AArguments, EffectiveNewTarget);
-        NativeInstanceConstructedByNativeSuper := Assigned(NativeInstance) and
-          Assigned(TGocciaVMClassValue(WalkClass).NativeSuperConstructor);
-      end
-      else
-      begin
-        NativeInstance := WalkClass.CreateNativeInstance(AArguments);
-        NativeInstanceConstructedByNativeSuper := False;
-      end;
-      if Assigned(NativeInstance) then
-        Break;
-      WalkClass := WalkClass.SuperClass;
+      WalkClass := ImplicitSuperClass;
+      NativeInstance := ImplicitSuperClass.CreateNativeInstance(AArguments);
+      NativeInstanceConstructedByNativeSuper := False;
     end;
   end;
 
@@ -7003,10 +7037,6 @@ begin
         end
         else
         begin
-          ImplicitSuperClass := SuperClass;
-          if GetConstructorPrototype is TGocciaClassValue then
-            ImplicitSuperClass := TGocciaClassValue(GetConstructorPrototype);
-
           if (ImplicitSuperClass is TGocciaVMClassValue) and
                   Assigned(TGocciaVMClassValue(ImplicitSuperClass).FConstructorValue) then
           begin
@@ -7019,9 +7049,12 @@ begin
               TGocciaVMClassValue(ImplicitSuperClass).FVM.FPendingNewTarget := ANewTarget
             else
               TGocciaVMClassValue(ImplicitSuperClass).FVM.FPendingNewTarget := Self;
+            FVM.FCurrentConstructorSuperCalled := False;
             ConstructedValue := TGocciaVMClassValue(ImplicitSuperClass).FVM.InvokeFunctionValue(
               TGocciaVMClassValue(ImplicitSuperClass).FConstructorValue,
               AArguments, Instance);
+            RequireImplicitSuperConstructorInitializedThis(ImplicitSuperClass,
+              ConstructedValue, FVM.FCurrentConstructorSuperCalled);
             if TGocciaVMClassValue(ImplicitSuperClass).FConstructorValue is TGocciaBytecodeFunctionValue then
               ConstructorThisValue := RegisterToValue(
                 TGocciaVMClassValue(ImplicitSuperClass).FVM.FLastClosureThisValue)
@@ -7052,6 +7085,8 @@ begin
                 ConstructedValue := ConstructorToCall.CallWithThisValue(
                   AArguments, Instance, ConstructorThisValue, Self);
               ValidateClassConstructorReturn(ImplicitSuperClass, ConstructedValue);
+              RequireImplicitSuperConstructorInitializedThis(ImplicitSuperClass,
+                ConstructedValue, ConstructorToCall.LastSuperConstructorCalled);
               if IsUndefinedConstructedValue(ConstructedValue) then
                 ApplyReplacementResult(ConstructorThisValue)
               else
@@ -7059,8 +7094,19 @@ begin
             end
             else if Assigned(ImplicitSuperClass) then
             begin
-              ConstructedValue := FVM.InvokeImplicitSuperInitialization(
-                ImplicitSuperClass, Instance, AArguments);
+              { §10.2.2 step 5: the implicit constructor forwards newTarget up
+                the chain, and whatever built-in the recursion reaches
+                allocates from its prototype. Leaving this unset made an
+                intermediate class stand in for newTarget, so a subclass of a
+                subclass of Error came back with Error.prototype. }
+              PreviousPendingNewTarget := FVM.FPendingNewTarget;
+              FVM.FPendingNewTarget := EffectiveNewTarget;
+              try
+                ConstructedValue := FVM.InvokeImplicitSuperInitialization(
+                  ImplicitSuperClass, Instance, AArguments);
+              finally
+                FVM.FPendingNewTarget := PreviousPendingNewTarget;
+              end;
               ApplyReplacementResult(ConstructedValue);
             end
             else if Assigned(NativeSuperConstructor) and
@@ -7097,7 +7143,11 @@ begin
         the class is ~base~ or ~derived~ — skipping it for a derived class
         dropped every field of a subclass that declares no constructor.
         InstantiateRegisters, the path a bytecode `new` takes, has always run
-        it unconditionally here; this is the same step. }
+        it unconditionally here; this is the same step.
+
+        Every class the chain walk collapsed owes the same step first, base-most
+        of them last to reach `this` before this class's own fields. }
+      RunCollapsedInstanceInitializers;
       if not Assigned(InitializerReplayReceiver) or
          (Instance <> InitializerReplayReceiver) then
         FVM.RunClassInitializers(Self, Instance);
@@ -7145,6 +7195,8 @@ var
   PreviousConstructorSuperCalled: Boolean;
   ConstructorSuperCalled: Boolean;
   NativeInstanceConstructedByNativeSuper: Boolean;
+  CollapsedChain: TGocciaClassChain;
+  PreviousPendingNewTarget: TGocciaValue;
   procedure EnsureBoxedArgs;
   begin
     if not Assigned(BoxedArgs) then
@@ -7271,6 +7323,32 @@ var
       ThrowReferenceError(
         'Must call super constructor before returning from derived constructor');
   end;
+  { §10.2.2 step 13.c applies to whichever constructor returned, and for a
+    class with none of its own that is the superclass constructor its implicit
+    constructor forwarded to: a subclass of a class whose constructor never
+    calls super() finishes with `this` uninitialized just the same. }
+  procedure RequireImplicitSuperConstructorInitializedThis(
+    const AHostClass: TGocciaClassValue; const AValue: TGocciaValue;
+    const ASuperCalled: Boolean);
+  begin
+    if not Assigned(AHostClass) then
+      Exit;
+    if not ClassRequiresObjectConstructorReturn(AHostClass) then
+      Exit;
+    if not IsUndefinedConstructedValue(AValue) then
+      Exit;
+    if ASuperCalled then
+      Exit;
+    ThrowReferenceError(
+      'Must call super constructor before returning from derived constructor');
+  end;
+  procedure RunCollapsedInstanceInitializers;
+  var
+    Index: Integer;
+  begin
+    for Index := High(CollapsedChain) downto 0 do
+      FVM.RunClassInitializers(CollapsedChain[Index], Instance);
+  end;
   procedure ApplyReplacementResult(const AValue: TGocciaValue);
   begin
     if AValue is TGocciaObjectValue then
@@ -7299,27 +7377,32 @@ begin
   try
     NativeInstance := nil;
     NativeInstanceConstructedByNativeSuper := False;
+    { §15.7.14 step 15a: this class runs an implicit constructor, and so does
+      every class between it and the first ancestor with a constructor body of
+      its own. CollapsedChain is that stretch. }
+    ImplicitSuperClass := ResolveImplicitConstructorChain(Self, CollapsedChain);
+
+    { The receiver may only be allocated past this class when nothing sits in
+      between — see the same walk in Instantiate. Climbing the chain here
+      collapsed away the implicit constructor (§15.7.14 step 15a) of every
+      class it stepped over. }
     if not (Assigned(FConstructorValue) and HasDerivedConstructorReturnRestriction) then
     begin
       WalkClass := Self;
-      while Assigned(WalkClass) do
+      if Assigned(NativeSuperConstructor) then
       begin
-        if not (WalkClass is TGocciaVMClassValue) then
-        begin
-          EnsureBoxedArgs;
-          NativeInstance := WalkClass.CreateNativeInstance(BoxedArgs);
-          NativeInstanceConstructedByNativeSuper := False;
-        end
-        else if Assigned(TGocciaVMClassValue(WalkClass).NativeSuperConstructor) then
-        begin
-          EnsureBoxedArgs;
-          NativeInstance := TGocciaVMClassValue(WalkClass)
-            .CreateNativeInstanceWithNewTarget(BoxedArgs, Self);
-          NativeInstanceConstructedByNativeSuper := Assigned(NativeInstance);
-        end;
-        if Assigned(NativeInstance) then
-          Break;
-        WalkClass := WalkClass.SuperClass;
+        EnsureBoxedArgs;
+        NativeInstance := CreateNativeInstanceWithNewTarget(BoxedArgs, Self);
+        NativeInstanceConstructedByNativeSuper := Assigned(NativeInstance);
+      end;
+      if (not Assigned(NativeInstance)) and (Length(CollapsedChain) = 0) and
+         Assigned(ImplicitSuperClass) and
+         (ImplicitSuperClass.NativeInstanceDefaultPrototype <> nil) then
+      begin
+        EnsureBoxedArgs;
+        WalkClass := ImplicitSuperClass;
+        NativeInstance := ImplicitSuperClass.CreateNativeInstance(BoxedArgs);
+        NativeInstanceConstructedByNativeSuper := False;
       end;
     end;
 
@@ -7420,10 +7503,6 @@ begin
           end
           else
           begin
-            ImplicitSuperClass := SuperClass;
-            if GetConstructorPrototype is TGocciaClassValue then
-              ImplicitSuperClass := TGocciaClassValue(GetConstructorPrototype);
-
             if (ImplicitSuperClass is TGocciaVMClassValue) and
                     Assigned(TGocciaVMClassValue(ImplicitSuperClass).FConstructorValue) then
             begin
@@ -7434,6 +7513,7 @@ begin
                 TGocciaVMClassValue(ImplicitSuperClass).FVM.RunClassInitializers(
                   ImplicitSuperClass, Instance);
               TGocciaVMClassValue(ImplicitSuperClass).FVM.FPendingNewTarget := Self;
+              FVM.FCurrentConstructorSuperCalled := False;
               if TGocciaVMClassValue(ImplicitSuperClass).FConstructorValue is TGocciaBytecodeFunctionValue then
               begin
                 BytecodeSuperConstructor := TGocciaBytecodeFunctionValue(
@@ -7448,6 +7528,9 @@ begin
                   ConstructorThisRegister :=
                     TGocciaVMClassValue(ImplicitSuperClass).FVM.FLastClosureThisValue;
                   ValidateClassConstructorRegister(ImplicitSuperClass, ReturnRegister);
+                  RequireImplicitSuperConstructorInitializedThis(
+                    ImplicitSuperClass, RegisterToValue(ReturnRegister),
+                    FVM.FCurrentConstructorSuperCalled);
                   if IsUndefinedConstructedRegister(ReturnRegister) then
                     ApplyReplacementRegister(ConstructorThisRegister)
                   else
@@ -7462,6 +7545,9 @@ begin
                   ConstructorThisRegister :=
                     TGocciaVMClassValue(ImplicitSuperClass).FVM.FLastClosureThisValue;
                   ValidateClassConstructorReturn(ImplicitSuperClass, ConstructedValue);
+                  RequireImplicitSuperConstructorInitializedThis(
+                    ImplicitSuperClass, ConstructedValue,
+                    FVM.FCurrentConstructorSuperCalled);
                   if IsUndefinedConstructedValue(ConstructedValue) then
                     ApplyReplacementRegister(ConstructorThisRegister)
                   else
@@ -7475,6 +7561,9 @@ begin
                   TGocciaVMClassValue(ImplicitSuperClass).FConstructorValue,
                   BoxedArgs, Instance);
                 ValidateClassConstructorReturn(ImplicitSuperClass, ConstructedValue);
+                RequireImplicitSuperConstructorInitializedThis(
+                  ImplicitSuperClass, ConstructedValue,
+                  FVM.FCurrentConstructorSuperCalled);
                 ApplyReplacementResult(ConstructedValue);
               end;
             end
@@ -7494,6 +7583,9 @@ begin
                 ConstructedValue := ConstructorToCall.CallWithThisValue(
                   BoxedArgs, Instance, ConstructorThisValue, Self);
                 ValidateClassConstructorReturn(ImplicitSuperClass, ConstructedValue);
+                RequireImplicitSuperConstructorInitializedThis(
+                  ImplicitSuperClass, ConstructedValue,
+                  ConstructorToCall.LastSuperConstructorCalled);
                 if IsUndefinedConstructedValue(ConstructedValue) then
                   ApplyReplacementResult(ConstructorThisValue)
                 else
@@ -7501,8 +7593,19 @@ begin
               end
               else if Assigned(ImplicitSuperClass) then
               begin
-                ConstructedValue := FVM.InvokeImplicitSuperInitializationRegisters(
-                  ImplicitSuperClass, Instance, AArguments);
+                { §10.2.2 step 5: the implicit constructor forwards newTarget
+                  up the chain, and whatever built-in the recursion reaches
+                  allocates from its prototype. Leaving this unset made an
+                  intermediate class stand in for newTarget, so a subclass of a
+                  subclass of Error came back with Error.prototype. }
+                PreviousPendingNewTarget := FVM.FPendingNewTarget;
+                FVM.FPendingNewTarget := Self;
+                try
+                  ConstructedValue := FVM.InvokeImplicitSuperInitializationRegisters(
+                    ImplicitSuperClass, Instance, AArguments);
+                finally
+                  FVM.FPendingNewTarget := PreviousPendingNewTarget;
+                end;
                 ApplyReplacementResult(ConstructedValue);
               end
               else if Assigned(NativeSuperConstructor) and
@@ -7538,6 +7641,10 @@ begin
           FVM.FCurrentConstructorSuperCalled := PreviousConstructorSuperCalled;
         end;
 
+        { Every class the chain walk collapsed owes §15.7.14 step 15a's second
+          half — initialize its own instance elements — base-most of them last
+          so this class's own fields still land after theirs. }
+        RunCollapsedInstanceInitializers;
         if not Assigned(InitializerReplayReceiver) or
            (Instance <> InitializerReplayReceiver) then
           FVM.RunClassInitializers(Self, Instance);
@@ -9492,13 +9599,15 @@ begin
   //     admitted there.
   //  2. Native chain. Here: only this class's own native markers. There: a
   //     walk of the whole superclass chain. This guard is the laxer one, and
-  //     measurably so — for `class A extends Promise {...}; class B extends A
-  //     {...}`, B carries no native marker of its own, so it lands in
-  //     InstantiateClass and loses A's fields. Tightening this to the chain
-  //     walk does NOT fix that: Instantiate runs no instance elements at all
-  //     for an implicit constructor, so B would lose its own fields too. The
-  //     fix belongs in InstantiateClass (see the redirect's comment), which is
-  //     why this guard is left as it is rather than harmonized.
+  //     admits classes whose chain reaches a built-in further up. That is no
+  //     longer a fields gap on either side: InstantiateClass now runs the
+  //     instance elements of every class its implicit-constructor walk
+  //     collapses, and Instantiate runs its own through the AST hook, so a
+  //     subclass of a subclass of Promise keeps both classes' fields whichever
+  //     of the two it lands in. The remaining difference is which of them
+  //     implements the §10.1.13 GetPrototypeFromConstructor ordering that
+  //     ArrayBuffer, SharedArrayBuffer and DataView need, which is why this
+  //     guard is left as it is rather than harmonized.
   //  3. Anchor. Here: the running VM scope and the VM's own module callbacks
   //     and current module path — the calling environment. There: the class's
   //     DefinitionScope and defining file, because a native caller has no
@@ -10720,6 +10829,8 @@ var
   ReceiverPrototype: TGocciaObjectValue;
   SuperResult: TGocciaValue;
   TargetInstance: TGocciaValue;
+  PreviousConstructorSuperCalled: Boolean;
+  ConstructorSuperCalled: Boolean;
   function EffectiveNewTarget: TGocciaValue;
   begin
     if Assigned(FPendingNewTarget) then
@@ -10755,6 +10866,22 @@ var
     if AConstructorThisValue is TGocciaObjectValue then
       Exit(AConstructorThisValue);
     Result := AInstance;
+  end;
+  { §10.2.2 step 13.c: the constructor an implicit super() just entered is
+    itself derived, so returning without calling its own super() leaves `this`
+    uninitialized. The flag belongs to the constructor that returned, so it is
+    read immediately after the call. }
+  procedure RequireImplicitSuperConstructorInitializedThis(
+    const AValue: TGocciaValue; const ASuperCalled: Boolean);
+  begin
+    if not RequiresObjectReturn then
+      Exit;
+    if not IsUndefinedConstructedValue(AValue) then
+      Exit;
+    if ASuperCalled then
+      Exit;
+    ThrowReferenceError(
+      'Must call super constructor before returning from derived constructor');
   end;
 begin
   Result := AInstance;
@@ -10792,10 +10919,19 @@ begin
     // one does it when its own super() returns (§13.3.7.1 step 11).
     if not AClassValue.HasDerivedConstructorKind then
       RunClassInitializers(AClassValue, AInstance);
-    SuperResult := TGocciaVMClassValue(AClassValue).FVM.InvokeFunctionValue(
-      TGocciaVMClassValue(AClassValue).FConstructorValue,
-      AArguments, AInstance);
+    PreviousConstructorSuperCalled := FCurrentConstructorSuperCalled;
+    FCurrentConstructorSuperCalled := False;
+    try
+      SuperResult := TGocciaVMClassValue(AClassValue).FVM.InvokeFunctionValue(
+        TGocciaVMClassValue(AClassValue).FConstructorValue,
+        AArguments, AInstance);
+      ConstructorSuperCalled := FCurrentConstructorSuperCalled;
+    finally
+      FCurrentConstructorSuperCalled := PreviousConstructorSuperCalled;
+    end;
     ValidateImplicitSuperResult(SuperResult);
+    RequireImplicitSuperConstructorInitializedThis(SuperResult,
+      ConstructorSuperCalled);
     if TGocciaVMClassValue(AClassValue).FConstructorValue is TGocciaBytecodeFunctionValue then
       ConstructorThisValue := RegisterToValue(
         TGocciaVMClassValue(AClassValue).FVM.FLastClosureThisValue)
@@ -10820,18 +10956,22 @@ begin
     // one does it when its own super() returns (§13.3.7.1 step 11).
     if not AClassValue.HasDerivedConstructorKind then
       RunClassInitializers(AClassValue, AInstance);
+    { §10.2.2 step 5: the built-in allocates from newTarget's prototype, which
+      is the class the construction started at — not this intermediate one. }
     SuperResult := InvokeConstructableWithReceiver(
       TGocciaVMClassValue(AClassValue).NativeSuperConstructor,
-      AArguments, AInstance);
+      AArguments, AInstance, EffectiveNewTarget);
     ValidateImplicitSuperResult(SuperResult);
-    if SuperResult is TGocciaObjectValue then
-    begin
-      // §10.2.2 step 12: an object the constructor returns replaces the
-      // receiver wholesale — it never receives that constructor's own
-      // instance elements, which went on the receiver it was called with.
-      Exit(SuperResult);
-    end;
-    Exit;
+    { §13.3.7.1 step 11: this is the implicit constructor's own super(), not a
+      constructor body returning a replacement — what it produced becomes
+      `this`, and this class's instance elements land on it. Exiting without
+      them dropped every field of a class sitting between a subclass and the
+      built-in it extends. }
+    if not (SuperResult is TGocciaObjectValue) then
+      SuperResult := AInstance;
+    if AClassValue.HasDerivedConstructorKind then
+      RunClassInitializers(AClassValue, SuperResult);
+    Exit(SuperResult);
   end;
 
   if Assigned(AClassValue.ConstructorMethod) then
@@ -10875,6 +11015,8 @@ var
   SuperResult: TGocciaValue;
   SuperResultRegister: TGocciaRegister;
   TargetInstance: TGocciaValue;
+  PreviousConstructorSuperCalled: Boolean;
+  ConstructorSuperCalled: Boolean;
   function EffectiveNewTarget: TGocciaValue;
   begin
     if Assigned(FPendingNewTarget) then
@@ -10926,6 +11068,22 @@ var
       Exit(AConstructorThisValue);
     Result := AInstance;
   end;
+  { §10.2.2 step 13.c: the constructor an implicit super() just entered is
+    itself derived, so returning without calling its own super() leaves `this`
+    uninitialized. The flag belongs to the constructor that returned, so it is
+    read immediately after the call. }
+  procedure RequireImplicitSuperConstructorInitializedThis(
+    const AValue: TGocciaValue; const ASuperCalled: Boolean);
+  begin
+    if not RequiresObjectReturn then
+      Exit;
+    if not IsUndefinedConstructedValue(AValue) then
+      Exit;
+    if ASuperCalled then
+      Exit;
+    ThrowReferenceError(
+      'Must call super constructor before returning from derived constructor');
+  end;
 begin
   Result := AInstance;
   if not Assigned(AClassValue) then
@@ -10975,9 +11133,18 @@ begin
          Assigned(BytecodeConstructor.FClosure.Template) and
          (not BytecodeConstructor.FClosure.Template.IsAsync) then
       begin
-        SuperResultRegister := TGocciaVMClassValue(AClassValue).FVM.ExecuteClosureRegisters(
-          BytecodeConstructor.FClosure, RegisterObject(AInstance), AArguments);
+        PreviousConstructorSuperCalled := FCurrentConstructorSuperCalled;
+        FCurrentConstructorSuperCalled := False;
+        try
+          SuperResultRegister := TGocciaVMClassValue(AClassValue).FVM.ExecuteClosureRegisters(
+            BytecodeConstructor.FClosure, RegisterObject(AInstance), AArguments);
+          ConstructorSuperCalled := FCurrentConstructorSuperCalled;
+        finally
+          FCurrentConstructorSuperCalled := PreviousConstructorSuperCalled;
+        end;
         ValidateImplicitSuperRegister(SuperResultRegister);
+        RequireImplicitSuperConstructorInitializedThis(
+          RegisterToValue(SuperResultRegister), ConstructorSuperCalled);
         ConstructorThisValue := RegisterToValue(
           TGocciaVMClassValue(AClassValue).FVM.FLastClosureThisValue);
         SuperResult := RegisterToValue(SuperResultRegister);
@@ -10995,14 +11162,20 @@ begin
     end;
 
     BoxedArgs := MaterializeArguments(AArguments);
+    PreviousConstructorSuperCalled := FCurrentConstructorSuperCalled;
+    FCurrentConstructorSuperCalled := False;
     try
       SuperResult := TGocciaVMClassValue(AClassValue).FVM.InvokeFunctionValue(
         TGocciaVMClassValue(AClassValue).FConstructorValue,
         BoxedArgs, AInstance);
+      ConstructorSuperCalled := FCurrentConstructorSuperCalled;
     finally
+      FCurrentConstructorSuperCalled := PreviousConstructorSuperCalled;
       ReleaseArguments(BoxedArgs);
     end;
     ValidateImplicitSuperResult(SuperResult);
+    RequireImplicitSuperConstructorInitializedThis(SuperResult,
+      ConstructorSuperCalled);
     if TGocciaVMClassValue(AClassValue).FConstructorValue is TGocciaBytecodeFunctionValue then
       ConstructorThisValue := RegisterToValue(
         TGocciaVMClassValue(AClassValue).FVM.FLastClosureThisValue)
@@ -11029,21 +11202,26 @@ begin
       // one does it when its own super() returns (§13.3.7.1 step 11).
       if not AClassValue.HasDerivedConstructorKind then
         RunClassInitializers(AClassValue, AInstance);
+      { §10.2.2 step 5: the built-in allocates from newTarget's prototype,
+        which is the class the construction started at — not this intermediate
+        one. }
       SuperResult := InvokeConstructableWithReceiver(
         TGocciaVMClassValue(AClassValue).NativeSuperConstructor,
-        BoxedArgs, AInstance);
+        BoxedArgs, AInstance, EffectiveNewTarget);
     finally
       ReleaseArguments(BoxedArgs);
     end;
     ValidateImplicitSuperResult(SuperResult);
-    if SuperResult is TGocciaObjectValue then
-    begin
-      // §10.2.2 step 12: an object the constructor returns replaces the
-      // receiver wholesale — it never receives that constructor's own
-      // instance elements, which went on the receiver it was called with.
-      Exit(SuperResult);
-    end;
-    Exit;
+    { §13.3.7.1 step 11: this is the implicit constructor's own super(), not a
+      constructor body returning a replacement — what it produced becomes
+      `this`, and this class's instance elements land on it. Exiting without
+      them dropped every field of a class sitting between a subclass and the
+      built-in it extends. }
+    if not (SuperResult is TGocciaObjectValue) then
+      SuperResult := AInstance;
+    if AClassValue.HasDerivedConstructorKind then
+      RunClassInitializers(AClassValue, SuperResult);
+    Exit(SuperResult);
   end;
 
   if Assigned(AClassValue.ConstructorMethod) then

--- a/source/units/Goccia.Values.ClassValue.pas
+++ b/source/units/Goccia.Values.ClassValue.pas
@@ -453,6 +453,27 @@ function TryRunASTInstanceElements(const AClassValue: TGocciaClassValue;
 type
   TGocciaClassChain = array of TGocciaClassValue;
 
+  { What walking a class's implicit-constructor chain found. }
+  TGocciaImplicitConstructorChain = record
+    { Classes between the starting class and the constructor that actually
+      runs, derived-most first: §15.7.14 step 15a still owes each of them an
+      implicit constructor, so the caller owes their instance elements. }
+    Collapsed: TGocciaClassChain;
+    { The class whose constructor body the caller should run, or nil. }
+    HostClass: TGocciaClassValue;
+    { The object the chain's last super() reaches when it is not a class value
+      — a built-in constructor exposed as a function, or, after an
+      Object.setPrototypeOf, whatever the constructor was retargeted onto.
+      Nil when the chain ends at a class or at a ~base~ constructor. }
+    SuperConstructor: TGocciaObjectValue;
+    { The class whose super() reaches SuperConstructor. }
+    SuperConstructorOwner: TGocciaClassValue;
+    { Set when the chain stops at a ~derived~ class that has no [[Prototype]]
+      left at all — Object.setPrototypeOf(C, null). §13.3.7.3 hands super()
+      undefined and §13.3.7.1 step 3 rejects it. }
+    SuperConstructorAbsent: Boolean;
+  end;
+
 { ES2026 §15.7.14 step 15a: a class with no constructor of its own runs an
   implicit constructor that forwards its arguments to super and then, per
   §13.3.7.1 step 11, initializes its own instance elements.
@@ -464,21 +485,41 @@ type
   of its own, subclassed again by a class with another field, produced an
   instance carrying only the subclass's field.
 
-  This reports the class whose constructor the collapsed walk should actually
-  run — the first one up the chain that has a body of its own, its own
-  [[Construct]], or is a built-in — and collects, derived-most first, the
-  classes in between whose instance elements the caller still owes the receiver
-  once that construction has settled. Reports nil when the chain reaches a
-  built-in constructor exposed as a function value, or a ~base~ class that has
-  no super() to forward through. }
-function ResolveImplicitConstructorChain(
+  Every hop is §13.3.7.3 GetSuperConstructor, so the walk follows one chain —
+  the constructor objects' [[Prototype]] — and never mixes it with the declared
+  superclass. Mixing them was unsound as well as wrong: each relation alone is
+  acyclic (ordinary [[SetPrototypeOf]] rejects a cycle), their union is not, and
+  a plain Object.setPrototypeOf pair could spin this walk forever. }
+procedure ResolveImplicitConstructorChain(
   const AClassValue: TGocciaClassValue;
-  out ACollapsed: TGocciaClassChain): TGocciaClassValue;
+  out AChain: TGocciaImplicitConstructorChain);
 
-{ The class an implicit super() reaches: §13.3.7.3 GetSuperConstructor for a
-  ~derived~ class, and nothing at all for a ~base~ one. }
+{ True when AChain ends at an object that cannot be constructed — §13.3.7.1
+  SuperCall step 3 raises a TypeError for it. }
+function ImplicitSuperConstructorIsUnusable(
+  const AChain: TGocciaImplicitConstructorChain): Boolean;
+
+{ True when AChain's super constructor is one Object.setPrototypeOf moved there
+  rather than the one the class was declared with. The declared one is already
+  driven by the construction paths' native-super branches; a retargeted one has
+  to be constructed through instead of them. }
+function ImplicitSuperConstructorIsRetargeted(
+  const AChain: TGocciaImplicitConstructorChain): Boolean;
+
+{ The object an implicit super() reaches: §13.3.7.3 GetSuperConstructor reads
+  the active function object's [[GetPrototypeOf]], which Object.setPrototypeOf
+  moves. Nil for a ~base~ class, which has no super() at all. }
+function ImplicitSuperConstructorTarget(
+  const AClassValue: TGocciaClassValue): TGocciaObjectValue;
+
+{ The same hop, reported only when it lands on a class value. }
 function ImplicitSuperConstructorClass(
   const AClassValue: TGocciaClassValue): TGocciaClassValue;
+
+{ True when AClassValue is ~derived~ yet has nothing to resolve super()
+  through, which only Object.setPrototypeOf(C, null) produces. }
+function ImplicitSuperConstructorIsAbsent(
+  const AClassValue: TGocciaClassValue): Boolean;
 
 implementation
 
@@ -495,7 +536,9 @@ uses
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
+  Goccia.InstructionLimit,
   Goccia.Intrinsics.FunctionObjects,
+  Goccia.Timeout,
   Goccia.Values.ArrayBufferValue,
   Goccia.Values.ArrayValue,
   Goccia.Values.AutoAccessor,
@@ -550,8 +593,8 @@ begin
     GClassInstanceElementsHook(AClassValue, AInstance);
 end;
 
-function ImplicitSuperConstructorClass(
-  const AClassValue: TGocciaClassValue): TGocciaClassValue;
+function ImplicitSuperConstructorTarget(
+  const AClassValue: TGocciaClassValue): TGocciaObjectValue;
 begin
   Result := nil;
   if not Assigned(AClassValue) then
@@ -566,49 +609,121 @@ begin
     Exit;
   { §13.3.7.3 GetSuperConstructor: a ~derived~ constructor resolves super()
     through the active function object's [[GetPrototypeOf]], which
-    Object.setPrototypeOf does move. Probed against Node v24.0.1: a retargeted
-    derived class runs the new prototype's constructor and instance elements,
-    not its declared superclass's. }
-  if AClassValue.GetConstructorPrototype is TGocciaClassValue then
-    Exit(TGocciaClassValue(AClassValue.GetConstructorPrototype));
-  Result := AClassValue.SuperClass;
+    Object.setPrototypeOf does move — including onto something that is not a
+    constructor at all, which §13.3.7.1 SuperCall step 3 rejects. Falling back
+    to the declared superclass here instead was wrong twice over: it ran a
+    constructor Node never runs, and it mixed two chains into a walk that could
+    cycle. }
+  Result := AClassValue.GetConstructorPrototype;
 end;
 
-function ResolveImplicitConstructorChain(
-  const AClassValue: TGocciaClassValue;
-  out ACollapsed: TGocciaClassChain): TGocciaClassValue;
+function ImplicitSuperConstructorClass(
+  const AClassValue: TGocciaClassValue): TGocciaClassValue;
 var
-  Count: Integer;
-  Next: TGocciaClassValue;
+  Target: TGocciaObjectValue;
 begin
-  SetLength(ACollapsed, 0);
-  Count := 0;
-  if not Assigned(AClassValue) then
-    Exit(nil);
+  Target := ImplicitSuperConstructorTarget(AClassValue);
+  if Target is TGocciaClassValue then
+    Result := TGocciaClassValue(Target)
+  else
+    Result := nil;
+end;
 
-  Result := ImplicitSuperConstructorClass(AClassValue);
-  while Assigned(Result) and
-        (Result.NativeInstanceDefaultPrototype = nil) and
-        (not Result.UsesOwnInstantiation) and
-        (not Assigned(Result.ConstructorMethod)) do
+function ImplicitSuperConstructorIsAbsent(
+  const AClassValue: TGocciaClassValue): Boolean;
+begin
+  Result := Assigned(AClassValue) and AClassValue.HasDerivedConstructorKind and
+    (not Assigned(AClassValue.GetConstructorPrototype));
+end;
+
+function ImplicitSuperConstructorIsUnusable(
+  const AChain: TGocciaImplicitConstructorChain): Boolean;
+begin
+  Result := AChain.SuperConstructorAbsent or
+    (Assigned(AChain.SuperConstructor) and
+     ((AChain.SuperConstructor = TGocciaFunctionBase.GetSharedPrototype) or
+      (not AChain.SuperConstructor.IsConstructable)));
+end;
+
+function ImplicitSuperConstructorIsRetargeted(
+  const AChain: TGocciaImplicitConstructorChain): Boolean;
+begin
+  Result := Assigned(AChain.SuperConstructor) and
+    Assigned(AChain.SuperConstructorOwner) and
+    (AChain.SuperConstructor <>
+     AChain.SuperConstructorOwner.NativeSuperConstructor);
+end;
+
+procedure ResolveImplicitConstructorChain(
+  const AClassValue: TGocciaClassValue;
+  out AChain: TGocciaImplicitConstructorChain);
+var
+  Count, Index: Integer;
+  Current, Next: TGocciaClassValue;
+  Target: TGocciaObjectValue;
+  AlreadySeen: Boolean;
+begin
+  SetLength(AChain.Collapsed, 0);
+  AChain.HostClass := nil;
+  AChain.SuperConstructor := nil;
+  AChain.SuperConstructorOwner := nil;
+  AChain.SuperConstructorAbsent := False;
+  Count := 0;
+  Current := AClassValue;
+
+  while Assigned(Current) do
   begin
-    if Count = Length(ACollapsed) then
-      SetLength(ACollapsed, Count * 2 + 4);
-    ACollapsed[Count] := Result;
-    Inc(Count);
-    Next := ImplicitSuperConstructorClass(Result);
-    if not Assigned(Next) then
+    { The same bounds the sibling walk in InstantiateClass applies. Following
+      one [[Prototype]] chain cannot cycle, so these are defence in depth
+      rather than the correctness argument. }
+    CheckExecutionTimeout;
+    IncrementInstructionCounter;
+    CheckInstructionLimit;
+
+    Target := ImplicitSuperConstructorTarget(Current);
+    if not Assigned(Target) then
     begin
-      { This class's own super() reaches a built-in constructor exposed as a
-        function value, or it is ~base~ and has no super() at all. Either way
-        the construction path has already settled the receiver and there is no
-        further constructor left for the caller to run. }
-      Result := nil;
+      { Either a ~base~ constructor, which has no super() at all, or a derived
+        one whose [[Prototype]] was set to null and so has nothing to call. }
+      AChain.SuperConstructorAbsent := ImplicitSuperConstructorIsAbsent(Current);
+      if AChain.SuperConstructorAbsent then
+        AChain.SuperConstructorOwner := Current;
       Break;
     end;
-    Result := Next;
+
+    if not (Target is TGocciaClassValue) then
+    begin
+      AChain.SuperConstructor := Target;
+      AChain.SuperConstructorOwner := Current;
+      Break;
+    end;
+
+    Next := TGocciaClassValue(Target);
+    if (Next.NativeInstanceDefaultPrototype <> nil) or
+       Next.UsesOwnInstantiation or
+       Assigned(Next.ConstructorMethod) then
+    begin
+      AChain.HostClass := Next;
+      Break;
+    end;
+
+    { Defence in depth again: a repeat means the walk stopped following one
+      chain, which should be impossible. Stopping beats spinning. }
+    AlreadySeen := Next = AClassValue;
+    for Index := 0 to Count - 1 do
+      if AChain.Collapsed[Index] = Next then
+        AlreadySeen := True;
+    if AlreadySeen then
+      Break;
+
+    if Count = Length(AChain.Collapsed) then
+      SetLength(AChain.Collapsed, Count * 2 + 4);
+    AChain.Collapsed[Count] := Next;
+    Inc(Count);
+    Current := Next;
   end;
-  SetLength(ACollapsed, Count);
+
+  SetLength(AChain.Collapsed, Count);
 end;
 
 function ToNumberConstructorValue(
@@ -1846,7 +1961,7 @@ var
   DelayNativePrototypeLookup: Boolean;
   NativeInstanceInitialized: Boolean;
   NativeInstanceConstructedByNativeSuper: Boolean;
-  CollapsedChain: TGocciaClassChain;
+  Chain: TGocciaImplicitConstructorChain;
   CollapsedIndex: Integer;
   function IsUndefinedConstructResult(const AValue: TGocciaValue): Boolean;
   begin
@@ -1907,26 +2022,32 @@ begin
   DelayNativePrototypeLookup := False;
   NativeInstanceInitialized := False;
   NativeInstanceConstructedByNativeSuper := False;
+  ResolveImplicitConstructorChain(Self, Chain);
+  { Which built-in ends up allocating the receiver is decided by the same
+    §13.3.7.3 hops the chain walk takes, so this follows them rather than the
+    declared superclass: a retargeted constructor allocates from whatever it
+    was retargeted onto, and stops reaching the built-in it was declared with. }
   WalkClass := Self;
   while Assigned(WalkClass) do
   begin
+    CheckExecutionTimeout;
+    IncrementInstructionCounter;
+    CheckInstructionLimit;
     NativeIntrinsicPrototype := WalkClass.NativeInstanceDefaultPrototype;
     if Assigned(NativeIntrinsicPrototype) then
     begin
       NativeClass := WalkClass;
       Break;
     end;
-    if Assigned(WalkClass.NativeSuperConstructor) then
+    NativeSuperConstructor := ImplicitSuperConstructorTarget(WalkClass);
+    if Assigned(NativeSuperConstructor) and
+       not (NativeSuperConstructor is TGocciaClassValue) then
     begin
-      if WalkClass.NativeSuperConstructor is TGocciaClassValue then
-      begin
-        NativeClass := TGocciaClassValue(WalkClass.NativeSuperConstructor);
-        NativeIntrinsicPrototype := NativeClass.NativeInstanceDefaultPrototype;
-      end;
-      NativeSuperConstructor := WalkClass.NativeSuperConstructor;
+      NativeIntrinsicPrototype := nil;
       Break;
     end;
-    WalkClass := WalkClass.SuperClass;
+    NativeSuperConstructor := nil;
+    WalkClass := ImplicitSuperConstructorClass(WalkClass);
   end;
 
   // These constructors perform observable validation/coercion before
@@ -1995,9 +2116,16 @@ begin
   end;
 
   ConstructorToCall := FConstructorMethod;
-  ImplicitSuperClass := ResolveImplicitConstructorChain(Self, CollapsedChain);
+  ImplicitSuperClass := Chain.HostClass;
   if not Assigned(ConstructorToCall) and Assigned(ImplicitSuperClass) then
     ConstructorToCall := ImplicitSuperClass.ConstructorMethod;
+
+  { §13.3.7.1 SuperCall step 3: super() reaching something that is not a
+    constructor is a TypeError, and Object.setPrototypeOf is the only way to
+    put one there. }
+  if (not Assigned(FConstructorMethod)) and
+     ImplicitSuperConstructorIsUnusable(Chain) then
+    ThrowTypeError(SErrorSuperNotConstructor, SSuggestNotConstructorType);
 
   if Assigned(ConstructorToCall) then
   begin
@@ -2038,7 +2166,7 @@ begin
           (Assigned(ImplicitSuperClass) and
            ImplicitSuperClass.HasDerivedConstructorKind)) then
         ThrowReferenceError(
-          'Must call super constructor before returning from derived constructor');
+          SErrorSuperConstructorNotCalled);
 
       if (FinalThis is TGocciaObjectValue) then
       begin
@@ -2048,7 +2176,7 @@ begin
       end
       else if IsUndefinedConstructResult(ConstructResult) then
         ThrowReferenceError(
-          'Must call super constructor before returning from derived constructor');
+          SErrorSuperConstructorNotCalled);
     end;
   end
   else
@@ -2056,7 +2184,7 @@ begin
     if (not Assigned(NativeInstance)) and Assigned(NativeSuperConstructor) then
     begin
       if NativeSuperConstructor = TGocciaFunctionBase.GetSharedPrototype then
-        ThrowTypeError('Super constructor is not a constructor',
+        ThrowTypeError(SErrorSuperNotConstructor,
           SSuggestNotConstructorType);
       NativeInstance := ConstructNativeSuperInstance(NativeSuperConstructor);
       NativeInstanceConstructedByNativeSuper := Assigned(NativeInstance);
@@ -2093,8 +2221,8 @@ begin
   begin
     TGarbageCollector.Instance.AddTempRoot(Instance);
     try
-      for CollapsedIndex := High(CollapsedChain) downto 0 do
-        TryRunASTInstanceElements(CollapsedChain[CollapsedIndex], Instance);
+      for CollapsedIndex := High(Chain.Collapsed) downto 0 do
+        TryRunASTInstanceElements(Chain.Collapsed[CollapsedIndex], Instance);
       TryRunASTInstanceElements(Self, Instance);
     finally
       TGarbageCollector.Instance.RemoveTempRoot(Instance);

--- a/source/units/Goccia.Values.ClassValue.pas
+++ b/source/units/Goccia.Values.ClassValue.pas
@@ -444,10 +444,41 @@ procedure RegisterClassInstanceElementsHook(
   as closures instead and always reports False here. }
 function HasASTInstanceElements(
   const AClassValue: TGocciaClassValue): Boolean;
+
 { Runs them when there are any and an evaluator registered itself; reports
   whether it ran anything. }
 function TryRunASTInstanceElements(const AClassValue: TGocciaClassValue;
   const AInstance: TGocciaValue): Boolean;
+
+type
+  TGocciaClassChain = array of TGocciaClassValue;
+
+{ ES2026 §15.7.14 step 15a: a class with no constructor of its own runs an
+  implicit constructor that forwards its arguments to super and then, per
+  §13.3.7.1 step 11, initializes its own instance elements.
+
+  Every construction path collapses that recursion — it walks the superclass
+  chain in one go to find the built-in that has to allocate the receiver, then
+  runs one constructor against it — and each class the walk stepped over lost
+  both halves of its implicit constructor. A class extending Array with a field
+  of its own, subclassed again by a class with another field, produced an
+  instance carrying only the subclass's field.
+
+  This reports the class whose constructor the collapsed walk should actually
+  run — the first one up the chain that has a body of its own, its own
+  [[Construct]], or is a built-in — and collects, derived-most first, the
+  classes in between whose instance elements the caller still owes the receiver
+  once that construction has settled. Reports nil when the chain reaches a
+  built-in constructor exposed as a function value, or a ~base~ class that has
+  no super() to forward through. }
+function ResolveImplicitConstructorChain(
+  const AClassValue: TGocciaClassValue;
+  out ACollapsed: TGocciaClassChain): TGocciaClassValue;
+
+{ The class an implicit super() reaches: §13.3.7.3 GetSuperConstructor for a
+  ~derived~ class, and nothing at all for a ~base~ one. }
+function ImplicitSuperConstructorClass(
+  const AClassValue: TGocciaClassValue): TGocciaClassValue;
 
 implementation
 
@@ -517,6 +548,67 @@ begin
     HasASTInstanceElements(AClassValue);
   if Result then
     GClassInstanceElementsHook(AClassValue, AInstance);
+end;
+
+function ImplicitSuperConstructorClass(
+  const AClassValue: TGocciaClassValue): TGocciaClassValue;
+begin
+  Result := nil;
+  if not Assigned(AClassValue) then
+    Exit;
+  { §15.7.14 step 9 fixes [[ConstructorKind]] when the class is defined, and
+    §10.2.2 step 5 gives a ~base~ constructor no super() at all — so nothing
+    about its [[Construct]] follows the constructor object's [[Prototype]].
+    Probed against Node v24.0.1: an ordinary class retargeted with
+    Object.setPrototypeOf onto a class that has a constructor still constructs
+    a plain object and never runs it. }
+  if not AClassValue.HasDerivedConstructorKind then
+    Exit;
+  { §13.3.7.3 GetSuperConstructor: a ~derived~ constructor resolves super()
+    through the active function object's [[GetPrototypeOf]], which
+    Object.setPrototypeOf does move. Probed against Node v24.0.1: a retargeted
+    derived class runs the new prototype's constructor and instance elements,
+    not its declared superclass's. }
+  if AClassValue.GetConstructorPrototype is TGocciaClassValue then
+    Exit(TGocciaClassValue(AClassValue.GetConstructorPrototype));
+  Result := AClassValue.SuperClass;
+end;
+
+function ResolveImplicitConstructorChain(
+  const AClassValue: TGocciaClassValue;
+  out ACollapsed: TGocciaClassChain): TGocciaClassValue;
+var
+  Count: Integer;
+  Next: TGocciaClassValue;
+begin
+  SetLength(ACollapsed, 0);
+  Count := 0;
+  if not Assigned(AClassValue) then
+    Exit(nil);
+
+  Result := ImplicitSuperConstructorClass(AClassValue);
+  while Assigned(Result) and
+        (Result.NativeInstanceDefaultPrototype = nil) and
+        (not Result.UsesOwnInstantiation) and
+        (not Assigned(Result.ConstructorMethod)) do
+  begin
+    if Count = Length(ACollapsed) then
+      SetLength(ACollapsed, Count * 2 + 4);
+    ACollapsed[Count] := Result;
+    Inc(Count);
+    Next := ImplicitSuperConstructorClass(Result);
+    if not Assigned(Next) then
+    begin
+      { This class's own super() reaches a built-in constructor exposed as a
+        function value, or it is ~base~ and has no super() at all. Either way
+        the construction path has already settled the receiver and there is no
+        further constructor left for the caller to run. }
+      Result := nil;
+      Break;
+    end;
+    Result := Next;
+  end;
+  SetLength(ACollapsed, Count);
 end;
 
 function ToNumberConstructorValue(
@@ -1754,6 +1846,8 @@ var
   DelayNativePrototypeLookup: Boolean;
   NativeInstanceInitialized: Boolean;
   NativeInstanceConstructedByNativeSuper: Boolean;
+  CollapsedChain: TGocciaClassChain;
+  CollapsedIndex: Integer;
   function IsUndefinedConstructResult(const AValue: TGocciaValue): Boolean;
   begin
     Result := (not Assigned(AValue)) or
@@ -1901,9 +1995,7 @@ begin
   end;
 
   ConstructorToCall := FConstructorMethod;
-  ImplicitSuperClass := FSuperClass;
-  if GetConstructorPrototype is TGocciaClassValue then
-    ImplicitSuperClass := TGocciaClassValue(GetConstructorPrototype);
+  ImplicitSuperClass := ResolveImplicitConstructorChain(Self, CollapsedChain);
   if not Assigned(ConstructorToCall) and Assigned(ImplicitSuperClass) then
     ConstructorToCall := ImplicitSuperClass.ConstructorMethod;
 
@@ -1919,26 +2011,42 @@ begin
 
     // ES2026 §10.2.2 step 11: explicit Object return replaces the receiver
     if ConstructResult is TGocciaObjectValue then
-      Exit(TGocciaObjectValue(ConstructResult));
-
+    begin
+      if ConstructorToCall = FConstructorMethod then
+        Exit(TGocciaObjectValue(ConstructResult));
+      { A borrowed superclass constructor is standing in for this class's
+        implicit `super(...args)`, so §13.3.7.1 step 11 binds what it returned
+        as `this` and this class's own instance elements still land on it. }
+      Instance := TGocciaObjectValue(ConstructResult);
+    end
     // ES2026 §10.2.2 step 12: derived constructors must return Object or
     // undefined — any other value is a TypeError
-    if Assigned(FSuperClass) or Assigned(FNativeSuperConstructor) then
+    else if Assigned(FSuperClass) or Assigned(FNativeSuperConstructor) then
     begin
       if Assigned(ConstructResult) and
          not (ConstructResult is TGocciaUndefinedLiteralValue) then
         ThrowTypeError('Derived constructor returned non-object',
           SSuggestNotConstructorType);
 
-      if (ConstructorToCall = FConstructorMethod) and
-         IsUndefinedConstructResult(ConstructResult) and
-         not ConstructorToCall.LastSuperConstructorCalled then
+      { §10.2.2 step 13.c belongs to the constructor that returned, which is
+        the borrowed one when this class declares none of its own: a subclass
+        with no constructor of its own, extending a class whose constructor
+        never calls super(), leaves `this` uninitialized just the same. }
+      if IsUndefinedConstructResult(ConstructResult) and
+         not ConstructorToCall.LastSuperConstructorCalled and
+         ((ConstructorToCall = FConstructorMethod) or
+          (Assigned(ImplicitSuperClass) and
+           ImplicitSuperClass.HasDerivedConstructorKind)) then
         ThrowReferenceError(
           'Must call super constructor before returning from derived constructor');
 
       if (FinalThis is TGocciaObjectValue) then
-        Exit(TGocciaObjectValue(FinalThis));
-      if IsUndefinedConstructResult(ConstructResult) then
+      begin
+        if ConstructorToCall = FConstructorMethod then
+          Exit(TGocciaObjectValue(FinalThis));
+        Instance := TGocciaObjectValue(FinalThis);
+      end
+      else if IsUndefinedConstructResult(ConstructResult) then
         ThrowReferenceError(
           'Must call super constructor before returning from derived constructor');
     end;
@@ -1966,6 +2074,31 @@ begin
       if not NativeInstanceConstructedByNativeSuper then
         if not NativeInstanceInitialized then
           TGocciaInstanceValue(NativeInstance).InitializeNativeFromArguments(AArguments);
+  end;
+
+  { §15.7.14 step 15a / §7.3.33 InitializeInstanceElements: the implicit
+    constructor this class ran above forwards to super and then initializes its
+    own instance elements, and so does every class the chain walk collapsed on
+    the way to the constructor that actually ran. A class with a constructor of
+    its own already did this from its super() and is skipped.
+
+    The elements are AST expressions that only the evaluator can evaluate, so
+    they go through the registered hook. Without this every route through
+    §7.3.14 Construct — Reflect.construct, a proxy with no construct trap, a
+    bound class, and every species construction — handed back an instance whose
+    declared fields were undefined whenever the superclass chain reached a
+    built-in, because those are the classes the evaluator's construct redirect
+    declines. }
+  if not Assigned(FConstructorMethod) then
+  begin
+    TGarbageCollector.Instance.AddTempRoot(Instance);
+    try
+      for CollapsedIndex := High(CollapsedChain) downto 0 do
+        TryRunASTInstanceElements(CollapsedChain[CollapsedIndex], Instance);
+      TryRunASTInstanceElements(Self, Instance);
+    finally
+      TGarbageCollector.Instance.RemoveTempRoot(Instance);
+    end;
   end;
 
   Result := Instance;

--- a/tests/built-ins/Reflect/construct/native-chain-instance-elements.js
+++ b/tests/built-ins/Reflect/construct/native-chain-instance-elements.js
@@ -1,33 +1,20 @@
 /*---
-description: Every route through the abstract Construct operation treats a class whose chain reaches a built-in identically (known gap, see below)
+description: Every route through the abstract Construct operation initializes the instance elements of a class whose superclass chain reaches a built-in
 features: [Reflect]
 ---*/
 
 /*
-  KNOWN GAP, pinned deliberately.
+  ES2026 §7.3.33 InitializeInstanceElements runs for every [[Construct]], not
+  only for the `new` operator, and §15.7.14 step 15a gives a class with no
+  constructor of its own an implicit one that forwards to super and then
+  initializes its own elements. So Reflect.construct (§28.1.2), the proxy
+  [[Construct]] fallback (§10.5.13), construction through a bound wrapper
+  (§10.4.1.2) and every species construction have to agree with `new`.
 
-  A class whose superclass chain reaches a built-in constructor is declined by
-  RedirectEvaluatorClassConstruct (Goccia.Evaluator.pas) and built by
-  TGocciaClassValue.Instantiate instead, which runs no instance elements. In
-  interpreted mode that means every route through the abstract Construct
-  operation — Reflect.construct, a proxy without a construct trap, a bound
-  class, and every species construction (Array.from, Array.prototype.map,
-  Promise.prototype.then, ...) — hands back an instance whose declared fields
-  are undefined. `new` is unaffected: it calls InstantiateClass directly.
-  Bytecode mode is correct throughout, so this is also a mode divergence.
-
-  The guard cannot simply be widened: InstantiateClass resolves
-  newTarget.prototype before ArrayBuffer/SharedArrayBuffer/DataView validate
-  their arguments, and it builds the native receiver twice for a derived class
-  whose constructor calls super() explicitly (a Promise executor runs twice).
-  Both have to be fixed there first.
-
-  So these tests do not assert a value that differs per mode. They assert the
-  property that must survive any fix, partial or complete: all the Construct
-  routes agree with each other, and the answer is either "the field is
-  initialized" (fixed, and what `new` already does) or "no route initializes
-  it" (today's gap). A fix that reaches Reflect.construct but leaves species
-  construction behind — or the reverse — fails here.
+  These tests keep the agreement assertions they were written with — a fix that
+  reaches Reflect.construct but leaves species construction behind still fails
+  here — and now pin the answer they have to agree on: initialized, the same
+  value `new` produces. Probed against Node v24.0.1.
 */
 
 const routeResults = (makeSubclass, read) => {
@@ -59,8 +46,7 @@ describe("Array subclass instance elements across Construct routes", () => {
     const results = routeResults(makeArraySubclass, (o) => o.tag);
     const values = [results.reflect, results.proxy, results.bound];
     expect(allAgree(values)).toBe(true);
-    // Either all initialized (fixed) or none (the pinned gap).
-    expect(values[0] === "t" || values[0] === undefined).toBe(true);
+    expect(values[0]).toBe("t");
   });
 
   test("species construction agrees with the other Construct routes", () => {
@@ -68,10 +54,14 @@ describe("Array subclass instance elements across Construct routes", () => {
     const fromTag = Tagged.from([1, 2]).tag;
     const ofTag = Tagged.of(1, 2).tag;
     const mapTag = Tagged.from([1, 2]).map((x) => x).tag;
+    const filterTag = Tagged.from([1, 2]).filter(() => true).tag;
+    const sliceTag = Tagged.from([1, 2]).slice(0, 1).tag;
     const reflectTag = Reflect.construct(Tagged, []).tag;
 
-    expect(allAgree([fromTag, ofTag, mapTag, reflectTag])).toBe(true);
-    expect(reflectTag === "t" || reflectTag === undefined).toBe(true);
+    expect(
+      allAgree([fromTag, ofTag, mapTag, filterTag, sliceTag, reflectTag]),
+    ).toBe(true);
+    expect(reflectTag).toBe("t");
   });
 
   test("the built-in half of the instance is correct on every route", () => {
@@ -80,6 +70,12 @@ describe("Array subclass instance elements across Construct routes", () => {
     expect(Tagged.from([1, 2]).length).toBe(2);
     expect(Tagged.of(1, 2)[1]).toBe(2);
     expect(Tagged.from([1, 2]).map((x) => x * 2)[0]).toBe(2);
+  });
+
+  test("a species-constructed instance keeps the subclass prototype", () => {
+    const Tagged = makeArraySubclass();
+    expect(Tagged.from([1, 2]) instanceof Tagged).toBe(true);
+    expect(Tagged.from([1, 2]).map((x) => x) instanceof Tagged).toBe(true);
   });
 });
 
@@ -100,14 +96,46 @@ describe("Promise subclass instance elements across Construct routes", () => {
     expect(runs).toBe(1);
   });
 
+  test("an explicit constructor's super() runs the executor once too", () => {
+    // The receiver a native super constructor returns replaces the one
+    // construction started with, so pre-building it and then calling super()
+    // ran the executor twice.
+    class Tagged extends Promise {
+      tag = "t";
+
+      constructor(executor) {
+        super(executor);
+      }
+    }
+
+    let runs = 0;
+    const instance = new Tagged((resolve) => {
+      runs += 1;
+      resolve(1);
+    });
+    expect(instance.tag).toBe("t");
+    expect(runs).toBe(1);
+
+    let reflectRuns = 0;
+    const constructed = Reflect.construct(Tagged, [
+      (resolve) => {
+        reflectRuns += 1;
+        resolve(1);
+      },
+    ]);
+    expect(constructed.tag).toBe("t");
+    expect(reflectRuns).toBe(1);
+  });
+
   test("species construction agrees with Reflect.construct", () => {
     const Tagged = makePromiseSubclass();
     const resolveTag = Tagged.resolve(1).tag;
     const thenTag = Tagged.resolve(1).then((v) => v).tag;
+    const catchTag = Tagged.resolve(1).catch(() => 1).tag;
     const reflectTag = Reflect.construct(Tagged, [(resolve) => resolve(1)]).tag;
 
-    expect(allAgree([resolveTag, thenTag, reflectTag])).toBe(true);
-    expect(reflectTag === "t" || reflectTag === undefined).toBe(true);
+    expect(allAgree([resolveTag, thenTag, catchTag, reflectTag])).toBe(true);
+    expect(reflectTag).toBe("t");
   });
 
   test("the promise half of the instance still settles on every route", () => {
@@ -119,6 +147,56 @@ describe("Promise subclass instance elements across Construct routes", () => {
     ]).then((values) => {
       expect(values).toEqual([7, 8, 9]);
     });
+  });
+});
+
+describe("other built-in chains across Construct routes", () => {
+  test("a Map subclass keeps both halves", () => {
+    class Tagged extends Map {
+      tag = "t";
+    }
+
+    const constructed = Reflect.construct(Tagged, [[[1, 2]]]);
+    expect(constructed.tag).toBe("t");
+    expect(constructed.get(1)).toBe(2);
+    expect(constructed instanceof Map).toBe(true);
+  });
+
+  test("an Error subclass keeps both halves", () => {
+    class Tagged extends Error {
+      tag = "t";
+    }
+
+    const constructed = Reflect.construct(Tagged, ["boom"]);
+    expect(constructed.tag).toBe("t");
+    expect(constructed.message).toBe("boom");
+    expect(constructed instanceof Error).toBe(true);
+  });
+
+  test("a Set subclass keeps both halves", () => {
+    class Tagged extends Set {
+      tag = "t";
+    }
+
+    const constructed = Reflect.construct(Tagged, [[1, 2]]);
+    expect(constructed.tag).toBe("t");
+    expect(constructed.has(2)).toBe(true);
+  });
+});
+
+describe("private instance elements on a native chain", () => {
+  test("Reflect.construct stamps the brand and runs the initializer", () => {
+    class Tagged extends Array {
+      #secret = "s";
+
+      read() {
+        return this.#secret;
+      }
+    }
+
+    expect(new Tagged().read()).toBe("s");
+    expect(Reflect.construct(Tagged, []).read()).toBe("s");
+    expect(Tagged.from([1]).read()).toBe("s");
   });
 });
 

--- a/tests/built-ins/Reflect/construct/native-chain-instance-elements.js
+++ b/tests/built-ins/Reflect/construct/native-chain-instance-elements.js
@@ -184,6 +184,90 @@ describe("other built-in chains across Construct routes", () => {
   });
 });
 
+describe("a borrowed constructor's super() over a native chain", () => {
+  // A subclass with no constructor of its own borrows the one above it, and
+  // that borrowed body calls super() itself. Pre-building the native receiver
+  // as well ran the Promise executor twice, and left a second construction
+  // with no arguments to fail outright.
+  test("the executor runs once through a borrowed constructor", () => {
+    class Tagged extends Promise {
+      tag = "t";
+
+      constructor(executor) {
+        super(executor);
+      }
+    }
+    class Borrowing extends Tagged {}
+
+    let runs = 0;
+    const instance = new Borrowing((resolve) => {
+      runs += 1;
+      resolve(1);
+    });
+    expect(runs).toBe(1);
+    expect(instance.tag).toBe("t");
+    expect(instance instanceof Promise).toBe(true);
+    expect(Object.getPrototypeOf(instance)).toBe(Borrowing.prototype);
+
+    let reflectRuns = 0;
+    const constructed = Reflect.construct(Borrowing, [
+      (resolve) => {
+        reflectRuns += 1;
+        resolve(1);
+      },
+    ]);
+    expect(reflectRuns).toBe(1);
+    expect(constructed.tag).toBe("t");
+  });
+
+  test("a borrowed constructor that supplies its own executor constructs", () => {
+    // The borrowed constructor ignores the arguments and resolves itself, so
+    // there is exactly one construction to get right. (Chaining .then() off it
+    // is a different matter: §27.2.1.5 NewPromiseCapability needs the executor
+    // it passed to have been called, and Node rejects this shape too.)
+    class Tagged extends Promise {
+      constructor() {
+        super((resolve) => resolve(1));
+      }
+    }
+    class Borrowing extends Tagged {}
+
+    const instance = new Borrowing();
+    expect(instance instanceof Promise).toBe(true);
+    expect(Object.getPrototypeOf(instance)).toBe(Borrowing.prototype);
+    expect(instance instanceof Tagged).toBe(true);
+  });
+});
+
+describe("a foreign newTarget over an implicit native chain", () => {
+  // ES2026 §10.2.2 steps 5-6 put newTarget's prototype on the receiver before
+  // the built-in's own steps, and §24.1.1.1 Map then reads its `set` adder off
+  // that receiver. Populating through Map.prototype instead hid the failure.
+  // Probed against Node v24.0.1: a TypeError either way.
+  test("Map population reads the adder off newTarget's prototype", () => {
+    class First extends Map {}
+    class Second extends First {}
+    class Foreign {}
+
+    let name = "<no error>";
+    try {
+      Reflect.construct(Second, [[[1, 2]]], Foreign);
+    } catch (error) {
+      name = error.name;
+    }
+    expect(name).toBe("TypeError");
+  });
+
+  test("with no iterable there is no adder to look up", () => {
+    class First extends Map {}
+    class Second extends First {}
+    class Foreign {}
+
+    const constructed = Reflect.construct(Second, [], Foreign);
+    expect(Object.getPrototypeOf(constructed)).toBe(Foreign.prototype);
+  });
+});
+
 describe("private instance elements on a native chain", () => {
   test("Reflect.construct stamps the brand and runs the initializer", () => {
     class Tagged extends Array {

--- a/tests/language/classes/constructor-prototype-retargeting.js
+++ b/tests/language/classes/constructor-prototype-retargeting.js
@@ -1,0 +1,127 @@
+/*---
+description: Object.setPrototypeOf on a constructor does not change which superclass its [[Construct]] runs
+features: [class, class-inheritance, Reflect]
+---*/
+
+// ES2026 §15.7.14 ClassDefinitionEvaluation step 9 fixes [[ConstructorKind]]
+// and the constructor's [[HomeObject]]/super binding when the class is
+// evaluated. §10.2.2 [[Construct]] then runs the body that class was defined
+// with; the constructor object's own [[Prototype]] only takes part in ordinary
+// property lookup — static-method inheritance and static `super` — never in
+// choosing whose constructor body executes or which receiver is allocated.
+//
+// Probed against Node v24.0.1: an ordinary class retargeted onto another class
+// constructs a plain object with its own prototype and runs neither the other
+// class's constructor nor its allocator.
+
+describe("retargeting an ordinary class", () => {
+  test("the retargeted class does not run the new prototype's constructor", () => {
+    class PlainBase {
+      constructor() {
+        this.tag = "pb";
+      }
+    }
+    class Retarget {}
+    Object.setPrototypeOf(Retarget, PlainBase);
+
+    expect(new Retarget().tag).toBe(undefined);
+    expect(Reflect.construct(Retarget, []).tag).toBe(undefined);
+    expect(Object.keys(new Retarget())).toEqual([]);
+  });
+
+  test("the retargeted class does not inherit instance fields either", () => {
+    class Fielded {
+      own = 1;
+    }
+    class Retarget {}
+    Object.setPrototypeOf(Retarget, Fielded);
+
+    expect(Object.keys(new Retarget())).toEqual([]);
+  });
+
+  test("the instance still gets the retargeted class's own prototype", () => {
+    class PlainBase {}
+    class Retarget {}
+    Object.setPrototypeOf(Retarget, PlainBase);
+
+    const instance = new Retarget();
+    expect(Object.getPrototypeOf(instance)).toBe(Retarget.prototype);
+    expect(instance instanceof Retarget).toBe(true);
+    expect(instance instanceof PlainBase).toBe(false);
+  });
+
+  test("static methods do follow the mutated chain", () => {
+    class StaticSource {
+      static make() {
+        return "made";
+      }
+    }
+    class Retarget {}
+    Object.setPrototypeOf(Retarget, StaticSource);
+
+    expect(Retarget.make()).toBe("made");
+  });
+});
+
+describe("retargeting onto a class whose chain reaches a built-in", () => {
+  test("no built-in receiver is allocated", () => {
+    class WithMap extends Map {}
+    class Retarget {}
+    Object.setPrototypeOf(Retarget, WithMap);
+
+    const constructed = Reflect.construct(Retarget, []);
+    expect(constructed instanceof Map).toBe(false);
+    expect(Object.getPrototypeOf(constructed)).toBe(Retarget.prototype);
+
+    const created = new Retarget();
+    expect(created instanceof Map).toBe(false);
+    expect(Object.getPrototypeOf(created)).toBe(Retarget.prototype);
+  });
+
+  test("an Array-backed retarget is an ordinary object too", () => {
+    class WithArray extends Array {}
+    class Retarget {}
+    Object.setPrototypeOf(Retarget, WithArray);
+
+    expect(Array.isArray(new Retarget())).toBe(false);
+    expect(Array.isArray(Reflect.construct(Retarget, []))).toBe(false);
+  });
+});
+
+describe("retargeting a derived class", () => {
+  // §13.3.7.3 GetSuperConstructor reads the active function object's
+  // [[GetPrototypeOf]], so a ~derived~ constructor's super() — explicit or the
+  // implicit one of §15.7.14 step 15a — does follow the mutated chain. Only
+  // the ~base~ case above is unaffected, because it has no super() to resolve.
+  test("super() runs the new prototype's constructor, not the declared one", () => {
+    class Declared {
+      constructor() {
+        this.from = "declared";
+      }
+    }
+    class Other {
+      constructor() {
+        this.from = "other";
+      }
+    }
+    class Sub extends Declared {}
+    Object.setPrototypeOf(Sub, Other);
+
+    expect(new Sub().from).toBe("other");
+    expect(Reflect.construct(Sub, []).from).toBe("other");
+  });
+
+  test("the new prototype's instance fields run before the subclass's", () => {
+    class Declared {}
+    class Fielded {
+      own = 1;
+    }
+    class Sub extends Declared {
+      mine = 2;
+    }
+    Object.setPrototypeOf(Sub, Fielded);
+
+    expect(Object.keys(new Sub())).toEqual(["own", "mine"]);
+    expect(Object.keys(Reflect.construct(Sub, []))).toEqual(["own", "mine"]);
+  });
+});

--- a/tests/language/classes/constructor-prototype-retargeting.js
+++ b/tests/language/classes/constructor-prototype-retargeting.js
@@ -1,18 +1,19 @@
 /*---
-description: Object.setPrototypeOf on a constructor does not change which superclass its [[Construct]] runs
+description: Object.setPrototypeOf on a constructor moves super() for a derived class and is inert for a base one
 features: [class, class-inheritance, Reflect]
 ---*/
 
 // ES2026 §15.7.14 ClassDefinitionEvaluation step 9 fixes [[ConstructorKind]]
-// and the constructor's [[HomeObject]]/super binding when the class is
-// evaluated. §10.2.2 [[Construct]] then runs the body that class was defined
-// with; the constructor object's own [[Prototype]] only takes part in ordinary
-// property lookup — static-method inheritance and static `super` — never in
-// choosing whose constructor body executes or which receiver is allocated.
+// when the class is evaluated, and it never changes afterwards. What the
+// constructor object's own [[Prototype]] decides is where super() goes:
+// §13.3.7.3 GetSuperConstructor reads it when the call runs, so a ~derived~
+// class follows an Object.setPrototypeOf — including onto a built-in, or onto
+// something that is not a constructor at all, which §13.3.7.1 SuperCall step 3
+// rejects. A ~base~ class has no super() to resolve, so the same mutation only
+// affects ordinary property lookup on the constructor: static-method
+// inheritance and static `super`.
 //
-// Probed against Node v24.0.1: an ordinary class retargeted onto another class
-// constructs a plain object with its own prototype and runs neither the other
-// class's constructor nor its allocator.
+// Every expectation here was probed against Node v24.0.1.
 
 describe("retargeting an ordinary class", () => {
   test("the retargeted class does not run the new prototype's constructor", () => {
@@ -85,6 +86,267 @@ describe("retargeting onto a class whose chain reaches a built-in", () => {
 
     expect(Array.isArray(new Retarget())).toBe(false);
     expect(Array.isArray(Reflect.construct(Retarget, []))).toBe(false);
+  });
+});
+
+describe("retargeting onto something that is not a constructor", () => {
+  // §13.3.7.3 GetSuperConstructor hands super() whatever the constructor's
+  // [[Prototype]] is, and §13.3.7.1 SuperCall step 3 rejects it when that is
+  // not a constructor. Probed against Node v24.0.1: every one of these throws
+  // a TypeError.
+  const expectSuperTypeError = (build) => {
+    let name = "<no error>";
+    try {
+      build();
+    } catch (error) {
+      name = error.name;
+    }
+    expect(name).toBe("TypeError");
+  };
+
+  const makeSubclass = () => {
+    class Declared {
+      constructor() {
+        this.who = "declared";
+      }
+    }
+    return class Sub extends Declared {};
+  };
+
+  test("a plain object is not a super constructor", () => {
+    const Sub = makeSubclass();
+    Object.setPrototypeOf(Sub, {});
+
+    expectSuperTypeError(() => new Sub());
+    expectSuperTypeError(() => Reflect.construct(Sub, []));
+    expectSuperTypeError(() => new (Sub.bind(null))());
+  });
+
+  test("null leaves nothing to resolve super() through", () => {
+    const Sub = makeSubclass();
+    Object.setPrototypeOf(Sub, null);
+
+    expectSuperTypeError(() => new Sub());
+    expectSuperTypeError(() => Reflect.construct(Sub, []));
+  });
+
+  test("an arrow function is callable but not constructable", () => {
+    const Sub = makeSubclass();
+    Object.setPrototypeOf(Sub, (x) => x);
+
+    expectSuperTypeError(() => new Sub());
+  });
+
+  test("Function.prototype is not a constructor either", () => {
+    const Sub = makeSubclass();
+    Object.setPrototypeOf(Sub, Object.getPrototypeOf(Object));
+
+    expectSuperTypeError(() => new Sub());
+  });
+
+  test("an explicit constructor's super() throws the same way", () => {
+    class Declared {
+      constructor() {
+        this.who = "declared";
+      }
+    }
+    class Sub extends Declared {
+      constructor() {
+        super();
+      }
+    }
+    Object.setPrototypeOf(Sub, {});
+
+    expectSuperTypeError(() => new Sub());
+    expectSuperTypeError(() => Reflect.construct(Sub, []));
+  });
+
+  test("mixing a retarget with a declared chain terminates", () => {
+    // The two relations are individually acyclic — ordinary [[SetPrototypeOf]]
+    // rejects a cycle, and a declared superclass is fixed at definition time —
+    // but a resolver that followed the mutable one and fell back to the
+    // declared one walked a union of the two that could close on itself.
+    class Base {
+      b = 1;
+    }
+    class Middle extends Base {
+      m = 2;
+    }
+    class Leaf extends Middle {
+      l = 3;
+    }
+    Object.setPrototypeOf(Leaf, {});
+    Object.setPrototypeOf(Middle, Leaf);
+
+    expectSuperTypeError(() => new Leaf());
+    expectSuperTypeError(() => Reflect.construct(Leaf, []));
+  });
+});
+
+describe("retargeting onto a built-in constructor", () => {
+  // A built-in exposed as a function value rather than as a class value is a
+  // perfectly good super constructor, and the declared one stops running.
+  // Probed against Node v24.0.1.
+  test("Error runs and the declared superclass does not", () => {
+    class Declared {
+      constructor() {
+        this.who = "declared";
+      }
+    }
+    class Sub extends Declared {}
+    Object.setPrototypeOf(Sub, Error);
+
+    const instance = new Sub("boom");
+    expect(instance.message).toBe("boom");
+    expect(instance.who).toBe(undefined);
+    expect(Object.getPrototypeOf(instance)).toBe(Sub.prototype);
+  });
+
+  test("a bound class is constructable and runs", () => {
+    class Declared {
+      constructor() {
+        this.who = "declared";
+      }
+    }
+    class Alt {
+      constructor() {
+        this.who = "alt";
+      }
+    }
+    class Sub extends Declared {}
+    Object.setPrototypeOf(Sub, Alt.bind(null));
+
+    expect(new Sub().who).toBe("alt");
+  });
+});
+
+describe("an explicit constructor over a retargeted class", () => {
+  // §13.3.7.3 is read when super() runs, so an explicit body sees the same
+  // target an implicit one would. Probed against Node v24.0.1.
+  test("super() runs the retargeted constructor", () => {
+    class Declared {
+      constructor() {
+        this.who = "declared";
+      }
+    }
+    class Alt {
+      constructor() {
+        this.who = "alt";
+      }
+    }
+    class Sub extends Declared {
+      constructor() {
+        super();
+        this.tail = 1;
+      }
+    }
+    Object.setPrototypeOf(Sub, Alt);
+
+    expect(new Sub().who).toBe("alt");
+    expect(new Sub().tail).toBe(1);
+    expect(Reflect.construct(Sub, []).who).toBe("alt");
+  });
+
+  test("super() through a retargeted built-in allocates its receiver", () => {
+    class Declared {}
+    class Sub extends Declared {
+      constructor() {
+        super();
+        this.tail = 1;
+      }
+    }
+    Object.setPrototypeOf(Sub, Array);
+
+    const instance = new Sub();
+    expect(Array.isArray(instance)).toBe(true);
+    expect(instance.tail).toBe(1);
+  });
+});
+
+describe("retargeting a class in the middle of a chain", () => {
+  // Each hop is resolved when super() runs, so a retarget part-way up moves
+  // everything above it. Probed against Node v24.0.1.
+  const build = (LeafShape) => {
+    class Base {
+      b = "b";
+    }
+    class Middle extends Base {
+      m = "m";
+    }
+    class Alt {
+      a = "a";
+    }
+    const Leaf = LeafShape(Middle);
+    Object.setPrototypeOf(Middle, Alt);
+    return Leaf;
+  };
+
+  test("an implicit leaf follows the retargeted middle", () => {
+    const Leaf = build(
+      (Middle) =>
+        class Leaf extends Middle {
+          l = "l";
+        },
+    );
+    expect(Object.keys(new Leaf())).toEqual(["a", "m", "l"]);
+    expect(Object.keys(Reflect.construct(Leaf, []))).toEqual(["a", "m", "l"]);
+  });
+
+  test("an explicit leaf's super() follows it too", () => {
+    const Leaf = build(
+      (Middle) =>
+        class Leaf extends Middle {
+          l = "l";
+
+          constructor() {
+            super();
+          }
+        },
+    );
+    expect(Object.keys(new Leaf())).toEqual(["a", "m", "l"]);
+  });
+
+  test("a middle with its own constructor still forwards to the retarget", () => {
+    class Base {
+      b = "b";
+    }
+    class Middle extends Base {
+      m = "m";
+
+      constructor() {
+        super();
+      }
+    }
+    class Leaf extends Middle {
+      l = "l";
+    }
+    class Alt {
+      a = "a";
+    }
+    Object.setPrototypeOf(Middle, Alt);
+
+    expect(Object.keys(new Leaf())).toEqual(["a", "m", "l"]);
+  });
+
+  test("a four-deep chain drops everything above the retarget", () => {
+    class A0 {
+      a0 = 0;
+    }
+    class A1 extends A0 {
+      a1 = 1;
+    }
+    class A2 extends A1 {
+      a2 = 2;
+    }
+    class A3 extends A2 {
+      a3 = 3;
+    }
+    class Alt {
+      alt = "alt";
+    }
+    Object.setPrototypeOf(A2, Alt);
+
+    expect(Object.keys(new A3())).toEqual(["alt", "a2", "a3"]);
   });
 });
 

--- a/tests/language/classes/derived-constructor-missing-super.js
+++ b/tests/language/classes/derived-constructor-missing-super.js
@@ -11,10 +11,10 @@ features: [class-inheritance, Reflect, class]
 // covers `this` *access*, so a body that touches neither has no error of its
 // own to raise. Probed against Node v24.0.1: every one of these throws.
 //
-// Known deviation, identical in both modes and therefore not a parity break: a
-// subclass with no constructor of its own (`class L extends Middle {}`) still
-// constructs successfully. Its implicit constructor forwards through a
-// different set of paths, none of which consult the flag yet.
+// A subclass with no constructor of its own is not exempt: §15.7.14 step 15a
+// gives it an implicit constructor whose super() enters the same body, so the
+// constructor that returned without initializing `this` is still the one the
+// check asks about.
 
 class Base {}
 
@@ -55,6 +55,33 @@ describe("a derived constructor that never calls super()", () => {
 
   test("construction through a bound wrapper throws", () => {
     expectMissingSuper(() => new (Middle.bind(null))());
+  });
+
+  test("a subclass with no constructor of its own throws", () => {
+    class Leafless extends Middle {}
+
+    expectMissingSuper(() => new Leafless());
+    expectMissingSuper(() => Reflect.construct(Leafless, []));
+    expectMissingSuper(() => new (Leafless.bind(null))());
+  });
+
+  test("the check reaches through a chain of implicit constructors", () => {
+    class Leafless extends Middle {}
+    class Deeper extends Leafless {}
+
+    expectMissingSuper(() => new Deeper());
+    expectMissingSuper(() => Reflect.construct(Deeper, []));
+  });
+
+  test("a subclass with fields of its own still throws", () => {
+    // The fields would otherwise be initialized against a receiver that
+    // §10.2.2 step 13.c says was never bound.
+    class Fielded extends Middle {
+      own = 1;
+    }
+
+    expectMissingSuper(() => new Fielded());
+    expectMissingSuper(() => Reflect.construct(Fielded, []));
   });
 
   test("a constructor that does call super() is unaffected", () => {

--- a/tests/language/classes/derived-constructor-missing-super.js
+++ b/tests/language/classes/derived-constructor-missing-super.js
@@ -99,6 +99,36 @@ describe("a derived constructor that never calls super()", () => {
     expect(Object.keys(new (Ok.bind(null))())).toEqual(["seq", "tail"]);
   });
 
+  test("both modes report the same message", () => {
+    // The two checks — reading `this` and returning without super() — live in
+    // different places and fire in different orders per mode, so they share one
+    // message rather than describing the route they took.
+    class TouchesThis extends Base {
+      constructor() {
+        this.x = 1;
+      }
+    }
+    class TouchesNothing extends Base {
+      constructor() {}
+    }
+
+    const messageOf = (build) => {
+      try {
+        build();
+      } catch (error) {
+        return error.message;
+      }
+      return "<no error>";
+    };
+
+    expect(messageOf(() => new TouchesThis())).toBe(
+      messageOf(() => new TouchesNothing()),
+    );
+    expect(messageOf(() => new TouchesThis())).toContain(
+      "Must call super constructor",
+    );
+  });
+
   test("an explicit object return stands in for super()", () => {
     // §10.2.2 step 13.a: returning an Object is the other way a derived
     // constructor can finish, and it is checked before step 13.c.

--- a/tests/language/classes/native-chain-implicit-constructors.js
+++ b/tests/language/classes/native-chain-implicit-constructors.js
@@ -1,0 +1,178 @@
+/*---
+description: Every class between a subclass and the built-in it extends runs its implicit constructor and initializes its own instance elements
+features: [class, class-fields-public, class-fields-private, class-inheritance, Reflect]
+---*/
+
+// ES2026 §15.7.14 ClassDefinitionEvaluation step 15a synthesizes
+// `constructor(...args) { super(...args); }` for a class that declares none,
+// and §13.3.7.1 SuperCall step 11 initializes that class's instance elements
+// once super() returns. Construction paths used to collapse the whole chain in
+// one walk — find the built-in that has to allocate the receiver, run one
+// constructor against it — and every class the walk stepped over silently lost
+// both halves. Probed against Node v24.0.1.
+
+const keysOf = (value) => Object.keys(value);
+
+describe("two-level chains reaching a built-in", () => {
+  test("an Array chain initializes both classes' fields, base-most first", () => {
+    class Middle extends Array {
+      mid = "m";
+    }
+    class Leaf extends Middle {
+      leaf = "l";
+    }
+
+    const instance = new Leaf();
+    expect(instance.mid).toBe("m");
+    expect(instance.leaf).toBe("l");
+    expect(keysOf(instance)).toEqual(["mid", "leaf"]);
+    expect(Array.isArray(instance)).toBe(true);
+    expect(instance instanceof Leaf).toBe(true);
+  });
+
+  test("a Map chain initializes both classes' fields", () => {
+    class Middle extends Map {
+      mid = "m";
+    }
+    class Leaf extends Middle {
+      leaf = "l";
+    }
+
+    const instance = new Leaf([[1, 2]]);
+    expect(instance.mid).toBe("m");
+    expect(instance.leaf).toBe("l");
+    expect(instance.get(1)).toBe(2);
+  });
+
+  test("a Promise chain initializes both classes' fields", () => {
+    class Middle extends Promise {
+      mid = "m";
+    }
+    class Leaf extends Middle {
+      leaf = "l";
+    }
+
+    const instance = new Leaf((resolve) => resolve(1));
+    expect(instance.mid).toBe("m");
+    expect(instance.leaf).toBe("l");
+    return instance.then((value) => {
+      expect(value).toBe(1);
+    });
+  });
+
+  test("an Error chain keeps the subclass prototype", () => {
+    class Middle extends Error {
+      mid = "m";
+    }
+    class Leaf extends Middle {
+      leaf = "l";
+    }
+
+    const instance = new Leaf("boom");
+    expect(instance.mid).toBe("m");
+    expect(instance.leaf).toBe("l");
+    expect(instance.message).toBe("boom");
+    expect(Object.getPrototypeOf(instance)).toBe(Leaf.prototype);
+    expect(instance instanceof Leaf).toBe(true);
+    expect(instance instanceof Middle).toBe(true);
+    expect(instance instanceof Error).toBe(true);
+  });
+
+  test("Reflect.construct agrees with `new` on the whole chain", () => {
+    class Middle extends Array {
+      mid = "m";
+    }
+    class Leaf extends Middle {
+      leaf = "l";
+    }
+
+    expect(keysOf(Reflect.construct(Leaf, []))).toEqual(["mid", "leaf"]);
+  });
+});
+
+describe("three-level chains reaching a built-in", () => {
+  test("every implicit constructor in the chain contributes", () => {
+    class First extends Array {
+      first = 1;
+    }
+    class Second extends First {
+      second = 2;
+    }
+    class Third extends Second {
+      third = 3;
+    }
+
+    expect(keysOf(new Third())).toEqual(["first", "second", "third"]);
+    expect(keysOf(Reflect.construct(Third, []))).toEqual([
+      "first",
+      "second",
+      "third",
+    ]);
+  });
+
+  test("an explicit constructor part-way up still runs", () => {
+    const order = [];
+
+    class First extends Array {
+      first = 1;
+
+      constructor() {
+        super();
+        order.push("First");
+      }
+    }
+    class Second extends First {
+      second = 2;
+    }
+    class Third extends Second {
+      third = 3;
+    }
+
+    const instance = new Third();
+    expect(order).toEqual(["First"]);
+    expect(keysOf(instance)).toEqual(["first", "second", "third"]);
+  });
+});
+
+describe("private instance elements on an intermediate class", () => {
+  test("the brand is stamped once and the initializer runs", () => {
+    class Middle extends Array {
+      #mid = "m";
+
+      readMid() {
+        return this.#mid;
+      }
+    }
+    class Leaf extends Middle {
+      #leaf = "l";
+
+      readLeaf() {
+        return this.#leaf;
+      }
+    }
+
+    const instance = new Leaf();
+    expect(instance.readMid()).toBe("m");
+    expect(instance.readLeaf()).toBe("l");
+
+    const constructed = Reflect.construct(Leaf, []);
+    expect(constructed.readMid()).toBe("m");
+    expect(constructed.readLeaf()).toBe("l");
+  });
+});
+
+describe("a chain with no built-in is unaffected", () => {
+  test("plain classes keep initializing in declaration order", () => {
+    class First {
+      first = 1;
+    }
+    class Second extends First {
+      second = 2;
+    }
+    class Third extends Second {
+      third = 3;
+    }
+
+    expect(keysOf(new Third())).toEqual(["first", "second", "third"]);
+  });
+});

--- a/tests/language/modules/hoisted-function-import-capture/class-construction.js
+++ b/tests/language/modules/hoisted-function-import-capture/class-construction.js
@@ -17,6 +17,7 @@ import {
   fnDeclClosureRead,
   fnDeclConstruct,
   makeEvaluatorBuiltBase,
+  makeFieldedSubclassOf,
   makeSubclassOf,
   fnDeclDerivedConstruct,
   fnDeclLocalImplicitSubclassConstruct,
@@ -189,6 +190,30 @@ describe("imported module functions construct module classes", () => {
     expect(implicit.label).toBe("id-evaluator-base");
     expect(implicit.n).toBe(5);
     expect(implicit.brand()).toBe("id-evaluator-brand");
+  });
+
+  // §15.7.14 step 15a: the evaluator-built class in the middle has no
+  // constructor of its own, so the compiled subclass's implicit constructor
+  // used to walk straight past it to the base that does — dropping the middle
+  // class's fields and its private brand.
+  test("a compiled subclass runs an evaluator-built middle class's fields", () => {
+    const Base = makeEvaluatorBuiltBase();
+    const Middle = makeFieldedSubclassOf(Base);
+
+    class Compiled extends Middle {
+      own = "compiled";
+    }
+
+    const instance = new Compiled(4);
+    expect(Object.keys(instance)).toEqual(["label", "n", "middle", "own"]);
+    expect(instance.middle).toBe("id-evaluator-middle");
+    expect(instance.middleBrand()).toBe("id-evaluator-middle-brand");
+    expect(instance.brand()).toBe("id-evaluator-brand");
+    expect(instance.n).toBe(4);
+
+    const constructed = Reflect.construct(Compiled, [6]);
+    expect(Object.keys(constructed)).toEqual(["label", "n", "middle", "own"]);
+    expect(constructed.middle).toBe("id-evaluator-middle");
   });
 
   test("entry-file construction of a derived module class initializes once", () => {

--- a/tests/language/modules/hoisted-function-import-capture/helpers/module-classes.js
+++ b/tests/language/modules/hoisted-function-import-capture/helpers/module-classes.js
@@ -176,3 +176,19 @@ export function makeEvaluatorBuiltBase() {
 export function makeSubclassOf(Base) {
   return class EvaluatorBuiltSub extends Base {};
 }
+
+// An evaluator-built class with fields of its own and no constructor, meant to
+// sit *between* a compiled subclass and the constructor that actually runs.
+// §15.7.14 step 15a still owes it an implicit constructor, and the class it is
+// sandwiched between is what makes the omission observable.
+export function makeFieldedSubclassOf(Base) {
+  return class EvaluatorBuiltMiddle extends Base {
+    middle = PREFIX + "evaluator-middle";
+
+    #middleBrand = PREFIX + "evaluator-middle-brand";
+
+    middleBrand() {
+      return this.#middleBrand;
+    }
+  };
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Runs the implicit-constructor chain per spec (ES2026 §10.2.2 / §13.3.7) on **every** construction path, in both engines. Prototype-retargeting a derived class (`Object.setPrototypeOf(Sub, WithMap)`, `extends null`, arrow/`Function.prototype` targets) now yields the correct result — a `TypeError`, the retargeted constructor, or the declared super — matching Node v24 across an exhaustive retarget matrix.
- Fixes a resolver that could follow a non-acyclic union of the mutable `[[Prototype]]` chain and the fixed declared-superclass relation, which on a mixed-relation cycle **hung past both `--timeout` and `--max-instructions`** (a Blocking finding); the walk now resolves through the moved target with timeout/instruction/visited guards as defense in depth.

## Testing

- [x] Full suite both modes (+19 tests); test262 `language/**/class/**` zero regressions, three interpreted fixes
- [x] Node v24-verified retarget matrix; mixed-relation cycle terminates with a `TypeError` under both limits
- [x] Differential zero divergence under bun 1.4.0 and CI-pinned 1.3.14; `./format.pas --check` and doc checks clean
