### PR TITLE
fix(runtime): root binary-operator operands across coercion re-entry

### DIFF
--- a/source/units/Goccia.Arithmetic.pas
+++ b/source/units/Goccia.Arithmetic.pas
@@ -130,17 +130,30 @@ begin
     ThrowTypeError(SErrorBigIntMixedTypes, SSuggestBigIntNoMixedArithmetic);
 end;
 
+// ES2026 §13.15.3 step 1 coerces the left operand before the right, and the
+// coercion of either one can re-enter guest code (valueOf / toString /
+// Symbol.toPrimitive). The left result is a fresh allocation whenever the hook
+// returned one or a primitive had to be boxed, and until the right operand is
+// coerced it lives only in a Pascal local that no root source walks — so a
+// collection driven from the right-hand hook would sweep it. Keep it on the
+// active-root stack across the second coercion.
+//
+// The active-root stack (rather than AddTempRoot) is what makes this reentrant:
+// it is a LIFO of pushes, so a nested operator inside one of the hooks cannot
+// drop a root an outer operator still depends on, whereas a bare
+// AddTempRoot/RemoveTempRoot pair on the same object would.
 procedure ToPrimitiveOperands(const ALeft, ARight: TGocciaValue;
-  out APrimitiveLeft, APrimitiveRight: TGocciaValue); {$IFDEF FPC}inline;{$ENDIF}
+  out APrimitiveLeft, APrimitiveRight: TGocciaValue);
+var
+  Roots: TGocciaActiveRootFrame;
 begin
+  Roots.Initialize;
   APrimitiveLeft := ToPrimitive(ALeft);
-  if (TGarbageCollector.Instance <> nil) then
-    TGarbageCollector.Instance.AddTempRoot(APrimitiveLeft);
+  Roots.Add(APrimitiveLeft);
   try
     APrimitiveRight := ToPrimitive(ARight);
   finally
-    if (TGarbageCollector.Instance <> nil) then
-      TGarbageCollector.Instance.RemoveTempRoot(APrimitiveLeft);
+    Roots.Clear;
   end;
 end;
 
@@ -152,6 +165,23 @@ begin
   if Result is TGocciaBigIntValue then
     Exit;
   Result := Result.ToNumberLiteral;
+end;
+
+// ToNumericOperand twin of ToPrimitiveOperands: same rooting obligation, same
+// spec-mandated left-then-right order.
+procedure ToNumericOperands(const ALeft, ARight: TGocciaValue;
+  out ANumericLeft, ANumericRight: TGocciaValue);
+var
+  Roots: TGocciaActiveRootFrame;
+begin
+  Roots.Initialize;
+  ANumericLeft := ToNumericOperand(ALeft);
+  Roots.Add(ANumericLeft);
+  try
+    ANumericRight := ToNumericOperand(ARight);
+  finally
+    Roots.Clear;
+  end;
 end;
 
 function ToNumberPair(const ALeft, ARight: TGocciaValue;
@@ -213,8 +243,7 @@ var
   NumericLeft, NumericRight: TGocciaValue;
   LeftNum, RightNum: TGocciaNumberLiteralValue;
 begin
-  NumericLeft := ToNumericOperand(ALeft);
-  NumericRight := ToNumericOperand(ARight);
+  ToNumericOperands(ALeft, ARight, NumericLeft, NumericRight);
 
   // ES2026 §6.1.6.2.2 BigInt::subtract
   if (NumericLeft is TGocciaBigIntValue) and (NumericRight is TGocciaBigIntValue) then
@@ -248,8 +277,7 @@ var
   LeftZero, RightZero: Boolean;
   SameSign: Boolean;
 begin
-  NumericLeft := ToNumericOperand(ALeft);
-  NumericRight := ToNumericOperand(ARight);
+  ToNumericOperands(ALeft, ARight, NumericLeft, NumericRight);
 
   // ES2026 §6.1.6.2.3 BigInt::multiply
   if (NumericLeft is TGocciaBigIntValue) and (NumericRight is TGocciaBigIntValue) then
@@ -283,8 +311,7 @@ var
   LeftNum, RightNum: TGocciaNumberLiteralValue;
   SameSign: Boolean;
 begin
-  NumericLeft := ToNumericOperand(ALeft);
-  NumericRight := ToNumericOperand(ARight);
+  ToNumericOperands(ALeft, ARight, NumericLeft, NumericRight);
 
   // ES2026 §6.1.6.2.6 BigInt::divide
   if (NumericLeft is TGocciaBigIntValue) and (NumericRight is TGocciaBigIntValue) then
@@ -341,8 +368,7 @@ var
   NumericLeft, NumericRight: TGocciaValue;
   LeftNum, RightNum: TGocciaNumberLiteralValue;
 begin
-  NumericLeft := ToNumericOperand(ALeft);
-  NumericRight := ToNumericOperand(ARight);
+  ToNumericOperands(ALeft, ARight, NumericLeft, NumericRight);
 
   // ES2026 §6.1.6.2.7 BigInt::remainder
   if (NumericLeft is TGocciaBigIntValue) and (NumericRight is TGocciaBigIntValue) then
@@ -363,8 +389,7 @@ var
   NumericLeft, NumericRight: TGocciaValue;
   LeftNum, RightNum: TGocciaNumberLiteralValue;
 begin
-  NumericLeft := ToNumericOperand(ALeft);
-  NumericRight := ToNumericOperand(ARight);
+  ToNumericOperands(ALeft, ARight, NumericLeft, NumericRight);
 
   // ES2026 §6.1.6.2.8 BigInt::exponentiate
   if (NumericLeft is TGocciaBigIntValue) and (NumericRight is TGocciaBigIntValue) then
@@ -384,8 +409,7 @@ function EvaluateBitwiseAnd(const ALeft, ARight: TGocciaValue): TGocciaValue;
 var
   NumericLeft, NumericRight: TGocciaValue;
 begin
-  NumericLeft := ToNumericOperand(ALeft);
-  NumericRight := ToNumericOperand(ARight);
+  ToNumericOperands(ALeft, ARight, NumericLeft, NumericRight);
   if (NumericLeft is TGocciaBigIntValue) and (NumericRight is TGocciaBigIntValue) then
     Exit(TGocciaBigIntValue.Create(
       TGocciaBigIntValue(NumericLeft).Value.BitwiseAnd(
@@ -398,8 +422,7 @@ function EvaluateBitwiseOr(const ALeft, ARight: TGocciaValue): TGocciaValue;
 var
   NumericLeft, NumericRight: TGocciaValue;
 begin
-  NumericLeft := ToNumericOperand(ALeft);
-  NumericRight := ToNumericOperand(ARight);
+  ToNumericOperands(ALeft, ARight, NumericLeft, NumericRight);
   if (NumericLeft is TGocciaBigIntValue) and (NumericRight is TGocciaBigIntValue) then
     Exit(TGocciaBigIntValue.Create(
       TGocciaBigIntValue(NumericLeft).Value.BitwiseOr(
@@ -412,8 +435,7 @@ function EvaluateBitwiseXor(const ALeft, ARight: TGocciaValue): TGocciaValue;
 var
   NumericLeft, NumericRight: TGocciaValue;
 begin
-  NumericLeft := ToNumericOperand(ALeft);
-  NumericRight := ToNumericOperand(ARight);
+  ToNumericOperands(ALeft, ARight, NumericLeft, NumericRight);
   if (NumericLeft is TGocciaBigIntValue) and (NumericRight is TGocciaBigIntValue) then
     Exit(TGocciaBigIntValue.Create(
       TGocciaBigIntValue(NumericLeft).Value.BitwiseXor(
@@ -427,8 +449,7 @@ function EvaluateLeftShift(const ALeft, ARight: TGocciaValue): TGocciaValue;
 var
   NumericLeft, NumericRight: TGocciaValue;
 begin
-  NumericLeft := ToNumericOperand(ALeft);
-  NumericRight := ToNumericOperand(ARight);
+  ToNumericOperands(ALeft, ARight, NumericLeft, NumericRight);
   if (NumericLeft is TGocciaBigIntValue) and (NumericRight is TGocciaBigIntValue) then
     Exit(TGocciaBigIntValue.Create(
       TGocciaBigIntValue(NumericLeft).Value.ShiftLeft(
@@ -443,8 +464,7 @@ function EvaluateRightShift(const ALeft, ARight: TGocciaValue): TGocciaValue;
 var
   NumericLeft, NumericRight: TGocciaValue;
 begin
-  NumericLeft := ToNumericOperand(ALeft);
-  NumericRight := ToNumericOperand(ARight);
+  ToNumericOperands(ALeft, ARight, NumericLeft, NumericRight);
   if (NumericLeft is TGocciaBigIntValue) and (NumericRight is TGocciaBigIntValue) then
     Exit(TGocciaBigIntValue.Create(
       TGocciaBigIntValue(NumericLeft).Value.ShiftRight(
@@ -460,8 +480,7 @@ function EvaluateUnsignedRightShift(const ALeft, ARight: TGocciaValue): TGocciaV
 var
   NumericLeft, NumericRight: TGocciaValue;
 begin
-  NumericLeft := ToNumericOperand(ALeft);
-  NumericRight := ToNumericOperand(ARight);
+  ToNumericOperands(ALeft, ARight, NumericLeft, NumericRight);
   if (NumericLeft is TGocciaBigIntValue) or (NumericRight is TGocciaBigIntValue) then
     ThrowTypeError(SErrorBigIntUnsignedRightShift,
       SSuggestBigIntNoMixedArithmetic);
@@ -860,14 +879,23 @@ begin
   Result := AValue.ToNumberLiteral;
 end;
 
-function CompareRelationalValues(const ALeft, ARight: TGocciaValue): Integer; {$IFDEF FPC}inline;{$ENDIF}
+function CompareRelationalValues(const ALeft, ARight: TGocciaValue): Integer;
 var
   PrimLeft, PrimRight: TGocciaValue;
   NumericLeft, NumericRight: TGocciaValue;
   Cmp: Integer;
+  Roots: TGocciaActiveRootFrame;
 begin
+  // Same rooting obligation as ToPrimitiveOperands, with the tphNumber hint
+  // ES2026 §7.2.12 IsLessThan requires.
+  Roots.Initialize;
   PrimLeft := ToPrimitive(ALeft, tphNumber);
-  PrimRight := ToPrimitive(ARight, tphNumber);
+  Roots.Add(PrimLeft);
+  try
+    PrimRight := ToPrimitive(ARight, tphNumber);
+  finally
+    Roots.Clear;
+  end;
 
   if (PrimLeft is TGocciaUndefinedLiteralValue) or
      (PrimRight is TGocciaUndefinedLiteralValue) then

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -2311,6 +2311,62 @@ begin
   end;
 end;
 
+// Rooted slow-path entry points for the binary operators.
+//
+// Materializing an operand register allocates: RegisterToValue builds a fresh
+// TGocciaNumberLiteralValue for every grkInt other than the 0/1 singletons and
+// for every grkFloat (Goccia.VM.Registers.pas). That box lives only in a Pascal
+// temporary, and no root source walks Pascal temporaries — while the operator
+// helpers below re-enter guest code through ToPrimitive (valueOf / toString /
+// Symbol.toPrimitive), a collection there sweeps it and the freed block is
+// handed straight back to the hook's own allocation, so the surviving operand
+// silently reads the other operand's value (or dangles).
+//
+// Root both materialized operands for the duration of the helper, mirroring how
+// the AST interpreter's EvaluateBinary roots Left and Right around exactly the
+// same helper calls (AddValueRoot in Goccia.Evaluator.pas) — which is why only
+// bytecode mode was affected. The active-root stack is an O(1) array push/pop,
+// and these wrappers sit only on the non-scalar arm of each opcode: the scalar
+// fast paths never materialize a value and never re-enter, so they stay
+// allocation- and root-free.
+//
+// Materializing both operands before the call is safe: allocation alone never
+// collects (TGarbageCollector.RegisterObject only accounts), so nothing can run
+// between the two GetRegister calls and the pushes below.
+type
+  TGocciaVMBinaryValueOp = function(const ALeft, ARight: TGocciaValue): TGocciaValue;
+  TGocciaVMBinaryPredicateOp = function(const ALeft, ARight: TGocciaValue): Boolean;
+
+function VMRootedBinaryValue(const AOperation: TGocciaVMBinaryValueOp;
+  const ALeft, ARight: TGocciaValue): TGocciaValue;
+var
+  Roots: TGocciaActiveRootFrame;
+begin
+  Roots.Initialize;
+  Roots.Add(ALeft);
+  Roots.Add(ARight);
+  try
+    Result := AOperation(ALeft, ARight);
+  finally
+    Roots.Clear;
+  end;
+end;
+
+function VMRootedBinaryPredicate(const AOperation: TGocciaVMBinaryPredicateOp;
+  const ALeft, ARight: TGocciaValue): Boolean;
+var
+  Roots: TGocciaActiveRootFrame;
+begin
+  Roots.Initialize;
+  Roots.Add(ALeft);
+  Roots.Add(ARight);
+  try
+    Result := AOperation(ALeft, ARight);
+  finally
+    Roots.Clear;
+  end;
+end;
+
 function VMRegisterToStringFast(
   const AValue: TGocciaRegister): TGocciaStringLiteralValue; {$IFDEF FPC}inline;{$ENDIF}
 begin
@@ -15642,7 +15698,10 @@ begin
               SetRegisterFast(A, EvaluateAddition(LeftValue, RightValue));
           end
           else
-            SetRegister(A, EvaluateAddition(LeftValue, RightValue));
+            // Rooted: at least one operand is an object, so EvaluateAddition
+            // re-enters guest code. See VMRootedBinaryValue.
+            SetRegister(A, VMRootedBinaryValue(@EvaluateAddition,
+              LeftValue, RightValue));
         end;
         end;
       end;
@@ -15665,7 +15724,7 @@ begin
         else
         begin
           if FProfilingOpcodes then TGocciaProfiler.Instance.RecordScalarMiss;
-          SetRegister(A, EvaluateSubtraction(
+          SetRegister(A, VMRootedBinaryValue(@EvaluateSubtraction,
             GetRegisterFast(B), GetRegisterFast(C)));
         end;
       end;
@@ -15902,7 +15961,7 @@ begin
         else
         begin
           if FProfilingOpcodes then TGocciaProfiler.Instance.RecordScalarMiss;
-          SetRegister(A, EvaluateMultiplication(
+          SetRegister(A, VMRootedBinaryValue(@EvaluateMultiplication,
             GetRegisterFast(B), GetRegisterFast(C)));
         end;
       end;
@@ -15919,7 +15978,7 @@ begin
         else
         begin
           if FProfilingOpcodes then TGocciaProfiler.Instance.RecordScalarMiss;
-          SetRegister(A, EvaluateDivision(
+          SetRegister(A, VMRootedBinaryValue(@EvaluateDivision,
             GetRegisterFast(B), GetRegisterFast(C)));
         end;
       end;
@@ -15936,7 +15995,7 @@ begin
         else
         begin
           if FProfilingOpcodes then TGocciaProfiler.Instance.RecordScalarMiss;
-          SetRegister(A, EvaluateModulo(
+          SetRegister(A, VMRootedBinaryValue(@EvaluateModulo,
             GetRegisterFast(B), GetRegisterFast(C)));
         end;
       end;
@@ -15953,7 +16012,7 @@ begin
         else
         begin
           if FProfilingOpcodes then TGocciaProfiler.Instance.RecordScalarMiss;
-          SetRegister(A, EvaluateExponentiation(
+          SetRegister(A, VMRootedBinaryValue(@EvaluateExponentiation,
             GetRegisterFast(B), GetRegisterFast(C)));
         end;
       end;
@@ -15983,7 +16042,7 @@ begin
             LongInt(FRegisters[B].IntValue) and
             LongInt(FRegisters[C].IntValue))
         else
-          SetRegister(A, EvaluateBitwiseAnd(
+          SetRegister(A, VMRootedBinaryValue(@EvaluateBitwiseAnd,
             GetRegister(B), GetRegister(C)));
 
       OP_BOR:
@@ -15993,7 +16052,7 @@ begin
             LongInt(FRegisters[B].IntValue) or
             LongInt(FRegisters[C].IntValue))
         else
-          SetRegister(A, EvaluateBitwiseOr(
+          SetRegister(A, VMRootedBinaryValue(@EvaluateBitwiseOr,
             GetRegister(B), GetRegister(C)));
 
       OP_BXOR:
@@ -16003,7 +16062,7 @@ begin
             LongInt(FRegisters[B].IntValue) xor
             LongInt(FRegisters[C].IntValue))
         else
-          SetRegister(A, EvaluateBitwiseXor(
+          SetRegister(A, VMRootedBinaryValue(@EvaluateBitwiseXor,
             GetRegister(B), GetRegister(C)));
 
       OP_SHL:
@@ -16013,7 +16072,7 @@ begin
             LongWord(FRegisters[B].IntValue) shl
             (LongWord(FRegisters[C].IntValue) and 31)))
         else
-          SetRegister(A, EvaluateLeftShift(
+          SetRegister(A, VMRootedBinaryValue(@EvaluateLeftShift,
             GetRegister(B), GetRegister(C)));
 
       OP_SHR:
@@ -16023,7 +16082,7 @@ begin
             LongInt(FRegisters[B].IntValue),
             LongWord(FRegisters[C].IntValue)))
         else
-          SetRegister(A, EvaluateRightShift(
+          SetRegister(A, VMRootedBinaryValue(@EvaluateRightShift,
             GetRegister(B), GetRegister(C)));
 
       OP_USHR:
@@ -16033,7 +16092,7 @@ begin
             FRegisters[B].IntValue) shr
             (LongWord(FRegisters[C].IntValue) and 31)))
         else
-          SetRegister(A, EvaluateUnsignedRightShift(
+          SetRegister(A, VMRootedBinaryValue(@EvaluateUnsignedRightShift,
             GetRegister(B), GetRegister(C)));
 
       OP_BNOT:
@@ -16076,7 +16135,8 @@ begin
             FRegisters[B].IntValue = FRegisters[C].IntValue)
         else
           SetRegister(A, TGocciaBooleanLiteralValue.FromBoolean(
-            Goccia.Arithmetic.IsLooselyEqual(GetRegister(B), GetRegister(C))));
+            VMRootedBinaryPredicate(@Goccia.Arithmetic.IsLooselyEqual,
+              GetRegister(B), GetRegister(C))));
 
       OP_LOOSE_NEQ:
         if (FRegisters[B].Kind = grkInt) and (FRegisters[C].Kind = grkInt) then
@@ -16084,7 +16144,8 @@ begin
             FRegisters[B].IntValue <> FRegisters[C].IntValue)
         else
           SetRegister(A, TGocciaBooleanLiteralValue.FromBoolean(
-            Goccia.Arithmetic.IsNotLooselyEqual(GetRegister(B), GetRegister(C))));
+            VMRootedBinaryPredicate(@Goccia.Arithmetic.IsNotLooselyEqual,
+              GetRegister(B), GetRegister(C))));
 
       OP_LT:
       begin
@@ -16113,8 +16174,8 @@ begin
                 TGocciaStringLiteralValue(LeftValue).Value,
                 TGocciaStringLiteralValue(RightValue).Value) < 0)
           else
-            FRegisters[A] := RegisterBoolean(
-              Goccia.Arithmetic.LessThan(LeftValue, RightValue));
+            FRegisters[A] := RegisterBoolean(VMRootedBinaryPredicate(
+              @Goccia.Arithmetic.LessThan, LeftValue, RightValue));
         end;
       end;
 
@@ -16145,8 +16206,8 @@ begin
                 TGocciaStringLiteralValue(LeftValue).Value,
                 TGocciaStringLiteralValue(RightValue).Value) > 0)
           else
-            FRegisters[A] := RegisterBoolean(
-              Goccia.Arithmetic.GreaterThan(LeftValue, RightValue));
+            FRegisters[A] := RegisterBoolean(VMRootedBinaryPredicate(
+              @Goccia.Arithmetic.GreaterThan, LeftValue, RightValue));
         end;
       end;
 
@@ -16177,8 +16238,8 @@ begin
                 TGocciaStringLiteralValue(LeftValue).Value,
                 TGocciaStringLiteralValue(RightValue).Value) <= 0)
           else
-            FRegisters[A] := RegisterBoolean(
-              Goccia.Arithmetic.LessThanOrEqual(LeftValue, RightValue));
+            FRegisters[A] := RegisterBoolean(VMRootedBinaryPredicate(
+              @Goccia.Arithmetic.LessThanOrEqual, LeftValue, RightValue));
         end;
       end;
 
@@ -16209,8 +16270,8 @@ begin
                 TGocciaStringLiteralValue(LeftValue).Value,
                 TGocciaStringLiteralValue(RightValue).Value) >= 0)
           else
-            FRegisters[A] := RegisterBoolean(
-              Goccia.Arithmetic.GreaterThanOrEqual(LeftValue, RightValue));
+            FRegisters[A] := RegisterBoolean(VMRootedBinaryPredicate(
+              @Goccia.Arithmetic.GreaterThanOrEqual, LeftValue, RightValue));
         end;
       end;
 

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -8674,6 +8674,7 @@ var
   TargetValue: TGocciaValue;
   BoxedTarget: TGocciaObjectValue;
   FastIndex: Integer;
+  Roots: TGocciaActiveRootFrame;
 begin
   // ES2026 §6.2.5.6 PutValue step 3.a precedes step 3.c, so a nullish target must
   // throw before ClassifyPropertyKey below — that call can run a user
@@ -8693,7 +8694,15 @@ begin
        .TryWriteIndexedScalar(FastIndex, RegisterToDouble(AValueReg)) then
     Exit;
 
+  // Value is materialized into a fresh, native-only number object for scalar
+  // registers; every branch below runs ClassifyPropertyKey, which coerces an
+  // object key through ToPrimitive and re-enters guest code. Root Value across
+  // the whole store so a collection forced from the key's coercion cannot sweep
+  // it out from under the property write.
   Value := RegisterToValue(AValueReg);
+  Roots.Initialize;
+  Roots.Add(Value);
+  try
   if (FRegisters[ATargetIndex].Kind = grkObject) and
      (FRegisters[ATargetIndex].ObjectValue is TGocciaArrayValue) then
   begin
@@ -8792,6 +8801,9 @@ begin
         SetBytecodeHomeObject(Value, TargetValue);
       SetPropertyValue(TargetValue, PropertyKeyName(Key), Value);
     end;
+  end;
+  finally
+    Roots.Clear;
   end;
 end;
 
@@ -12220,6 +12232,7 @@ var
   HomeObject: TGocciaObjectValue;
   SuperPrototype: TGocciaValue;
   KeyValue: TGocciaValue;
+  Roots: TGocciaActiveRootFrame;
   function ResolveCurrentCtorClass: TGocciaClassValue;
   begin
     Result := nil;
@@ -12254,6 +12267,13 @@ var
         AThisValue);
   end;
 begin
+  // AThisValue is the accessor receiver read after ToPropertyKey below, which
+  // coerces an object key through guest code. For a boxed primitive this it is a
+  // fresh, native-only object; root it across the coercion so a collection
+  // forced from the key's hook cannot sweep it before ReadSuperProperty uses it.
+  Roots.Initialize;
+  Roots.Add(AThisValue);
+  try
   HomeObject := nil;
   if Assigned(FCurrentClosure) then
     HomeObject := FCurrentClosure.HomeObject;
@@ -12346,6 +12366,9 @@ begin
 
   ThrowTypeError(SErrorCannotConvertNullOrUndefined,
     SSuggestCheckNullBeforeAccess);
+  finally
+    Roots.Clear;
+  end;
 end;
 
 function TGocciaVM.ResolveSuperPropertyBaseValue(const ASuperValue,
@@ -12378,19 +12401,29 @@ function TGocciaVM.GetSuperPropertyValueFromBase(const ABaseValue,
 var
   BaseObject: TGocciaObjectValue;
   KeyValue: TGocciaValue;
+  Roots: TGocciaActiveRootFrame;
 begin
   if not (ABaseValue is TGocciaObjectValue) then
     ThrowTypeError(SErrorCannotConvertNullOrUndefined,
       SSuggestCheckNullBeforeAccess);
 
   BaseObject := TGocciaObjectValue(ABaseValue);
-  KeyValue := ToPropertyKey(AKey);
-  if KeyValue is TGocciaSymbolValue then
-    Result := BaseObject.GetSymbolPropertyWithReceiver(
-      TGocciaSymbolValue(KeyValue), AThisValue)
-  else
-    Result := BaseObject.GetPropertyWithContext(KeyToPropertyName(KeyValue),
-      AThisValue);
+  // Root the accessor receiver across ToPropertyKey: a boxed primitive this is a
+  // fresh object that the key's coercion hook could otherwise collect before the
+  // resolved accessor reads it.
+  Roots.Initialize;
+  Roots.Add(AThisValue);
+  try
+    KeyValue := ToPropertyKey(AKey);
+    if KeyValue is TGocciaSymbolValue then
+      Result := BaseObject.GetSymbolPropertyWithReceiver(
+        TGocciaSymbolValue(KeyValue), AThisValue)
+    else
+      Result := BaseObject.GetPropertyWithContext(KeyToPropertyName(KeyValue),
+        AThisValue);
+  finally
+    Roots.Clear;
+  end;
 end;
 
 procedure TGocciaVM.SetSuperPropertyValueByKey(const ASuperValue, AThisValue,
@@ -12403,7 +12436,15 @@ var
   NonStrictSet: Boolean;
   PropertyName: string;
   Success: Boolean;
+  Roots: TGocciaActiveRootFrame;
 begin
+  // The assigned value is materialized fresh for scalar registers and is used
+  // after ToPropertyKey below, which coerces an object key through guest code.
+  // Root it so a collection forced from the key's hook cannot sweep it before
+  // the receiver-aware [[Set]] stores it.
+  Roots.Initialize;
+  Roots.Add(AValue);
+  try
   BaseValue := nil;
   HomeObject := nil;
   if Assigned(FCurrentClosure) then
@@ -12449,6 +12490,9 @@ begin
     ThrowTypeError(Format(SErrorCannotAssignReadOnly, [PropertyName]),
       SSuggestCannotDeleteNonConfigurable);
   end;
+  finally
+    Roots.Clear;
+  end;
 end;
 
 procedure TGocciaVM.SetSuperPropertyBaseValueByKey(const ABaseValue,
@@ -12459,11 +12503,17 @@ var
   NonStrictSet: Boolean;
   PropertyName: string;
   Success: Boolean;
+  Roots: TGocciaActiveRootFrame;
 begin
   if not (ABaseValue is TGocciaObjectValue) then
     ThrowTypeError(Format(SErrorCannotSetPropertiesOfNull, ['super']),
       SSuggestCheckNullBeforeAccess);
 
+  // Root the assigned value across ToPropertyKey's key coercion; see
+  // SetSuperPropertyValueByKey.
+  Roots.Initialize;
+  Roots.Add(AValue);
+  try
   KeyValue := ToPropertyKey(AKey);
   if KeyValue is TGocciaSymbolValue then
     PropertyName := TGocciaSymbolValue(KeyValue).ToDisplayString.Value
@@ -12487,6 +12537,9 @@ begin
       Exit;
     ThrowTypeError(Format(SErrorCannotAssignReadOnly, [PropertyName]),
       SSuggestCannotDeleteNonConfigurable);
+  end;
+  finally
+    Roots.Clear;
   end;
 end;
 
@@ -12616,6 +12669,7 @@ var
   PropertyName: string;
   StringUnit, StringValue: string;
   KeyIndex: Integer;
+  Roots: TGocciaActiveRootFrame;
 begin
   if (AReceiverReg.Kind = grkObject) and
      (AReceiverReg.ObjectValue is TGocciaStringLiteralValue) and
@@ -12635,7 +12689,15 @@ begin
     end;
   end;
 
+  // A primitive receiver is boxed into a fresh, native-only number object here;
+  // the object-key resolution below (TryResolveObjectKey / KeyToPropertyNameRegister)
+  // coerces the key through ToPrimitive and re-enters guest code. Root the
+  // receiver across the whole lookup so a collection forced from the key's hook
+  // cannot sweep it before the boxed [[Get]] uses it as the accessor receiver.
   ReceiverValue := RegisterToValue(AReceiverReg);
+  Roots.Initialize;
+  Roots.Add(ReceiverValue);
+  try
 
   if (AKeyReg.Kind = grkObject) and
      (AKeyReg.ObjectValue is TGocciaSymbolValue) then
@@ -12686,6 +12748,10 @@ begin
       PropertyValue := TGocciaUndefinedLiteralValue.UndefinedValue;
   end;
   SetRegister(ADest, PropertyValue);
+
+  finally
+    Roots.Clear;
+  end;
 end;
 
 // ES2026 §10.2.1.2 OrdinaryCallBindThis steps 5–6 for non-strict callees,
@@ -13165,18 +13231,28 @@ var
   BindingObject: TGocciaObjectValue;
   KeyStr: string;
   StillExists: Boolean;
+  Roots: TGocciaActiveRootFrame;
 begin
   BindingObject := ToObject(AObject);
-  KeyStr := KeyToPropertyName(AKey);
-  StillExists := BindingObject.HasProperty(KeyStr);
+  // A fresh, native-only value is held across HasProperty, which runs the proxy
+  // `has` trap and re-enters guest code. Root it so a collection forced from the
+  // trap cannot sweep it before the store completes.
+  Roots.Initialize;
+  Roots.Add(AValue);
+  try
+    KeyStr := KeyToPropertyName(AKey);
+    StillExists := BindingObject.HasProperty(KeyStr);
 
-  if AStrict and not StillExists then
-    ThrowReferenceError(KeyStr + ' is not defined');
+    if AStrict and not StillExists then
+      ThrowReferenceError(KeyStr + ' is not defined');
 
-  if AStrict then
-    SetPropertyValue(BindingObject, KeyStr, AValue)
-  else
-    SetPropertyValueLoose(BindingObject, KeyStr, AValue);
+    if AStrict then
+      SetPropertyValue(BindingObject, KeyStr, AValue)
+    else
+      SetPropertyValueLoose(BindingObject, KeyStr, AValue);
+  finally
+    Roots.Clear;
+  end;
 end;
 
 function TGocciaVM.MatchHasPropertyValue(const AObject, AKey: TGocciaValue): TGocciaValue;
@@ -13249,7 +13325,15 @@ var
   ExtractedArray: TGocciaArrayValue;
   CallArgs: TGocciaArgumentsCollection;
   ObjectConstructorValue, FunctionConstructorValue: TGocciaValue;
+  Roots: TGocciaActiveRootFrame;
 begin
+  // GetCustomMatcher reads AMatcher[Symbol.customMatcher], which can run a user
+  // getter/proxy trap. A boxed primitive subject is a fresh, native-only object;
+  // root it so a collection forced from that lookup cannot sweep it before it is
+  // handed to the matcher (or to VMInstanceOfValue) below.
+  Roots.Initialize;
+  Roots.Add(ASubject);
+  try
   CustomMatcher := GetCustomMatcher(AMatcher);
   if not Assigned(CustomMatcher) then
   begin
@@ -13291,6 +13375,9 @@ begin
   if not TryIterableToArray(Extracted, ExtractedArray) then
     ThrowTypeError('Extractor pattern result must be true, false, or iterable');
   Result := ExtractedArray;
+  finally
+    Roots.Clear;
+  end;
 end;
 
 function TGocciaVM.InvokeFunctionValue(const ACallee: TGocciaValue;
@@ -14207,6 +14294,10 @@ var
   InstructionLimitState: PGocciaInstructionLimitState;
   GC: TGarbageCollector;
   PreviousMemoryPressureCountdown: PInteger;
+  // Scratch active-root frame for opcode arms that materialize a fresh operand
+  // and then re-enter guest code (key coercion / custom-matcher lookup) before
+  // consuming it. Re-Initialized per use, so sharing one record is safe.
+  OperandRoots: TGocciaActiveRootFrame;
 
   procedure CurrentInstructionDebugLocation(out ALine, AColumn: Integer);
   begin
@@ -15632,18 +15723,29 @@ begin
         // step 3.e is strict-only.
         RequireCoercibleBaseRegister(FRegisters[A], FRegisters[B], True);
 
+        // Both the value and a boxed-primitive target are materialized fresh
+        // here, then held across SetIndexValueLoose's key coercion, which
+        // re-enters guest code. Root both so a collection forced from the key's
+        // hook cannot sweep them before the store.
         RightValue := RegisterToValue(FRegisters[C]);
         TargetValue := GetRegister(A);
-        if (TargetValue is TGocciaClassValue) or
-           (TargetValue is TGocciaObjectValue) then
-          SetBytecodeHomeObject(RightValue, TargetValue);
-        if not ((TargetValue is TGocciaArrayValue) and
-                (FRegisters[B].Kind = grkInt) and
-                (FRegisters[B].IntValue >= 0) and
-                (FRegisters[B].IntValue <= High(Integer)) and
-                TGocciaArrayValue(TargetValue).TryAppendDenseElementFast(
-                  FRegisters[B].IntValue, RightValue)) then
-          SetIndexValueLoose(TargetValue, FRegisters[B], RightValue);
+        OperandRoots.Initialize;
+        OperandRoots.Add(RightValue);
+        OperandRoots.Add(TargetValue);
+        try
+          if (TargetValue is TGocciaClassValue) or
+             (TargetValue is TGocciaObjectValue) then
+            SetBytecodeHomeObject(RightValue, TargetValue);
+          if not ((TargetValue is TGocciaArrayValue) and
+                  (FRegisters[B].Kind = grkInt) and
+                  (FRegisters[B].IntValue >= 0) and
+                  (FRegisters[B].IntValue <= High(Integer)) and
+                  TGocciaArrayValue(TargetValue).TryAppendDenseElementFast(
+                    FRegisters[B].IntValue, RightValue)) then
+            SetIndexValueLoose(TargetValue, FRegisters[B], RightValue);
+        finally
+          OperandRoots.Clear;
+        end;
       end;
 
       OP_ADD:
@@ -16311,44 +16413,54 @@ begin
 
       OP_MATCH_VALUE:
       begin
+        // The subject is materialized fresh for scalar registers and is used
+        // after GetCustomMatcher, which reads matcher[Symbol.customMatcher] and
+        // can run a user getter/proxy trap. Root the subject so a collection
+        // forced from that lookup cannot sweep it before the matcher sees it.
         LeftValue := GetRegister(B);
         RightValue := GetRegister(C);
-        CustomMatcherValue := GetCustomMatcher(RightValue);
-        if Assigned(CustomMatcherValue) then
-        begin
-          if not CustomMatcherValue.IsCallable then
-            ThrowTypeError('Symbol.customMatcher must be callable');
-          CallArgs := AcquireArguments(2);
-          try
-            MatchHintObject := TGocciaObjectValue.Create;
-            MatchHintObject.AssignProperty(PROP_MATCH_TYPE,
-              TGocciaStringLiteralValue.Create('boolean'));
-            CallArgs.Add(LeftValue);
-            CallArgs.Add(MatchHintObject);
-            MatchResultValue := InvokeFunctionValue(CustomMatcherValue,
-              CallArgs, RightValue);
-            SetRegister(A, MatchResultValue.ToBooleanLiteral);
-          finally
-            ReleaseArguments(CallArgs);
-          end;
-        end
-        else if RightValue is TGocciaClassValue then
-        begin
-          ObjectConstructorValue := VMGlobalObjectConstructor(FGlobalScope);
-          FunctionConstructorValue := VMGlobalFunctionConstructor(FGlobalScope);
-          if VMBuiltinConstructorMatchValue(RightValue, LeftValue,
+        OperandRoots.Initialize;
+        OperandRoots.Add(LeftValue);
+        try
+          CustomMatcherValue := GetCustomMatcher(RightValue);
+          if Assigned(CustomMatcherValue) then
+          begin
+            if not CustomMatcherValue.IsCallable then
+              ThrowTypeError('Symbol.customMatcher must be callable');
+            CallArgs := AcquireArguments(2);
+            try
+              MatchHintObject := TGocciaObjectValue.Create;
+              MatchHintObject.AssignProperty(PROP_MATCH_TYPE,
+                TGocciaStringLiteralValue.Create('boolean'));
+              CallArgs.Add(LeftValue);
+              CallArgs.Add(MatchHintObject);
+              MatchResultValue := InvokeFunctionValue(CustomMatcherValue,
+                CallArgs, RightValue);
+              SetRegister(A, MatchResultValue.ToBooleanLiteral);
+            finally
+              ReleaseArguments(CallArgs);
+            end;
+          end
+          else if RightValue is TGocciaClassValue then
+          begin
+            ObjectConstructorValue := VMGlobalObjectConstructor(FGlobalScope);
+            FunctionConstructorValue := VMGlobalFunctionConstructor(FGlobalScope);
+            if VMBuiltinConstructorMatchValue(RightValue, LeftValue,
+              FGlobalScope, BuiltinConstructorMatch) then
+              SetRegister(A, TGocciaBooleanLiteralValue.Create(BuiltinConstructorMatch))
+            else
+              SetRegister(A, VMInstanceOfValue(LeftValue, RightValue,
+                ObjectConstructorValue, FunctionConstructorValue));
+          end
+          else if VMBuiltinConstructorMatchValue(RightValue, LeftValue,
             FGlobalScope, BuiltinConstructorMatch) then
             SetRegister(A, TGocciaBooleanLiteralValue.Create(BuiltinConstructorMatch))
           else
-            SetRegister(A, VMInstanceOfValue(LeftValue, RightValue,
-              ObjectConstructorValue, FunctionConstructorValue));
-        end
-        else if VMBuiltinConstructorMatchValue(RightValue, LeftValue,
-          FGlobalScope, BuiltinConstructorMatch) then
-          SetRegister(A, TGocciaBooleanLiteralValue.Create(BuiltinConstructorMatch))
-        else
-          SetRegister(A, TGocciaBooleanLiteralValue.Create(
-            MatchValueEquals(LeftValue, RightValue)));
+            SetRegister(A, TGocciaBooleanLiteralValue.Create(
+              MatchValueEquals(LeftValue, RightValue)));
+        finally
+          OperandRoots.Clear;
+        end;
       end;
 
       OP_TO_NUMBER:

--- a/source/units/Goccia.Values.FunctionBase.pas
+++ b/source/units/Goccia.Values.FunctionBase.pas
@@ -562,36 +562,49 @@ var
   Args: TGocciaArgumentsCollection;
   Handler: TGocciaValue;
   HandlerResult: TGocciaValue;
+  Roots: TGocciaActiveRootFrame;
 begin
   if not (ATarget is TGocciaObjectValue) then
     ThrowTypeError('Right-hand side of instanceof is not an object',
       'use a constructor function or an object with Symbol.hasInstance');
 
-  Handler := TGocciaObjectValue(ATarget).GetSymbolProperty(
-    TGocciaSymbolValue.WellKnownHasInstance);
-  if Assigned(Handler) and
-     not (Handler is TGocciaUndefinedLiteralValue) and
-     not (Handler is TGocciaNullLiteralValue) then
-  begin
-    if not Handler.IsCallable then
-      ThrowTypeError('Symbol.hasInstance must be callable',
-        'set Symbol.hasInstance to a function or remove it');
+  // The instance can be a boxed primitive — a fresh, native-only object — and
+  // the Symbol.hasInstance lookup below can run a user getter or proxy trap. Root
+  // the instance across that lookup so a collection forced from it cannot sweep
+  // the instance before it is handed to the handler. (The ordinary path exits via
+  // a fresh number never being TGocciaObjectValue, but the lookup itself is the
+  // re-entry point, so the root must span it.)
+  Roots.Initialize;
+  Roots.Add(AInstance);
+  try
+    Handler := TGocciaObjectValue(ATarget).GetSymbolProperty(
+      TGocciaSymbolValue.WellKnownHasInstance);
+    if Assigned(Handler) and
+       not (Handler is TGocciaUndefinedLiteralValue) and
+       not (Handler is TGocciaNullLiteralValue) then
+    begin
+      if not Handler.IsCallable then
+        ThrowTypeError('Symbol.hasInstance must be callable',
+          'set Symbol.hasInstance to a function or remove it');
 
-    Args := TGocciaArgumentsCollection.CreateWithCapacity(1);
-    try
-      Args.Add(AInstance);
-      HandlerResult := DispatchCall(Handler, Args, ATarget);
-      Exit(HandlerResult.ToBooleanLiteral.Value);
-    finally
-      Args.Free;
+      Args := TGocciaArgumentsCollection.CreateWithCapacity(1);
+      try
+        Args.Add(AInstance);
+        HandlerResult := DispatchCall(Handler, Args, ATarget);
+        Exit(HandlerResult.ToBooleanLiteral.Value);
+      finally
+        Args.Free;
+      end;
     end;
+
+    if not IsCallableForHasInstance(ATarget) then
+      ThrowTypeError('Right-hand side of instanceof is not callable',
+        'use a constructor function or define Symbol.hasInstance');
+
+    Result := OrdinaryHasInstance(ATarget, AInstance);
+  finally
+    Roots.Clear;
   end;
-
-  if not IsCallableForHasInstance(ATarget) then
-    ThrowTypeError('Right-hand side of instanceof is not callable',
-      'use a constructor function or define Symbol.hasInstance');
-
-  Result := OrdinaryHasInstance(ATarget, AInstance);
 end;
 
 { TGocciaFunctionBase }

--- a/tests/language/execution-context-gc-roots.js
+++ b/tests/language/execution-context-gc-roots.js
@@ -93,6 +93,15 @@ describe("execution-context stack under collection", () => {
     expect(String({ toString() { collect(); return "s"; } })).toBe("s");
     const sym = { [Symbol.toPrimitive]() { collect(); return 3; } };
     expect(Number(sym)).toBe(3);
+
+    // The same hooks driven straight from the operators, whose operands are
+    // materialized into native temporaries the collector cannot see unless the
+    // opcode roots them. Exhaustive per-operator coverage lives in
+    // tests/language/expressions/operand-gc-roots/.
+    expect(box * 7).toBe(35);
+    expect(box - 2).toBe(3);
+    expect(box < 9).toBe(true);
+    expect(sym * 7).toBe(21);
   });
 
   test("error-path unwinding leaves no stale entries", () => {

--- a/tests/language/expressions/operand-gc-roots/computed-load-gc.js
+++ b/tests/language/expressions/operand-gc-roots/computed-load-gc.js
@@ -1,0 +1,52 @@
+/*---
+description: computed property loads on a primitive receiver keep the receiver alive across key coercion
+features: [Goccia]
+---*/
+
+// `(2.5)[keyObj]` boxes the primitive receiver into a fresh number object, then
+// resolves the object key through ToPrimitive — re-entering guest code. A
+// collection forced from the key's hook can sweep the still-unrooted receiver
+// before the boxed [[Get]] runs, so an accessor that reads `this` sees a freed
+// block rather than the original number.
+
+const collect = () => {
+  Goccia.gc();
+  Goccia.gc();
+};
+
+const churn = () => {
+  const junk = Array.from({ length: 256 }, (_, i) => ({ i, s: `${i}` }));
+  return junk.length;
+};
+
+const keyBox = (name) => ({
+  toString() {
+    churn();
+    collect();
+    return name;
+  },
+});
+
+// A getter on Number.prototype that reads its receiver, so a corrupted receiver
+// produces a wrong (or faulting) result rather than the exact expected value.
+Object.defineProperty(Number.prototype, "gcProbe", {
+  get() {
+    return this * 10;
+  },
+  configurable: true,
+});
+
+describe("computed load receiver under collection", () => {
+  test("primitive number receiver survives key coercion", () => {
+    expect((2.5)[keyBox("gcProbe")]).toBe(25);
+    expect((6.5)[keyBox("gcProbe")]).toBe(65);
+    expect((123456.75)[keyBox("gcProbe")]).toBe(1234567.5);
+  });
+
+  test("chained loads keep each receiver alive", () => {
+    const a = (2.5)[keyBox("gcProbe")];
+    const b = (4.5)[keyBox("gcProbe")];
+    expect(a).toBe(25);
+    expect(b).toBe(45);
+  });
+});

--- a/tests/language/expressions/operand-gc-roots/computed-store-gc.js
+++ b/tests/language/expressions/operand-gc-roots/computed-store-gc.js
@@ -1,0 +1,72 @@
+/*---
+description: strict computed property stores keep the stored value alive across key coercion
+features: [Goccia, Symbol]
+---*/
+
+// A strict computed store `o[keyObj] = 1.5` materializes the value operand into
+// a fresh, native-only number object, then runs ClassifyPropertyKey on the key.
+// When the key is an object, classification coerces it through ToPrimitive and
+// re-enters guest code (toString/valueOf). A collection forced from there can
+// sweep the still-unrooted value and hand the freed block back to the hook, so
+// the property ends up storing garbage rather than the intended number.
+//
+// Every case asserts an exact, distinctive value and collects twice inside the
+// key's coercion hook, with a churn allocation so the freed block is likely to
+// be reused before the store completes.
+
+const collect = () => {
+  Goccia.gc();
+  Goccia.gc();
+};
+
+const churn = () => {
+  const junk = Array.from({ length: 256 }, (_, i) => ({ i, s: `${i}` }));
+  return junk.length;
+};
+
+// A key object whose string coercion churns the heap and collects twice.
+const keyBox = (name) => ({
+  toString() {
+    churn();
+    collect();
+    return name;
+  },
+});
+
+describe("strict computed store operands under collection", () => {
+  test("plain object store keeps the value alive across key coercion", () => {
+    const o = {};
+    o[keyBox("a")] = 1.5;
+    expect(o.a).toBe(1.5);
+
+    const o2 = {};
+    o2[keyBox("b")] = 2.5;
+    o2[keyBox("c")] = 3.5;
+    expect(o2.b).toBe(2.5);
+    expect(o2.c).toBe(3.5);
+  });
+
+  test("large-int values survive too (non-singleton materialization)", () => {
+    const o = {};
+    o[keyBox("n")] = 123456.75;
+    expect(o.n).toBe(123456.75);
+  });
+
+  test("array target keeps a non-index value alive across key coercion", () => {
+    const arr = [];
+    arr[keyBox("tag")] = 9.5;
+    expect(arr.tag).toBe(9.5);
+  });
+
+  test("class static computed store keeps the value alive", () => {
+    class C {}
+    C[keyBox("s")] = 4.5;
+    expect(C.s).toBe(4.5);
+  });
+
+  test("compound computed store goes through the same opcode", () => {
+    const o = { k: 10 };
+    o[keyBox("k")] += 2.5;
+    expect(o.k).toBe(12.5);
+  });
+});

--- a/tests/language/expressions/operand-gc-roots/define-prop-gc.js
+++ b/tests/language/expressions/operand-gc-roots/define-prop-gc.js
@@ -1,0 +1,76 @@
+/*---
+description: computed data-property and field definitions define the value correctly under collection
+features: [Goccia]
+---*/
+
+// Regression guard for the property-definition paths. Unlike computed *stores*,
+// the define opcodes (OP_DEFINE_DATA_PROP / OP_DEFINE_METHOD_PROP and the
+// class-field DYNAMIC opcodes) receive an already-coerced key: the compiler
+// emits OP_TO_PROPERTY_KEY (object literals) or captures the coerced key as an
+// upvalue/local (class fields) *before* the value operand is materialized, so
+// the define op's own ClassifyPropertyKey never re-enters guest code and cannot
+// collect while the value is unrooted. Method values are register-rooted
+// functions. These cases therefore do not leak; this file collects hard from the
+// key hook to keep that invariant honest.
+
+const collect = () => {
+  Goccia.gc();
+  Goccia.gc();
+};
+
+const churn = () => {
+  const junk = Array.from({ length: 256 }, (_, i) => ({ i, s: `${i}` }));
+  return junk.length;
+};
+
+const keyBox = (name) => ({
+  toString() {
+    churn();
+    collect();
+    return name;
+  },
+});
+
+describe("computed definition operands under collection", () => {
+  test("object literal computed data property keeps its value", () => {
+    const obj = { [keyBox("k")]: 2.5 };
+    expect(obj.k).toBe(2.5);
+
+    const multi = { [keyBox("a")]: 3.5, [keyBox("b")]: 4.5 };
+    expect(multi.a).toBe(3.5);
+    expect(multi.b).toBe(4.5);
+  });
+
+  test("class instance field with a computed key keeps its value", () => {
+    class C {
+      [keyBox("f")] = 5.5;
+    }
+    const c = new C();
+    expect(c.f).toBe(5.5);
+  });
+
+  test("class static field with a computed key keeps its value", () => {
+    class C {
+      static [keyBox("s")] = 6.5;
+    }
+    expect(C.s).toBe(6.5);
+  });
+
+  test("mixed static and instance computed fields keep their values", () => {
+    class C {
+      static [keyBox("s")] = 7.5;
+      [keyBox("f")] = 8.5;
+    }
+    expect(C.s).toBe(7.5);
+    expect(new C().f).toBe(8.5);
+  });
+
+  test("class method with a computed key still resolves correctly", () => {
+    class C {
+      [keyBox("m")]() {
+        return 42;
+      }
+    }
+    expect(new C().m()).toBe(42);
+  });
+});

--- a/tests/language/expressions/operand-gc-roots/goccia.json
+++ b/tests/language/expressions/operand-gc-roots/goccia.json
@@ -1,0 +1,3 @@
+{
+  "compat-loose-equality": true
+}

--- a/tests/language/expressions/operand-gc-roots/instanceof-gc.js
+++ b/tests/language/expressions/operand-gc-roots/instanceof-gc.js
@@ -1,0 +1,54 @@
+/*---
+description: instanceof keeps the instance alive across a Symbol.hasInstance getter
+features: [Goccia, Symbol.hasInstance]
+---*/
+
+// `value instanceof RHS` boxes a primitive left operand into a fresh number
+// object, then looks up RHS[Symbol.hasInstance]. When that lookup runs a user
+// getter (or proxy trap), a collection forced from it can sweep the still-
+// unrooted instance before it is handed to the handler, so the handler sees a
+// freed block instead of the original value.
+
+const collect = () => {
+  Goccia.gc();
+  Goccia.gc();
+};
+
+const churn = () => {
+  const junk = Array.from({ length: 256 }, (_, i) => ({ i, s: `${i}` }));
+  return junk.length;
+};
+
+describe("instanceof instance under collection", () => {
+  test("primitive instance survives a collecting hasInstance getter", () => {
+    const RHS = {};
+    Object.defineProperty(RHS, Symbol.hasInstance, {
+      get() {
+        churn();
+        collect();
+        return (v) => v === 42.5;
+      },
+      configurable: true,
+    });
+
+    expect(42.5 instanceof RHS).toBe(true);
+    expect(41.5 instanceof RHS).toBe(false);
+    expect(123456.75 instanceof RHS).toBe(false);
+  });
+
+  test("proxy hasInstance trap keeps the instance alive", () => {
+    const RHS = new Proxy(
+      { [Symbol.hasInstance]: (v) => v === 7.5 },
+      {
+        get(target, key, receiver) {
+          churn();
+          collect();
+          return Reflect.get(target, key, receiver);
+        },
+      },
+    );
+
+    expect(7.5 instanceof RHS).toBe(true);
+    expect(8.5 instanceof RHS).toBe(false);
+  });
+});

--- a/tests/language/expressions/operand-gc-roots/match-gc.js
+++ b/tests/language/expressions/operand-gc-roots/match-gc.js
@@ -1,0 +1,59 @@
+/*---
+description: pattern-match subjects survive a collecting Symbol.customMatcher getter
+features: [Goccia, pattern-matching, Symbol.customMatcher]
+---*/
+
+// A value or extractor pattern boxes a primitive subject into a fresh number
+// object, then reads matcher[Symbol.customMatcher]. When that read runs a user
+// getter (or proxy trap), a collection forced from it can sweep the still-
+// unrooted subject before it is passed to the matcher, so the matcher sees a
+// freed block instead of the original value.
+
+const collect = () => {
+  Goccia.gc();
+  Goccia.gc();
+};
+
+const churn = () => {
+  const junk = Array.from({ length: 256 }, (_, i) => ({ i, s: `${i}` }));
+  return junk.length;
+};
+
+describe("pattern-match subject under collection", () => {
+  test("value pattern subject survives a collecting matcher getter", () => {
+    const Matcher = {};
+    Object.defineProperty(Matcher, Symbol.customMatcher, {
+      get() {
+        churn();
+        collect();
+        return (subject) => subject === 2.5;
+      },
+      configurable: true,
+    });
+
+    expect(2.5 is Matcher).toBe(true);
+    expect(3.5 is Matcher).toBe(false);
+    expect(123456.75 is Matcher).toBe(false);
+  });
+
+  test("extractor pattern subject survives a collecting matcher getter", () => {
+    const Ext = {};
+    Object.defineProperty(Ext, Symbol.customMatcher, {
+      get() {
+        churn();
+        collect();
+        return (subject) => [subject, subject * 2];
+      },
+      configurable: true,
+    });
+
+    let first = 0;
+    let second = 0;
+    if (2.5 is Ext(const a, const b)) {
+      first = a;
+      second = b;
+    }
+    expect(first).toBe(2.5);
+    expect(second).toBe(5);
+  });
+});

--- a/tests/language/expressions/operand-gc-roots/non-strict/goccia.json
+++ b/tests/language/expressions/operand-gc-roots/non-strict/goccia.json
@@ -1,0 +1,4 @@
+{
+  "compat-non-strict-mode": true,
+  "compat-var": true
+}

--- a/tests/language/expressions/operand-gc-roots/non-strict/set-index-loose-gc.js
+++ b/tests/language/expressions/operand-gc-roots/non-strict/set-index-loose-gc.js
@@ -1,0 +1,58 @@
+/*---
+description: non-strict computed stores keep the value alive across key coercion
+features: [Goccia]
+---*/
+
+// In non-strict code `o[keyObj] = 1.5` compiles to the loose set-index opcode,
+// which materializes the value operand and then coerces the object key through
+// SetIndexValueLoose. That coercion re-enters guest code; a collection forced
+// from the key's hook can sweep the still-unrooted value before the store, so
+// the property ends up holding garbage.
+
+const collect = () => {
+  Goccia.gc();
+  Goccia.gc();
+};
+
+const churn = () => {
+  const junk = Array.from({ length: 256 }, (_, i) => ({ i, s: `${i}` }));
+  return junk.length;
+};
+
+const keyBox = (name) => ({
+  toString() {
+    churn();
+    collect();
+    return name;
+  },
+});
+
+describe("non-strict computed store operands under collection", () => {
+  test("object target keeps the value alive across key coercion", () => {
+    const o = {};
+    o[keyBox("a")] = 1.5;
+    expect(o.a).toBe(1.5);
+
+    const o2 = {};
+    o2[keyBox("b")] = 2.5;
+    o2[keyBox("c")] = 3.5;
+    expect(o2.b).toBe(2.5);
+    expect(o2.c).toBe(3.5);
+  });
+
+  test("large-int value survives too", () => {
+    const o = {};
+    o[keyBox("n")] = 123456.75;
+    expect(o.n).toBe(123456.75);
+  });
+
+  test("primitive target does not crash while the key coerces", () => {
+    // Assigning to a property of a primitive is a silent no-op in non-strict
+    // code, but the boxed target and value must still survive the key coercion
+    // rather than faulting mid-store.
+    const x = 2.5;
+    expect(() => {
+      x[keyBox("ignored")] = 9.5;
+    }).not.toThrow();
+  });
+});

--- a/tests/language/expressions/operand-gc-roots/non-strict/with-binding-gc.js
+++ b/tests/language/expressions/operand-gc-roots/non-strict/with-binding-gc.js
@@ -1,0 +1,55 @@
+/*---
+description: with-statement binding assignments keep the value alive across the has trap
+features: [Goccia, Proxy]
+---*/
+
+// Assigning to a name resolved through a `with` object materializes the value
+// operand and then probes the binding object with HasProperty. For a Proxy that
+// runs a `has` trap, a collection forced from the trap can sweep the still-
+// unrooted value before the store, so the property ends up holding garbage.
+
+const collect = () => {
+  Goccia.gc();
+  Goccia.gc();
+};
+
+const churn = () => {
+  const junk = Array.from({ length: 256 }, (_, i) => ({ i, s: `${i}` }));
+  return junk.length;
+};
+
+describe("with-binding value under collection", () => {
+  test("value survives a collecting proxy has trap", () => {
+    const target = { x: 0 };
+    const bindings = new Proxy(target, {
+      has(t, k) {
+        churn();
+        collect();
+        return k in t;
+      },
+    });
+
+    with (bindings) {
+      x = 1.5;
+    }
+    expect(target.x).toBe(1.5);
+  });
+
+  test("successive assignments keep distinct values", () => {
+    const target = { a: 0, b: 0 };
+    const bindings = new Proxy(target, {
+      has(t, k) {
+        churn();
+        collect();
+        return k in t;
+      },
+    });
+
+    with (bindings) {
+      a = 12345.75;
+      b = 67890.25;
+    }
+    expect(target.a).toBe(12345.75);
+    expect(target.b).toBe(67890.25);
+  });
+});

--- a/tests/language/expressions/operand-gc-roots/operand-gc-roots.js
+++ b/tests/language/expressions/operand-gc-roots/operand-gc-roots.js
@@ -1,0 +1,244 @@
+/*---
+description: binary operator operands survive collections forced from their own coercion hooks
+features: [Goccia.gc, compat-loose-equality, Symbol.toPrimitive, Proxy]
+---*/
+
+// A binary operator materializes both operands before handing them to the
+// shared Goccia.Arithmetic helpers, and the helpers then coerce each operand in
+// turn through ToPrimitive — which re-enters guest code whenever an operand is
+// an object with valueOf / toString / Symbol.toPrimitive.
+//
+// Materializing is an allocation in the bytecode VM: a register holding an
+// integer other than 0/1, or any float, becomes a fresh number object that
+// lives only in a native temporary. Nothing else refers to it, so a collection
+// driven from the *other* operand's hook could sweep it and hand the freed
+// block straight back to the hook's own allocation. The operator then read the
+// wrong operand and returned a wrong number rather than failing — `box * 2`
+// answered 25 instead of 10, and `box * 3` and `box * 7` both answered 25 too,
+// because both were really computing `5 * 5`.
+//
+// Every case below therefore asserts an exact value with a distinctive result,
+// and collects twice inside the hook so a surviving operand has to be genuinely
+// rooted rather than merely not-yet-swept. The operand pairs deliberately avoid
+// 0 and 1, whose number objects are pinned singletons that never allocate.
+
+const collect = () => {
+  Goccia.gc();
+  Goccia.gc();
+};
+
+// valueOf hook: collects, then returns a value that itself needs an allocation.
+const box = (n) => ({
+  valueOf() {
+    collect();
+    return n;
+  },
+});
+
+// valueOf hook that allocates a pile of garbage first, so the collection has
+// something to reclaim and the freed block is very likely to be reused.
+const churningBox = (n) => ({
+  valueOf() {
+    const junk = Array.from({ length: 256 }, (_, i) => ({ i, s: `${i}` }));
+    collect();
+    return n + junk.length - 256;
+  },
+});
+
+const stringBox = (s) => ({
+  toString() {
+    collect();
+    return s;
+  },
+});
+
+const primitiveBox = (n) => ({
+  [Symbol.toPrimitive]() {
+    collect();
+    return n;
+  },
+});
+
+describe("operator operands under collection", () => {
+  test("multiplication keeps the other operand alive", () => {
+    // The clincher: if the surviving operand were the hook's own value these
+    // would all answer 25.
+    expect(box(5) * 2).toBe(10);
+    expect(box(5) * 3).toBe(15);
+    expect(box(5) * 7).toBe(35);
+    expect(2 * box(5)).toBe(10);
+    expect(7 * box(5)).toBe(35);
+    // 0 and 1 are the pinned singletons; they must keep working too.
+    expect(box(5) * 0).toBe(0);
+    expect(box(5) * 1).toBe(5);
+  });
+
+  test("addition keeps the other operand alive", () => {
+    expect(box(5) + 2).toBe(7);
+    expect(2 + box(5)).toBe(7);
+    expect(box(5) + 7).toBe(12);
+  });
+
+  test("subtraction keeps the other operand alive", () => {
+    expect(box(5) - 2).toBe(3);
+    expect(2 - box(5)).toBe(-3);
+    expect(box(9) - 4).toBe(5);
+  });
+
+  test("division keeps the other operand alive", () => {
+    expect(box(5) / 2).toBe(2.5);
+    expect(20 / box(8)).toBe(2.5);
+  });
+
+  test("remainder keeps the other operand alive", () => {
+    expect(box(5) % 3).toBe(2);
+    expect(23 % box(5)).toBe(3);
+  });
+
+  test("exponentiation keeps the other operand alive", () => {
+    expect(box(5) ** 2).toBe(25);
+    expect(2 ** box(5)).toBe(32);
+  });
+
+  test("float operands survive too", () => {
+    expect(box(5) * 2.5).toBe(12.5);
+    expect(box(2.5) * 4).toBe(10);
+    expect(box(2.5) - 0.5).toBe(2);
+  });
+
+  test("relational comparisons keep the other operand alive", () => {
+    expect(box(5) < 9).toBe(true);
+    expect(box(5) > 9).toBe(false);
+    expect(box(5) <= 4).toBe(false);
+    expect(box(5) >= 4).toBe(true);
+    expect(9 > box(5)).toBe(true);
+    expect(4 >= box(5)).toBe(false);
+  });
+
+  test("loose equality keeps the other operand alive", () => {
+    expect(box(5) == 5).toBe(true);
+    expect(box(5) == 7).toBe(false);
+    expect(7 == box(5)).toBe(false);
+    expect(box(5) != 7).toBe(true);
+    expect(box(5) == "5").toBe(true);
+  });
+
+  test("bitwise and shift operators keep the other operand alive", () => {
+    expect(box(5) & 12).toBe(4);
+    expect(box(5) | 8).toBe(13);
+    expect(box(5) ^ 12).toBe(9);
+    expect(box(5) << 3).toBe(40);
+    expect(box(40) >> 2).toBe(10);
+    expect(box(40) >>> 2).toBe(10);
+    expect(12 & box(5)).toBe(4);
+    expect(3 << box(4)).toBe(48);
+  });
+
+  test("both operands coercing keeps the left result alive", () => {
+    // The left operand's coerced value is itself a fresh allocation, and the
+    // right operand's hook collects after it exists: 9 * 4 answered 16 when it
+    // was unrooted, because the left had been replaced by the right.
+    expect(box(9) * box(4)).toBe(36);
+    expect(box(9) - box(4)).toBe(5);
+    expect(box(9) + box(4)).toBe(13);
+    expect(box(9) / box(4)).toBe(2.25);
+    expect(box(9) < box(4)).toBe(false);
+    expect(box(4) < box(9)).toBe(true);
+    expect(box(9) == box(9)).toBe(false); // distinct objects, ES2026 §7.2.13
+  });
+
+  test("hooks that allocate before collecting", () => {
+    expect(churningBox(5) * 3).toBe(15);
+    expect(churningBox(9) - churningBox(4)).toBe(5);
+    expect(3 * churningBox(7)).toBe(21);
+    expect(churningBox(5) < 9).toBe(true);
+  });
+
+  test("toString-only hooks", () => {
+    expect(stringBox("8") * 4).toBe(32);
+    expect(4 * stringBox("8")).toBe(32);
+    expect(stringBox("8") - 3).toBe(5);
+    expect("a" + stringBox("8") + "b").toBe("a8b");
+    expect(stringBox("8") + 3).toBe("83");
+  });
+
+  test("Symbol.toPrimitive hooks", () => {
+    expect(primitiveBox(6) * 4).toBe(24);
+    expect(4 * primitiveBox(6)).toBe(24);
+    expect(primitiveBox(6) < 100).toBe(true);
+    expect(primitiveBox(6) - primitiveBox(2)).toBe(4);
+  });
+
+  test("compound assignment goes through the same opcodes", () => {
+    let x = 3;
+    x *= box(7);
+    expect(x).toBe(21);
+
+    let y = 20;
+    y -= box(6);
+    expect(y).toBe(14);
+
+    let z = 5;
+    z **= box(3);
+    expect(z).toBe(125);
+
+    let w = 12;
+    w &= box(5);
+    expect(w).toBe(4);
+  });
+
+  test("nested operators inside a coercion hook", () => {
+    // The inner operator roots its own operands while the outer operator's are
+    // still live; a non-LIFO rooting scheme would drop the outer pair here.
+    const nesting = {
+      valueOf() {
+        expect(box(9) * 3).toBe(27);
+        collect();
+        return 5;
+      },
+    };
+    expect(nesting * 7).toBe(35);
+    expect(nesting - 2).toBe(3);
+  });
+
+  test("throwing out of a coercion hook leaves the operand rooted", () => {
+    const thrower = {
+      valueOf() {
+        collect();
+        throw new Error("from valueOf");
+      },
+    };
+    let caught = null;
+    try {
+      // eslint-disable-next-line no-unused-expressions
+      thrower * 7;
+    } catch (e) {
+      caught = e;
+    }
+    collect();
+    expect(caught.message).toBe("from valueOf");
+    // The rooting must have unwound; a leaked root would keep growing here.
+    expect(box(5) * 7).toBe(35);
+  });
+
+  test("a Proxy get trap that collects still yields the right operand", () => {
+    const proxied = new Proxy(
+      {
+        valueOf() {
+          collect();
+          return 5;
+        },
+      },
+      {
+        get(target, key, receiver) {
+          collect();
+          return Reflect.get(target, key, receiver);
+        },
+      },
+    );
+    expect(proxied * 7).toBe(35);
+    expect(proxied < 9).toBe(true);
+  });
+});
+
+collect();

--- a/tests/language/expressions/operand-gc-roots/super-gc.js
+++ b/tests/language/expressions/operand-gc-roots/super-gc.js
@@ -1,0 +1,89 @@
+/*---
+description: computed super get/set keep this and value alive across key coercion
+features: [Goccia]
+---*/
+
+// A computed super reference `super[keyObj]` resolves the super base, then
+// coerces the object key through ToPropertyKey — re-entering guest code. For a
+// super GET the receiver (`this`) is used after that coercion to run the
+// resolved accessor; for a super SET the assigned value is used after it. When
+// `this` is a boxed primitive or the value is a fresh number, a collection
+// forced from the key's hook can sweep the still-unrooted operand and corrupt
+// the accessor receiver or the stored value.
+
+const collect = () => {
+  Goccia.gc();
+  Goccia.gc();
+};
+
+const churn = () => {
+  const junk = Array.from({ length: 256 }, (_, i) => ({ i, s: `${i}` }));
+  return junk.length;
+};
+
+const keyBox = (name) => ({
+  toString() {
+    churn();
+    collect();
+    return name;
+  },
+});
+
+describe("computed super operands under collection", () => {
+  test("super get keeps a primitive this alive across key coercion", () => {
+    class Base {
+      get gcProbe() {
+        return this * 10;
+      }
+    }
+    class Derived extends Base {
+      read(key) {
+        return super[key];
+      }
+    }
+    // `this` is the primitive 2.5, which the getter reads; a swept receiver
+    // would answer something other than 25.
+    expect(Derived.prototype.read.call(2.5, keyBox("gcProbe"))).toBe(25);
+    expect(Derived.prototype.read.call(6.5, keyBox("gcProbe"))).toBe(65);
+  });
+
+  test("super get with an object this reads the inherited value", () => {
+    class Base {
+      get gcValue() {
+        return 33.5;
+      }
+    }
+    class Derived extends Base {
+      read(key) {
+        return super[key];
+      }
+    }
+    expect(new Derived().read(keyBox("gcValue"))).toBe(33.5);
+  });
+
+  test("super set keeps the assigned value alive across key coercion", () => {
+    class Base {}
+    class Derived extends Base {
+      write(key) {
+        super[key] = 1.5;
+      }
+    }
+    const d = new Derived();
+    d.write(keyBox("x"));
+    expect(d.x).toBe(1.5);
+  });
+
+  test("super set stores distinct values across successive keys", () => {
+    class Base {}
+    class Derived extends Base {
+      writeTwo(k1, k2) {
+        super[k1] = 12345.75;
+        super[k2] = 67890.25;
+      }
+    }
+    const d = new Derived();
+    d.writeTwo(keyBox("a"), keyBox("b"));
+    expect(d.a).toBe(12345.75);
+    expect(d.b).toBe(67890.25);
+  });
+});


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Closes a garbage-collection use-after-free class in the bytecode VM: a freshly materialized operand held in a Pascal local across a coercion that re-enters guest code (`ToPrimitive`, key coercion, a `Symbol` lookup, a proxy trap) could be swept mid-operation. Binary-operator operands are rooted across coercion re-entry, plus the seven further sites a completeness sweep confirmed leak — computed store/load, loose set-index, super get/set, `instanceof`, match subject, and `with`-binding.
- Two candidate sites were verified **not** to leak (the compiler pre-coerces those keys) and deliberately left unrooted rather than adding needless frames.

## Testing

- [x] Full suite both modes; per-family GC-forcing regression tests that fault before the fix and pass after
- [x] Mutation-checked: reverting the root (keeping the try/finally) re-faults, proving the root itself is load-bearing
- [x] Differential zero divergence under bun 1.4.0 and CI-pinned 1.3.14; `./format.pas --check` and doc checks clean
