### PR TITLE
fix(diagnostics): render identical runtime-error diagnostics in both modes with sandbox-safe code frames

### DIFF
--- a/docs/bytecode-vm.md
+++ b/docs/bytecode-vm.md
@@ -166,6 +166,35 @@ The `--profile` option on GocciaScriptLoader enables language-level profiling of
 
 The profiler follows the same singleton-tracker pattern as coverage (`Goccia.Coverage.pas`). When profiling is disabled, a predictable boolean guard remains in the dispatch loop. Enabled-mode overhead depends on the workload and profiling mode, so measure it on the corpus being investigated rather than relying on a fixed percentage.
 
+## Runtime Error Diagnostics
+
+A runtime fault must read identically in both execution modes. Two pieces of
+machinery keep that true, both of them cold-path only:
+
+- **Call-site descriptors.** `TGocciaFunctionTemplate` carries a runtime-only
+  table mapping a call/construct instruction's start PC to the callee as the
+  author wrote it (`Goccia.Error.CallDiagnostics.TGocciaCalleeDescriptor`) plus
+  the call expression's own line and column. The compiler fills it while
+  emitting `OP_CALL`, `OP_CALL_METHOD`, `OP_CONSTRUCT` and
+  `OP_CONSTRUCT_SPREAD`; the VM reads it only when the callee turns out not to
+  be callable or constructable, so `obj.missingMethod()` reports
+  `obj.missingMethod is not a function` rather than `undefined is not a
+  function`. The evaluator derives the same descriptor straight from the AST,
+  and both modes format the message and suggestion through the same functions.
+  The table is **not** serialised to `.gbc`: a module loaded from binary
+  bytecode falls back to the runtime-type-name form of the message.
+- **Throw-path source positions.** Deferred call frames carry no position
+  ([ADR 0074](adr/0074-deferred-bytecode-call-stack-frames.md)), which left
+  every bytecode-mode stack frame at `file:0:0` and the runner with no line to
+  render a code frame for. `TGocciaCallStack.SetTopFrameLocation` stamps the
+  executing frame with a position, and the VM calls it only where a fault is
+  being raised or a native constructor is about to run (`new Error(...)`
+  captures a trace). Those sites already pay a debug-map lookup, so the hot
+  dispatch path is unchanged. `TGocciaVM.StampThrowLocation` recovers the
+  current instruction for throw paths outside the dispatch loop through a
+  pointer probe into the innermost loop's `Template`/`InstructionStartIP`
+  locals, saved and restored once per native re-entry.
+
 ## Instruction Limit
 
 The dispatch loop supports an optional instruction counter (`Goccia.InstructionLimit.pas`). When armed, the counter increments on every dispatched instruction and the limit is checked at the top of each iteration. When disabled, only the guard read of the limit threadvar remains on the hot path. See [Embedding — Execution Limits](embedding.md#execution-limits) for the full API and interpreter-mode behavior.

--- a/docs/bytecode-vm.md
+++ b/docs/bytecode-vm.md
@@ -168,32 +168,111 @@ The profiler follows the same singleton-tracker pattern as coverage (`Goccia.Cov
 
 ## Runtime Error Diagnostics
 
-A runtime fault must read identically in both execution modes. Two pieces of
-machinery keep that true, both of them cold-path only:
+A runtime fault must read identically in both execution modes. Three pieces of
+machinery keep that true:
 
 - **Call-site descriptors.** `TGocciaFunctionTemplate` carries a runtime-only
   table mapping a call/construct instruction's start PC to the callee as the
-  author wrote it (`Goccia.Error.CallDiagnostics.TGocciaCalleeDescriptor`) plus
-  the call expression's own line and column. The compiler fills it while
-  emitting `OP_CALL`, `OP_CALL_METHOD`, `OP_CONSTRUCT` and
-  `OP_CONSTRUCT_SPREAD`; the VM reads it only when the callee turns out not to
-  be callable or constructable, so `obj.missingMethod()` reports
-  `obj.missingMethod is not a function` rather than `undefined is not a
-  function`. The evaluator derives the same descriptor straight from the AST,
-  and both modes format the message and suggestion through the same functions.
-  The table is **not** serialised to `.gbc`: a module loaded from binary
-  bytecode falls back to the runtime-type-name form of the message.
+  author wrote it (a `TGocciaCalleeDescriptor` from `Goccia.Error.CallDiagnostics`)
+  plus the call expression's own line and column. The compiler fills it while
+  emitting `OP_CALL`, `OP_CALL_METHOD`, `OP_CONSTRUCT`, `OP_CONSTRUCT_SPREAD`
+  and tagged-template calls — a **compile-time cost paid once per call site** (a
+  descriptor copy plus a whitespace-normalising pass over the callee's source
+  text), not a per-instruction runtime cost. The VM reads the table only when
+  the callee turns out not to be callable or constructable, so
+  `obj.missingMethod()` reports `obj.missingMethod is not a function` rather
+  than `undefined is not a function`. The evaluator derives the same descriptor
+  straight from the AST, and both modes format the message and suggestion
+  through the same functions. The table is **not** serialised to `.gbc`: a
+  module loaded from binary bytecode falls back to the runtime-type-name form of
+  the message (see the note below).
 - **Throw-path source positions.** Deferred call frames carry no position
   ([ADR 0074](adr/0074-deferred-bytecode-call-stack-frames.md)), which left
   every bytecode-mode stack frame at `file:0:0` and the runner with no line to
   render a code frame for. `TGocciaCallStack.SetTopFrameLocation` stamps the
-  executing frame with a position, and the VM calls it only where a fault is
-  being raised or a native constructor is about to run (`new Error(...)`
-  captures a trace). Those sites already pay a debug-map lookup, so the hot
-  dispatch path is unchanged. `TGocciaVM.StampThrowLocation` recovers the
-  current instruction for throw paths outside the dispatch loop through a
-  pointer probe into the innermost loop's `Template`/`InstructionStartIP`
-  locals, saved and restored once per native re-entry.
+  executing frame with a position. The dispatch loop's ordinary
+  call/property/index instructions never call it, so their throughput is
+  unchanged; it runs on the failure paths (a fault about to be raised) and, in
+  addition, once per `new` reaching `ConstructValue` — a native constructor such
+  as `new Error(...)` captures its trace *during* construction, before any
+  throw, so its caller frame must be stamped up front (a small per-`new` cost: a
+  binary search over the function's call-site table plus two string
+  assignments). `TGocciaVM.StampThrowLocation` recovers the current instruction
+  for throw paths outside the dispatch loop through a pointer probe into the
+  innermost loop's `Template`/`InstructionStartIP` locals, saved and restored
+  once per native re-entry.
+- **Frame source is provenance-bound, not `stack`-selected.** A code frame is
+  rendered only from provenance the engine records on a genuine error *when it
+  is created* — the top call frame's source location, plus a ±context excerpt of
+  that module captured from the engine's own per-scope source store. Both are
+  carried on the error object (`TGocciaErrorObjectValue`, an error-only subclass
+  so the fields never enlarge the base object's GC-charged size). The thrown
+  value's `stack` string is guest-writable and is never parsed to choose a file,
+  a line, or an excerpt: a forged `throw { stack: "…at f (/etc/passwd:2:1)" }`
+  object is not engine-created, carries no provenance, and renders no code frame
+  at all — so no host ever opens a guest-named path and the sandbox's
+  `sandbox.fs.path` gate cannot be bypassed through diagnostics. See
+  `Goccia.Values.ErrorHelper.AttachErrorSourceProvenance`,
+  `Goccia.Diagnostics.SourceRegistry`, and docs/module-resolution.md
+  "Runtime code frames".
+- **Principal exclusion — no host source to a guest.** Ownership is decided at
+  load, not inferred at capture. Host enrollment (`--globals`,
+  `--host-environment`, `--module`, `--modules`, manifests/configs, and embedding
+  injection) stamps the root module host-owned. Static, dynamic, and deferred
+  imports inherit that ownership transitively from the importing module, even
+  when the load begins later from a host-exported function called by the guest.
+  A host-injected virtual module is host-owned; imports reached only from a guest
+  module are guest-owned. Entries use file identity from the handle that read
+  the content: POSIX device+inode or Windows volume-serial+file-index. Symlinks,
+  junctions, hardlinks, and case aliases therefore cannot mint a guest-owned
+  second copy. If identity lookup fails, there is no lexical-path fallback and
+  source disclosure for the scope fails closed. An excerpt is captured only
+  from guest-owned source, so a genuine error thrown inside a host module —
+  including a transitive import, a `--module` the guest imported, or a held
+  `Error` the host created — shows its location but no source excerpt.
+- **Executing-engine scope, enforced again at render.** Each engine's module
+  loader owns one scope, identified by a durable process-monotonic principal;
+  registration targets the loader's own scope, and capture targets the scope the
+  engine activates around its execution (`RunModuleForSourceType` for bytecode,
+  `Execute`/`ExecuteProgram` for the interpreter) — and around every cross-engine
+  transition (`ActivateRealmExecutionContext` for a ShadowRealm `evaluate`/
+  `importValue`/wrapped function activates the child scope and restores it on
+  return). The excerpt is additionally stamped with its principal and re-checked
+  when rendered: each host explicitly passes its expected principal to
+  `Goccia.Error.Detail`, which renders source only when the two values match.
+  Zero/no supplied principal means location-only; no active execution scope is
+  never treated as authorization. A child's error formatted by a resumed parent
+  is therefore refused the child's source even though the object crossed the
+  boundary. Because the excerpt is captured while its scope is live, a host may
+  still render it after `Engine.Free` only if it retained and supplies the
+  originating engine's principal.
+- **Byte-accurate diagnostic memory.** Retained module source is accounted as
+  its actual UTF-16 line representation, including entry/list storage, pointer
+  slots, and separately allocated line strings. A captured excerpt is charged
+  as its retained UTF-16 string allocation. The identical byte figure is used
+  for caps, `--max-memory` reservation, and release. Reservation refusal yields
+  location-only, and transactional registry insertion rolls back partial map
+  keys and the reservation if allocation fails during commit.
+- **Construct/native-call frame stamping.** A successful `OP_CONSTRUCT` /
+  `OP_CONSTRUCT_SPREAD` snapshots and restores the caller frame around
+  `ConstructValue`, so a constructor's position does not leak onto a later throw
+  (`new Map(); JSON.parse("{")` reports the JSON fault at its own line, not the
+  `new`). Native calls stamp the call site around the invoke, likewise restored,
+  so a native callee's error carries a location rather than `0:0`.
+
+### `.gbc` parity note
+
+The call-site descriptor table is intentionally runtime-only, so a module
+executed straight from a compiled `.gbc` (rather than compiled in-process from
+source) has no descriptors: its non-callable/non-constructor faults fall back to
+the runtime-type-name form (`undefined is not a function`) and carry no
+suggestion, where an in-process compile would name the callee. This is the one
+diagnostic-parity gap left open. Serialising the table would close it at the
+cost of a new bytecode-format section (callee text, object/property text, kind,
+line, column per call site) and its verifier; that is a bounded but real format
+change, deferred rather than taken here because the `.gbc` path is not on the
+default runner or test surface. Revisit if binary modules become a primary
+execution path.
 
 ## Instruction Limit
 

--- a/docs/module-resolution.md
+++ b/docs/module-resolution.md
@@ -283,6 +283,86 @@ resolution error rather than misbehaving:
 Loading CommonJS itself is not on the roadmap; see
 [VISION](../VISION.md#what-gocciascript-is-not).
 
+## Runtime code frames
+
+When an uncaught error terminates a run, the diagnostic can show a code frame —
+the source line the error came from, with a caret. That excerpt is bound to the
+engine's own record of where the error was created, never to the thrown value's
+`stack` string:
+
+- **Provenance, not `stack`.** When the engine creates an error it records, on
+  the error object, the top call frame's source location and a ±context excerpt
+  of that module's source, read from the module text the loader already parsed.
+  The excerpt travels on the error, so the frame renders even after the engine
+  is gone. A guest can overwrite an error's `.stack` property, or `throw` a
+  plain object with a fabricated `stack` — that string is never parsed to pick a
+  file or read one, so a forged frame discloses nothing and no host opens a
+  guest-named path. A thrown value with no engine-recorded provenance gets no
+  code frame (its message still shows).
+
+- **Principal / ownership — a guest never reads host source.** Ownership travels
+  with each module and is decided *at load time by the loader*, never inferred
+  from which engine happens to be running when a later error is captured. Every
+  host enrollment API stamps its root module host-owned: `--globals`,
+  `--host-environment`, `--module`, `--modules`, manifest/config variants, and
+  their embedding equivalents. Static imports, dynamic `import()`, and deferred
+  loads inherit the importing module's ownership transitively, even when guest
+  code calls an exported host function after enrollment has finished. A
+  host-injected virtual module is also host-owned because the guest has no API
+  to add one. Only a module reached from a guest-owned importer is guest-owned.
+  An excerpt is captured only from guest-owned source. A genuine error thrown
+  *inside* a host-owned module — directly, transitively, from a `--module` the
+  guest imported, or from an `Error` the host created and the guest threw later
+  (a "held" error) — shows its location line but **no source excerpt**.
+
+- **Canonical file identity.** Registry entries are keyed on canonical identity
+  obtained from the same open handle used to read the module: POSIX uses a
+  device-and-inode pair; Windows uses volume serial and file-index high/low. The key therefore
+  collapses symlinks, junctions, hardlinks, and case aliases instead of minting
+  a second copy with different ownership. Because host enrollment happens
+  before guest execution, the host registration wins that identity. If handle
+  identity cannot be obtained, the source is not retained under a lexical-path
+  fallback; source lookup for that scope fails closed to location-only.
+
+- **Bound to the executing engine, enforced again at render.** Each engine's
+  module loader owns exactly one source scope (identified by a durable,
+  process-monotonic *principal* — a value never reused, unlike a freed pointer),
+  and registration always targets the *loader's own* scope. Capture targets the
+  scope the engine *activates around its own execution* — including every
+  cross-engine transition (a ShadowRealm `evaluate`, `importValue`, or wrapped
+  function switches the active scope to the engine actually running and restores
+  it on return). An excerpt is *also* stamped with its principal and re-checked
+  when it is rendered. Every formatting host explicitly passes the principal
+  it expects; `Goccia.Error.Detail` authorizes the excerpt only when that value
+  equals the stamp. Supplying no principal (zero) means location-only — the
+  absence of an active execution scope is never authorization. Hosts that keep
+  an error beyond `Execute` must keep the originating engine's principal if
+  they intend to render its excerpt. Thus a child engine's error formatted by a
+  resumed parent is refused the child's source even though the error object
+  crossed the boundary. Capture-time filtering is not trusted alone. This
+  holds independently of the filesystem capability gate: an isolated child that cannot
+  `fs.readFileSync` a parent module also cannot obtain its source through a forged
+  or genuine code frame.
+
+- **Bounded, budgeted.** Retained source and each captured excerpt are charged
+  against the `--max-memory` budget and released when the scope or error is
+  freed. Accounting uses the actual retained UTF-16 representation, not
+  `Length()`: source entries include object/container storage, pointer slots,
+  and each separately allocated line string; excerpts include their string
+  allocation. The same byte figure drives the per-module/per-scope or excerpt
+  cap, the collector reservation, and the later release. A reservation refusal
+  degrades to location-only. Registry insertion is transactional: allocation or
+  indexing failure rolls back every partial key and reservation before the
+  exception leaves the loader.
+
+Implementation: `Goccia.Values.ErrorHelper` (provenance capture, principal stamp,
+budget), `Goccia.Diagnostics.SourceRegistry` (engine-owned, execution-activated
+scope with per-load ownership tags, canonical-identity keying, and byte budgets),
+`Goccia.ExecutionContext` (activates a scope on each cross-engine transition),
+`Goccia.Error.Detail` (rendering with render-time principal enforcement).
+The bytecode side is described in
+[Bytecode VM — Runtime Error Diagnostics](bytecode-vm.md#runtime-error-diagnostics).
+
 ## Related documents
 
 - [Build System](build-system.md) — the authoritative CLI and config reference

--- a/docs/module-resolution.md
+++ b/docs/module-resolution.md
@@ -210,8 +210,8 @@ so a keyword the file only mentions counts for nothing. Every esbuild
 `__toCommonJS` bundle depends on that pass: it ends with the banner comment
 `// Annotate the CommonJS export names for ESM import in node:`, whose bare
 `export` and `import` words used to carry the whole file past the check. Such a
-bundle was loaded and then failed at its first `require`, with an
-`Undefined variable: require` reference error instead of the package-relative
+bundle was loaded and then failed at its first `require`, with a
+`require is not defined` reference error instead of the package-relative
 message below.
 
 The placeholder is chosen for what stood there. A string, template, or regular

--- a/scripts/test-cli-apps.ts
+++ b/scripts/test-cli-apps.ts
@@ -2104,6 +2104,52 @@ await section("Loader: --host-environment module controls time, zone, and random
   }
 });
 
+await section("Loader: --host-environment errors withhold provider source...", async () => {
+  const tmp = makeTmp();
+  try {
+    const marker = "HOST_ENVIRONMENT_PRIVATE_SOURCE_XZ";
+    const providerPath = join(tmp, "host-environment-secret.js");
+    writeFileSync(
+      providerPath,
+      [
+        "export const epochNanoseconds = () => 1700000000000000000n;",
+        "export const monotonicNanoseconds = () => 0n;",
+        'export const timeZoneIdentifier = () => "UTC";',
+        `export const random = () => new Map().get("x"); // ${marker}`,
+        "",
+      ].join("\n"),
+    );
+    const guestPath = join(tmp, "host-environment-guest.js");
+    writeFileSync(
+      guestPath,
+      ["Map.prototype.get = null;", "Math.random();", ""].join("\n"),
+    );
+
+    for (const mode of ["interpreted", "bytecode"] as const) {
+      const proc = Bun.spawnSync(
+        [
+          LOADER,
+          guestPath,
+          `--host-environment=${providerPath}`,
+          `--mode=${mode}`,
+        ],
+        { stdout: "pipe", stderr: "pipe" },
+      );
+      const output = proc.stdout.toString() + proc.stderr.toString();
+      if (proc.exitCode === 0 || !output.includes("host-environment-secret.js:4:"))
+        throw new Error(
+          `Loader host environment ${mode} should locate the provider throw, got: ${output}`,
+        );
+      if (output.includes(marker))
+        throw new Error(
+          `SECURITY: Loader host environment ${mode} disclosed provider source: ${output}`,
+        );
+    }
+  } finally {
+    clean(tmp);
+  }
+});
+
 await section("Loader: --global option...", async () => {
   const { json } = runLoaderJson("x + y;\n", ["--global", "x=10", "--global", "y=20"]);
   if (json.files?.[0]?.result !== 30) throw new Error(`--global x+y should be 30, got ${json.files?.[0]?.result}`);
@@ -5462,6 +5508,229 @@ await section("REPL: repeated tagged template execution (interpreted + bytecode)
 // ============================================================================
 // GocciaSandboxRunner
 // ============================================================================
+
+await section("SandboxRunner: a thrown stack cannot read a host file into the diagnostic...", async () => {
+  // A code frame's source must come from what the engine parsed, not from a
+  // path lifted out of a script-controlled `stack` string. In the sandbox this
+  // is load-bearing: reading such a path would bypass the sandbox.fs.path
+  // capability gate and hand guest code the contents of any host file through
+  // the reported ErrorMessage/ErrorOutput.
+  const tmp = makeTmp();
+  try {
+    const secretPath = join(tmp, "HOST_SECRET.txt");
+    const secretMarker = "SANDBOX_HOST_SECRET_LEAKED";
+    writeFileSync(secretPath, `${secretMarker}\nsecond line\n`);
+    const seed = join(tmp, "seed.json");
+    writeFileSync(seed, JSON.stringify({
+      files: [
+        {
+          path: "/main.js",
+          text: [
+            `const forged = { name: "Error", message: "forged", stack: "Error: forged\\n    at f (${secretPath.replace(/\\/g, "\\\\")}:1:1)" };`,
+            "throw forged;",
+          ].join("\n"),
+        },
+      ],
+    }));
+    for (const [label, extraArgs] of [
+      ["interpreter", []],
+      ["bytecode", ["--mode=bytecode"]],
+    ] as const) {
+      const proc = Bun.spawnSync(
+        [SANDBOXRUNNER, "/main.js", `--seed-config=${seed}`, "--source-type=module", ...extraArgs],
+        { stdout: "pipe", stderr: "pipe" },
+      );
+      const combined = proc.stdout.toString() + proc.stderr.toString();
+      if (combined.includes(secretMarker))
+        throw new Error(
+          `SECURITY: SandboxRunner ${label} leaked a host file named by a thrown stack: ${combined}`,
+        );
+    }
+  } finally {
+    clean(tmp);
+  }
+});
+
+await section("SandboxRunner: a nested isolated child cannot read the parent's module source...", async () => {
+  // Regression for the disclosure the source registry introduced: the parent
+  // imports a module (registering its source), then runs an ISOLATED child
+  // seeded with only its own file. The child forges a frame naming the parent's
+  // module. Because a code frame is bound to engine-recorded provenance (never
+  // the guest `.stack`) and each engine has its own source scope, the child gets
+  // no frame and the parent module's source never crosses the boundary — even
+  // though the child's own filesystem correctly cannot open that path either.
+  const tmp = makeTmp();
+  try {
+    // Appears ONLY as /parent_secret.js's source content; never in the child's
+    // own code or the forged stack string, so any occurrence in output is a leak.
+    const leakMarker = "LEAKED_PARENT_SOURCE_XZ";
+    const seed = join(tmp, "seed.json");
+    // The child names the parent module in a forged stack but never contains the
+    // leak marker itself. It first proves it cannot read that path through its
+    // own (isolated) filesystem, so the only channel under test is the code
+    // frame.
+    const childForge = [
+      'import fs from "fs";',
+      "let childCanRead = true;",
+      "try { fs.readFileSync('/parent_secret.js'); } catch (e) { childCanRead = false; }",
+      "console.log('childCanRead:' + childCanRead);",
+      'const forged = { name: "Error", message: "child forged", stack: "Error: child forged\\n    at f (/parent_secret.js:1:1)" };',
+      "throw forged;",
+    ].join("\n");
+    writeFileSync(seed, JSON.stringify({
+      files: [
+        {
+          path: "/parent_secret.js",
+          text: `export const secret = 1; // ${leakMarker}`,
+        },
+        { path: "/child.js", text: childForge },
+        {
+          path: "/main.js",
+          text: [
+            'import { secret } from "/parent_secret.js";',
+            'import { runScript } from "goccia";',
+            "void secret;",
+            // Isolated child seeded with ONLY its own file; no /parent_secret.js.
+            'const child = runScript("/child.js", { sandbox: true, seed: [{ path: "/child.js", text: ' +
+              JSON.stringify(childForge) +
+              " }] });",
+            "console.log(child.stdout);",
+            "console.log(child.stderr);",
+            "console.log(child.error);",
+          ].join("\n"),
+        },
+      ],
+    }));
+    for (const [label, extraArgs] of [
+      ["interpreter", []],
+      ["bytecode", ["--mode=bytecode"]],
+    ] as const) {
+      const proc = Bun.spawnSync(
+        [SANDBOXRUNNER, "/main.js", `--seed-config=${seed}`, "--source-type=module", ...extraArgs],
+        { stdout: "pipe", stderr: "pipe" },
+      );
+      const combined = proc.stdout.toString() + proc.stderr.toString();
+      if (combined.includes(leakMarker))
+        throw new Error(
+          `SECURITY: SandboxRunner ${label} nested child disclosed the parent module source: ${combined}`,
+        );
+      // The channel under test is the code frame, not the filesystem: confirm
+      // the isolated child genuinely cannot read the parent module directly.
+      if (!combined.includes("childCanRead:false"))
+        throw new Error(
+          `SandboxRunner ${label}: expected the isolated child to lack FS access to /parent_secret.js, got: ${combined}`,
+        );
+    }
+  } finally {
+    clean(tmp);
+  }
+});
+
+await section("SandboxRunner: a legitimate error in the child's own module still renders its code frame...", async () => {
+  // Feature-survival counterpart to the disclosure test: a genuine throw inside
+  // a module the child itself loaded must still produce that module's code frame
+  // in both modes (the fix must not blanket-disable frames).
+  const tmp = makeTmp();
+  try {
+    const seed = join(tmp, "seed.json");
+    writeFileSync(seed, JSON.stringify({
+      files: [
+        {
+          path: "/boom.js",
+          text: [
+            "// boom filler 1",
+            "// boom filler 2",
+            "export const boom = (() => { throw new Error('own module exploded'); })();",
+          ].join("\n"),
+        },
+        {
+          path: "/main.js",
+          text: ['import { boom } from "/boom.js";', "void boom;"].join("\n"),
+        },
+      ],
+    }));
+    for (const [label, extraArgs] of [
+      ["interpreter", []],
+      ["bytecode", ["--mode=bytecode"]],
+    ] as const) {
+      const proc = Bun.spawnSync(
+        [SANDBOXRUNNER, "/main.js", `--seed-config=${seed}`, "--source-type=module", ...extraArgs],
+        { stdout: "pipe", stderr: "pipe" },
+      );
+      const combined = proc.stdout.toString() + proc.stderr.toString();
+      if (!combined.includes("own module exploded"))
+        throw new Error(`SandboxRunner ${label} should report the module error, got: ${combined}`);
+      if (!combined.includes("boom.js:3:") ||
+          !combined.includes("throw new Error('own module exploded')"))
+        throw new Error(
+          `SandboxRunner ${label} should render the child's own module code frame, got: ${combined}`,
+        );
+    }
+  } finally {
+    clean(tmp);
+  }
+});
+
+await section("SandboxRunner: a nested child's genuine module source is withheld when the parent surfaces its error...", async () => {
+  // Render-time principal enforcement. The child GENUINELY throws inside a
+  // module it loaded itself, so the child engine captures a real code-frame
+  // excerpt (guest-owned, stamped with the child's principal). The parent then
+  // reads `child.error` — a string formatted while the PARENT scope is active.
+  // Capture-time filtering alone cannot stop this (the excerpt is legitimate in
+  // the child); the renderer must refuse an excerpt whose principal is not the
+  // active one. The parent must see the fault's location but never the child's
+  // source line. A sibling test above proves the SAME child, run at top level,
+  // does render its frame — so this is enforcement, not a blanket disable.
+  const tmp = makeTmp();
+  try {
+    const childMarker = "NESTED_CHILD_MODULE_SOURCE_XZ";
+    const seed = join(tmp, "seed.json");
+    writeFileSync(seed, JSON.stringify({
+      files: [
+        {
+          path: "/lib.js",
+          text: [
+            `// ${childMarker}`,
+            "export const boom = () => { const z = null; return z.x; };",
+          ].join("\n"),
+        },
+        {
+          path: "/child.js",
+          text: ['import { boom } from "/lib.js";', "boom();"].join("\n"),
+        },
+        {
+          path: "/main.js",
+          text: [
+            'import { runScript } from "goccia";',
+            'const c = runScript("/child.js", { sandbox: true, seed: ["/child.js", "/lib.js"] });',
+            "console.log(c.error);",
+          ].join("\n"),
+        },
+      ],
+    }));
+    for (const [label, extraArgs] of [
+      ["interpreter", []],
+      ["bytecode", ["--mode=bytecode"]],
+    ] as const) {
+      const proc = Bun.spawnSync(
+        [SANDBOXRUNNER, "/main.js", `--seed-config=${seed}`, "--source-type=module", ...extraArgs],
+        { stdout: "pipe", stderr: "pipe" },
+      );
+      const combined = proc.stdout.toString() + proc.stderr.toString();
+      if (combined.includes(childMarker))
+        throw new Error(
+          `SECURITY: SandboxRunner ${label} disclosed a nested child's module source when the parent surfaced its error: ${combined}`,
+        );
+      // The location must still be reported (only the source excerpt is gated).
+      if (!combined.includes("/lib.js:"))
+        throw new Error(
+          `SandboxRunner ${label} should still locate the nested child's fault, got: ${combined}`,
+        );
+    }
+  } finally {
+    clean(tmp);
+  }
+});
 
 await section("SandboxRunner: fs callback APIs and promises defer filesystem work...", async () => {
   const tmp = makeTmp();

--- a/scripts/test-cli.ts
+++ b/scripts/test-cli.ts
@@ -3349,6 +3349,107 @@ console.log("Assertion failure text...");
   }
 }
 
+// -- Runtime diagnostic parity (TestRunner) ------------------------------------
+
+// An uncaught runtime fault is reported by the runner, not by the suite, so the
+// rendered diagnostic is only observable from outside. It used to be a
+// different diagnostic per execution mode: interpreted runs printed the named
+// callee, a suggestion, a `--> file:line:column` header and a code frame, while
+// bytecode runs printed a bare "Fatal error: TypeError: undefined is not a
+// function". The two renderings are pinned together here — byte-for-byte
+// equality is the contract, because any drift in either mode is the defect.
+console.log("Runtime diagnostic parity...");
+{
+  const tmp = mkdtemp("goccia-diagnostic-parity-");
+  try {
+    const calleeSrc = join(tmp, "callee.test.js");
+    writeFileSync(calleeSrc, ["const obj = {};", "obj.missingMethod();", ""].join("\n"));
+
+    const renderings: Record<string, string> = {};
+    for (const mode of ["--mode=interpreted", "--mode=bytecode"]) {
+      const run = await $`${TESTRUNNER} ${calleeSrc} ${mode} --no-progress 2>&1`.nothrow();
+      const out = run.text();
+      for (const expected of [
+        "TypeError: obj.missingMethod is not a function",
+        "Suggestion: 'obj' is of type 'object' which does not have method 'missingMethod'",
+        "callee.test.js:2:18",
+        "2 | obj.missingMethod();",
+      ]) {
+        if (!out.includes(expected))
+          throw new Error(
+            `TestRunner (${mode}) should report "${expected}", got: ${out}`,
+          );
+      }
+      if (out.includes("Fatal error"))
+        throw new Error(
+          `TestRunner (${mode}) must render a thrown value as a diagnostic, not a fatal error, got: ${out}`,
+        );
+      // The header and code frame are the part that must match across modes;
+      // the results block below carries mode-specific timing lines.
+      renderings[mode] = out.slice(0, out.indexOf("Test Results Test Files:"));
+    }
+    if (renderings["--mode=interpreted"] !== renderings["--mode=bytecode"])
+      throw new Error(
+        `Both modes must render an identical diagnostic.\ninterpreted:\n${renderings["--mode=interpreted"]}\nbytecode:\n${renderings["--mode=bytecode"]}`,
+      );
+
+    // The code frame is read from a file, and the file it was read from used to
+    // be the entry every time: a module that threw while evaluating produced a
+    // header naming the module and an excerpt quoting whatever the entry file
+    // happened to have at that line number.
+    const dep = join(tmp, "dep.js");
+    writeFileSync(
+      dep,
+      [
+        "// dep filler 1",
+        "// dep filler 2",
+        "// dep filler 3",
+        "// dep filler 4",
+        "export const boom = (() => { throw new Error('dep exploded'); })();",
+        "",
+      ].join("\n"),
+    );
+    const entry = join(tmp, "entry.test.js");
+    writeFileSync(
+      entry,
+      [
+        "// entry filler 1",
+        "// entry filler 2",
+        "// entry filler 3",
+        "// entry filler 4",
+        "import { boom } from './dep.js';",
+        "console.log(boom);",
+        "",
+      ].join("\n"),
+    );
+
+    const frames: Record<string, string> = {};
+    for (const mode of ["--mode=interpreted", "--mode=bytecode"]) {
+      const run = await $`${TESTRUNNER} ${entry} ${mode} --no-progress 2>&1`.nothrow();
+      const out = run.text();
+      if (!out.includes("Error: dep exploded"))
+        throw new Error(`TestRunner (${mode}) should report the module's error, got: ${out}`);
+      if (!out.includes("dep.js:5:"))
+        throw new Error(`TestRunner (${mode}) should locate the fault in dep.js, got: ${out}`);
+      if (!out.includes("throw new Error('dep exploded')"))
+        throw new Error(
+          `TestRunner (${mode}) should quote dep.js in the code frame, got: ${out}`,
+        );
+      if (out.includes("entry filler") || out.includes("import { boom }"))
+        throw new Error(
+          `TestRunner (${mode}) must not quote the entry file for a fault in dep.js, got: ${out}`,
+        );
+      frames[mode] = out.slice(0, out.indexOf("Test Results Test Files:"));
+    }
+    if (frames["--mode=interpreted"] !== frames["--mode=bytecode"])
+      throw new Error(
+        `Both modes must render an identical module diagnostic.\ninterpreted:\n${frames["--mode=interpreted"]}\nbytecode:\n${frames["--mode=bytecode"]}`,
+      );
+  } finally {
+    clean(tmp);
+  }
+}
+
 // -- Global injection (TestRunner) ---------------------------------------------
 
 // The runner grew --global/--globals so a suite can be handed a host global it

--- a/scripts/test-cli.ts
+++ b/scripts/test-cli.ts
@@ -10,7 +10,14 @@
  */
 
 import { $ } from "bun";
-import { writeFileSync, readFileSync, existsSync } from "fs";
+import {
+  writeFileSync,
+  readFileSync,
+  existsSync,
+  mkdirSync,
+  symlinkSync,
+  linkSync,
+} from "fs";
 import { join } from "path";
 import {
   LOADER,
@@ -3361,6 +3368,17 @@ console.log("Assertion failure text...");
 console.log("Runtime diagnostic parity...");
 {
   const tmp = mkdtemp("goccia-diagnostic-parity-");
+  // The diagnostic (header + code frame) is everything before the results
+  // block. Guard the marker: if a run ever stops emitting it, slice(0, -1)
+  // would silently compare truncated output, so treat its absence as a failure
+  // rather than let the equality check pass on a coincidence.
+  const RESULTS_MARKER = "Test Results Test Files:";
+  const diagnosticPrefix = (out: string, label: string): string => {
+    const at = out.indexOf(RESULTS_MARKER);
+    if (at < 0)
+      throw new Error(`${label} produced no results block, got: ${out}`);
+    return out.slice(0, at);
+  };
   try {
     const calleeSrc = join(tmp, "callee.test.js");
     writeFileSync(calleeSrc, ["const obj = {};", "obj.missingMethod();", ""].join("\n"));
@@ -3369,6 +3387,11 @@ console.log("Runtime diagnostic parity...");
     for (const mode of ["--mode=interpreted", "--mode=bytecode"]) {
       const run = await $`${TESTRUNNER} ${calleeSrc} ${mode} --no-progress 2>&1`.nothrow();
       const out = run.text();
+      // A file whose top level throws is a failed file: the runner exits 1.
+      if (run.exitCode !== 1)
+        throw new Error(
+          `TestRunner (${mode}) should exit 1 on an uncaught throw, got ${run.exitCode}: ${out}`,
+        );
       for (const expected of [
         "TypeError: obj.missingMethod is not a function",
         "Suggestion: 'obj' is of type 'object' which does not have method 'missingMethod'",
@@ -3386,7 +3409,7 @@ console.log("Runtime diagnostic parity...");
         );
       // The header and code frame are the part that must match across modes;
       // the results block below carries mode-specific timing lines.
-      renderings[mode] = out.slice(0, out.indexOf("Test Results Test Files:"));
+      renderings[mode] = diagnosticPrefix(out, `TestRunner (${mode})`);
     }
     if (renderings["--mode=interpreted"] !== renderings["--mode=bytecode"])
       throw new Error(
@@ -3427,6 +3450,10 @@ console.log("Runtime diagnostic parity...");
     for (const mode of ["--mode=interpreted", "--mode=bytecode"]) {
       const run = await $`${TESTRUNNER} ${entry} ${mode} --no-progress 2>&1`.nothrow();
       const out = run.text();
+      if (run.exitCode !== 1)
+        throw new Error(
+          `TestRunner (${mode}) should exit 1 on a module that throws, got ${run.exitCode}: ${out}`,
+        );
       if (!out.includes("Error: dep exploded"))
         throw new Error(`TestRunner (${mode}) should report the module's error, got: ${out}`);
       if (!out.includes("dep.js:5:"))
@@ -3439,12 +3466,515 @@ console.log("Runtime diagnostic parity...");
         throw new Error(
           `TestRunner (${mode}) must not quote the entry file for a fault in dep.js, got: ${out}`,
         );
-      frames[mode] = out.slice(0, out.indexOf("Test Results Test Files:"));
+      frames[mode] = diagnosticPrefix(out, `TestRunner (${mode})`);
     }
     if (frames["--mode=interpreted"] !== frames["--mode=bytecode"])
       throw new Error(
         `Both modes must render an identical module diagnostic.\ninterpreted:\n${frames["--mode=interpreted"]}\nbytecode:\n${frames["--mode=bytecode"]}`,
       );
+
+    // A `new` before an unrelated throw must not drag its location onto the
+    // throw: the constructor-site stamp is scoped to the construction, so
+    // `m.missing.x` reports its own line in both modes, identically.
+    const precedingNewSrc = join(tmp, "preceding-new.test.js");
+    writeFileSync(
+      precedingNewSrc,
+      [
+        "const make = () => {",
+        "  const m = new Map();",
+        "  return m.missing.x;",
+        "};",
+        "make();",
+        "",
+      ].join("\n"),
+    );
+    const precedingNew: Record<string, string> = {};
+    for (const mode of ["--mode=interpreted", "--mode=bytecode"]) {
+      const run = await $`${TESTRUNNER} ${precedingNewSrc} ${mode} --no-progress 2>&1`.nothrow();
+      const out = run.text();
+      if (!out.includes("preceding-new.test.js:3:"))
+        throw new Error(
+          `TestRunner (${mode}) should locate the fault at the m.missing.x line (3), not the new Map() line, got: ${out}`,
+        );
+      if (out.includes("preceding-new.test.js:2:"))
+        throw new Error(
+          `TestRunner (${mode}) leaked the new Map() location (line 2) onto a later throw, got: ${out}`,
+        );
+      precedingNew[mode] = diagnosticPrefix(out, `TestRunner (${mode})`);
+    }
+    if (precedingNew["--mode=interpreted"] !== precedingNew["--mode=bytecode"])
+      throw new Error(
+        `Both modes must render an identical preceding-new diagnostic.\ninterpreted:\n${precedingNew["--mode=interpreted"]}\nbytecode:\n${precedingNew["--mode=bytecode"]}`,
+      );
+
+    // A successful construct must not leave its constructor's position stamped
+    // on the caller frame: a later native error reports its own line, not the
+    // `new`'s. `new Map()` on line 1, `JSON.parse("{")` on line 2 — the syntax
+    // error must locate to line 2 in both modes (the bytecode twin of the
+    // round-2 `new`-stamp finding).
+    const constructSrc = join(tmp, "construct-stamp.test.js");
+    writeFileSync(
+      constructSrc,
+      ['new Map();', 'JSON.parse("{");', ""].join("\n"),
+    );
+    for (const mode of ["--mode=interpreted", "--mode=bytecode"]) {
+      const run = await $`${TESTRUNNER} ${constructSrc} ${mode} --no-progress 2>&1`.nothrow();
+      const out = run.text();
+      if (!out.includes("construct-stamp.test.js:2:"))
+        throw new Error(
+          `TestRunner (${mode}) should locate the JSON error at line 2 (JSON.parse), got: ${out}`,
+        );
+      if (out.includes("construct-stamp.test.js:1:"))
+        throw new Error(
+          `TestRunner (${mode}) leaked the new Map() position (line 1) onto the JSON error: ${out}`,
+        );
+    }
+
+    // The automatic SuppressedError from a block+disposer double-throw carries
+    // genuine provenance (built as an error object, not a bare object): both
+    // modes render a "SuppressedError" diagnostic with a location, and the
+    // interpreter shows the source frame.
+    const suppSrc = join(tmp, "suppressed.test.js");
+    writeFileSync(
+      suppSrc,
+      [
+        "const run = () => {",
+        '  { using d = { [Symbol.dispose]() { throw new Error("disposer boom"); } }; throw new Error("body boom"); }',
+        "};",
+        "run();",
+        "",
+      ].join("\n"),
+    );
+    for (const mode of ["--mode=interpreted", "--mode=bytecode"]) {
+      const run = await $`${TESTRUNNER} ${suppSrc} ${mode} --no-progress 2>&1`.nothrow();
+      const out = run.text();
+      if (!out.includes("SuppressedError"))
+        throw new Error(`TestRunner (${mode}) should report a SuppressedError, got: ${out}`);
+      if (!out.includes("suppressed.test.js:"))
+        throw new Error(
+          `TestRunner (${mode}) should locate the SuppressedError, not print it bare, got: ${out}`,
+        );
+    }
+    {
+      const run = await $`${TESTRUNNER} ${suppSrc} --mode=interpreted --no-progress 2>&1`.nothrow();
+      if (!run.text().includes("throw new Error(\"body boom\")"))
+        throw new Error(
+          `TestRunner (interpreted) should render the SuppressedError's source frame, got: ${run.text()}`,
+        );
+    }
+
+    // A non-constructable super() reaches the class-construction machinery, not
+    // the ordinary call guard, so its message/location parity is governed there
+    // (a separate concern from these diagnostics). Pin only what this change
+    // owns: both modes render a TypeError diagnostic rather than a bare
+    // "Fatal error". Byte-level super() parity is tracked with the construction
+    // path, not here.
+    const superSrc = join(tmp, "super-call.test.js");
+    writeFileSync(
+      superSrc,
+      [
+        "class B extends null {",
+        "  constructor() {",
+        "    super();",
+        "  }",
+        "}",
+        "new B();",
+        "",
+      ].join("\n"),
+    );
+    for (const mode of ["--mode=interpreted", "--mode=bytecode"]) {
+      const run = await $`${TESTRUNNER} ${superSrc} ${mode} --no-progress 2>&1`.nothrow();
+      const out = run.text();
+      if (out.includes("Fatal error"))
+        throw new Error(
+          `TestRunner (${mode}) must render the super() fault as a diagnostic, not a fatal error, got: ${out}`,
+        );
+      if (!out.includes("TypeError"))
+        throw new Error(
+          `TestRunner (${mode}) should report a TypeError for a non-constructable super(), got: ${out}`,
+        );
+    }
+
+    // Security: a code frame is rendered only from provenance the engine
+    // recorded on a genuine error at creation, never from the thrown value's
+    // guest-writable `stack` string. A forged `{ stack: "...at f (FILE:1:1)" }`
+    // object carries no provenance, so no host opens FILE and no frame is shown.
+    const secretPath = join(tmp, "SECRET_MUST_NOT_APPEAR.txt");
+    const secretMarker = "TOP_SECRET_FILE_CONTENTS_LEAKED";
+    writeFileSync(secretPath, `${secretMarker}\nline two of the secret file\n`);
+    const attackSrc = join(tmp, "attack.test.js");
+    // Point the forged frame at the secret file. If a host reads it, the marker
+    // (its line 1) shows up in the rendered code frame.
+    writeFileSync(
+      attackSrc,
+      [
+        `const forged = { name: "Error", message: "forged", stack: "Error: forged\\n    at f (${secretPath.replace(/\\/g, "\\\\")}:1:1)" };`,
+        "throw forged;",
+        "",
+      ].join("\n"),
+    );
+    for (const mode of ["--mode=interpreted", "--mode=bytecode"]) {
+      const run = await $`${TESTRUNNER} ${attackSrc} ${mode} --no-progress 2>&1`.nothrow();
+      const out = run.text();
+      if (out.includes(secretMarker))
+        throw new Error(
+          `SECURITY: TestRunner (${mode}) read a file named by a thrown stack: ${out}`,
+        );
+    }
+    // Same attack through the loader and the sandbox runner (the sandbox path
+    // is the one that would otherwise bypass the sandbox.fs.path gate).
+    for (const bin of [LOADER, BARE]) {
+      const run = await $`${bin} ${attackSrc} 2>&1`.nothrow();
+      const out = run.text();
+      if (out.includes(secretMarker))
+        throw new Error(
+          `SECURITY: ${bin} read a file named by a thrown stack: ${out}`,
+        );
+    }
+
+    // A frame naming a FIFO must not make any host block on open(); the registry
+    // lookup misses and no filesystem call is made. Guard with a hard timeout so
+    // a regression hangs the suite visibly rather than silently.
+    if (process.platform !== "win32") {
+      const fifoPath = join(tmp, "frame.fifo");
+      const mk = await $`mkfifo ${fifoPath}`.nothrow();
+      if (mk.exitCode === 0) {
+        const fifoSrc = join(tmp, "fifo.test.js");
+        writeFileSync(
+          fifoSrc,
+          [
+            `const forged = { name: "Error", message: "f", stack: "Error: f\\n    at g (${fifoPath.replace(/\\/g, "\\\\")}:1:1)" };`,
+            "throw forged;",
+            "",
+          ].join("\n"),
+        );
+        const proc = Bun.spawnSync(
+          [TESTRUNNER, fifoSrc, "--mode=bytecode", "--no-progress"],
+          { stdout: "pipe", stderr: "pipe", timeout: 20_000 },
+        );
+        // spawnSync kills a run that exceeds the timeout with a signal; a clean
+        // exit means the diagnostic rendered without ever opening the FIFO.
+        if (proc.signalCode)
+          throw new Error(
+            `SECURITY: TestRunner hung rendering a frame that names a FIFO (${proc.signalCode})`,
+          );
+      }
+    }
+
+    // Host-preload disclosure: a module the HOST preloaded (which the guest
+    // never imported) must not be readable through a forged frame. The guest
+    // never throws from it, so it is never a genuine error's provenance; the
+    // forged object has none. The preloaded module's private source must not
+    // appear.
+    const preloadMarker = "HOST_PRELOAD_PRIVATE_SOURCE_MARKER";
+    const preloadSrc = join(tmp, "preload.js");
+    writeFileSync(
+      preloadSrc,
+      [
+        `// ${preloadMarker}`,
+        "export const hostValue = 42;",
+        "",
+      ].join("\n"),
+    );
+    const preloadAttack = join(tmp, "preload-attack.js");
+    writeFileSync(
+      preloadAttack,
+      [
+        `const forged = { name: "Error", message: "p", stack: "Error: p\\n    at f (${preloadSrc.replace(/\\/g, "\\\\")}:1:1)" };`,
+        "throw forged;",
+        "",
+      ].join("\n"),
+    );
+    for (const mode of ["", "--mode=bytecode"]) {
+      const run = await $`${LOADER} ${preloadAttack} --globals ${preloadSrc} ${mode} 2>&1`.nothrow();
+      const out = run.text();
+      if (out.includes(preloadMarker))
+        throw new Error(
+          `SECURITY: Loader (${mode || "interpreted"}) disclosed a host-preloaded module via a forged frame: ${out}`,
+        );
+    }
+
+    // Cross-run stale disclosure: in one TestRunner invocation over two files,
+    // file A loads a module carrying a secret; file B forges a frame naming that
+    // module. Each file runs in its own engine scope, and B's forged object has
+    // no provenance, so B must not surface A's module source.
+    const staleMarker = "PRIOR_RUN_MODULE_SOURCE_MARKER";
+    const staleDir = join(tmp, "stale");
+    mkdirSync(staleDir, { recursive: true });
+    writeFileSync(
+      join(staleDir, "secret-mod.js"),
+      [`// ${staleMarker}`, "export const v = 1;", ""].join("\n"),
+    );
+    writeFileSync(
+      join(staleDir, "a.test.js"),
+      ['import { v } from "./secret-mod.js";', "void v;", ""].join("\n"),
+    );
+    const secretModPath = join(staleDir, "secret-mod.js");
+    writeFileSync(
+      join(staleDir, "b.test.js"),
+      [
+        `const forged = { name: "Error", message: "b", stack: "Error: b\\n    at f (${secretModPath.replace(/\\/g, "\\\\")}:1:1)" };`,
+        "throw forged;",
+        "",
+      ].join("\n"),
+    );
+    for (const mode of ["--mode=interpreted", "--mode=bytecode"]) {
+      const run = await $`${TESTRUNNER} ${join(staleDir, "a.test.js")} ${join(staleDir, "b.test.js")} ${mode} --no-progress 2>&1`.nothrow();
+      const out = run.text();
+      if (out.includes(staleMarker))
+        throw new Error(
+          `SECURITY: TestRunner (${mode}) disclosed a prior run's module source via a forged frame: ${out}`,
+        );
+    }
+
+    // Host-preload GENUINE-error exclusion: a real error thrown INSIDE a
+    // host-preloaded module (not forged) must still withhold that module's
+    // source from the guest — location line yes, source lines no. The guest
+    // calls a host global whose body throws; the host module's own source lines
+    // must not appear.
+    const hostBodyMarker = "HOST_MODULE_BODY_SOURCE_LINE";
+    const hostThrower = join(tmp, "host-thrower.js");
+    writeFileSync(
+      hostThrower,
+      [
+        `// ${hostBodyMarker}`,
+        "export const boom = () => {",
+        `  const secret = "${hostBodyMarker}";`,
+        "  return secret.length.toFixed.call(null).nope();",
+        "};",
+        "",
+      ].join("\n"),
+    );
+    const hostThrowerMain = join(tmp, "host-thrower-main.js");
+    writeFileSync(hostThrowerMain, ["boom();", ""].join("\n"));
+    for (const mode of ["", "--mode=bytecode"]) {
+      const run = await $`${LOADER} ${hostThrowerMain} --globals ${hostThrower} --compat-asi ${mode} 2>&1`.nothrow();
+      const out = run.text();
+      if (out.includes(hostBodyMarker))
+        throw new Error(
+          `SECURITY: Loader (${mode || "interpreted"}) disclosed a host module's source for an error thrown inside it: ${out}`,
+        );
+    }
+
+    // Held-error exclusion: a host-preloaded factory creates an Error; the guest
+    // throws it later. The excerpt (host module source) must not be shown.
+    const heldMarker = "HOST_HELD_FACTORY_SOURCE";
+    const heldHost = join(tmp, "held-host.js");
+    writeFileSync(
+      heldHost,
+      [`// ${heldMarker}`, 'export const makeHeld = () => new Error("held");', ""].join("\n"),
+    );
+    const heldMain = join(tmp, "held-main.js");
+    writeFileSync(heldMain, ["const e = makeHeld();", "throw e;", ""].join("\n"));
+    for (const mode of ["", "--mode=bytecode"]) {
+      const run = await $`${LOADER} ${heldMain} --globals ${heldHost} --compat-asi ${mode} 2>&1`.nothrow();
+      const out = run.text();
+      if (out.includes(heldMarker))
+        throw new Error(
+          `SECURITY: Loader (${mode || "interpreted"}) disclosed a host factory's source via a held error: ${out}`,
+        );
+    }
+
+    // Deferred import-chain ownership: the host-injected module has finished
+    // loading before guest execution starts. Calling its exported function
+    // later must still carry host ownership into import(), transitively; a
+    // synchronous host-preload depth counter cannot protect this shape.
+    const deferredMarker = "DEFERRED_HOST_IMPORT_PRIVATE_SOURCE_XZ";
+    const deferredSecret = join(tmp, "deferred-host-secret.js");
+    writeFileSync(
+      deferredSecret,
+      [
+        `// ${deferredMarker}`,
+        `throw new Error("deferred host import failed"); // ${deferredMarker}`,
+        "export const never = 1;",
+        "",
+      ].join("\n"),
+    );
+    const deferredGlobals = join(tmp, "deferred-globals.js");
+    writeFileSync(
+      deferredGlobals,
+      [
+        'export const loadDeferredHostModule = () => import("./deferred-host-secret.js");',
+        "",
+      ].join("\n"),
+    );
+    const deferredMain = join(tmp, "deferred-main.js");
+    writeFileSync(deferredMain, ["await loadDeferredHostModule();", ""].join("\n"));
+    for (const mode of ["", "--mode=bytecode"]) {
+      const run = await $`${LOADER} ${deferredMain} --globals ${deferredGlobals} --compat-asi --source-type=module ${mode} 2>&1`.nothrow();
+      const out = run.text();
+      if (run.exitCode === 0 || !out.includes("deferred-host-secret.js:2:"))
+        throw new Error(
+          `Loader (${mode || "interpreted"}) should locate the deferred host import failure, got: ${out}`,
+        );
+      if (out.includes(deferredMarker))
+        throw new Error(
+          `SECURITY: Loader (${mode || "interpreted"}) disclosed a deferred host import's source: ${out}`,
+        );
+    }
+
+    // Memory bound: a guest module of long lines whose factory throws a genuine
+    // TypeError, held many times, must not retain diagnostic excerpts past the
+    // --max-memory ceiling. At a tight budget the run must hit the ceiling
+    // (RangeError or the uncatchable "exceed the memory budget"), never
+    // HELD:500 (unbounded retention) and never a nil-deref crash.
+    const memDir = join(tmp, "mem");
+    mkdirSync(memDir, { recursive: true });
+    const longLine = "// " + "é😀".repeat(700);
+    const memLines: string[] = [];
+    for (let i = 0; i < 9; i++) memLines.push(longLine);
+    memLines.push("export const boom = () => { const z = null; return z.x; };");
+    for (let i = 0; i < 9; i++) memLines.push("// " + "B".repeat(2000));
+    writeFileSync(join(memDir, "mod.js"), memLines.join("\n") + "\n");
+    writeFileSync(
+      join(memDir, "main.js"),
+      [
+        'import { boom } from "./mod.js";',
+        "const held = [];",
+        "Array.from({ length: 500 }).forEach(() => { try { boom(); } catch (e) { held.push(e); } });",
+        'console.log("HELD:" + held.length);',
+        "",
+      ].join("\n"),
+    );
+    for (const mode of ["", "--mode=bytecode"]) {
+      const run = await $`${LOADER} ${join(memDir, "main.js")} --max-memory=262144 --compat-asi --source-type=module ${mode} 2>&1`.nothrow();
+      const out = run.text();
+      if (out.includes("Object reference is Nil") || out.includes("Range check"))
+        throw new Error(
+          `Loader (${mode || "interpreted"}) crashed under a diagnostic memory bound: ${out}`,
+        );
+      if (out.includes("HELD:500"))
+        throw new Error(
+          `Loader (${mode || "interpreted"}) retained 500 diagnostic excerpts past --max-memory (unbounded): ${out}`,
+        );
+      if (!out.includes("RangeError") && !out.includes("exceed the memory budget"))
+        throw new Error(
+          `Loader (${mode || "interpreted"}) should hit the memory ceiling, got: ${out}`,
+        );
+    }
+
+    // Virtual-module ownership: a module the HOST injected (`--module`) is
+    // host-owned even though the GUEST imports it and a genuine error is thrown
+    // from inside it. The guest must see the fault's location but never the
+    // module's source text. (The guest has no API to inject a virtual module, so
+    // every virtual module is host-provided; ownership is decided at load, not
+    // inferred from who is running when the frame is captured.)
+    const vmMarker = "VIRTUAL_MODULE_BODY_SOURCE_XZ";
+    const vmMain = join(tmp, "vmodule-main.js");
+    writeFileSync(vmMain, ['import { boom } from "virtual:secret";', "boom();", ""].join("\n"));
+    const vmDef =
+      `virtual:secret=// ${vmMarker}\n` +
+      "export const boom = () => { const z = null; return z.x; };";
+    for (const mode of ["", "--mode=bytecode"]) {
+      const run = await $`${LOADER} ${vmMain} --module ${vmDef} --compat-asi --source-type=module ${mode} 2>&1`.nothrow();
+      const out = run.text();
+      if (out.includes(vmMarker))
+        throw new Error(
+          `SECURITY: Loader (${mode || "interpreted"}) disclosed a host --module's source to a guest: ${out}`,
+        );
+      if (!out.includes("virtual:secret:"))
+        throw new Error(
+          `Loader (${mode || "interpreted"}) should still locate the fault in the virtual module, got: ${out}`,
+        );
+    }
+
+    // Canonical-identity ownership: a second spelling of a host-preloaded file
+    // must resolve to its first, host-owned entry. POSIX uses device+inode;
+    // Windows uses volume serial + file index from the already-open handle.
+    const aliasMarker = "HOST_FILE_VIA_ALIAS_SOURCE_XZ";
+    const aliasChildMarker = "HOST_ALIAS_TRANSITIVE_IMPORT_SOURCE_XZ";
+    const hostDirectory = join(tmp, "canonical-host");
+    mkdirSync(hostDirectory, { recursive: true });
+    const aliasChildSource = [
+      `// ${aliasChildMarker}`,
+      `throw new Error("alias child failed"); // ${aliasChildMarker}`,
+      "export const never = 1;",
+      "",
+    ].join("\n");
+    writeFileSync(join(hostDirectory, "alias-child.js"), aliasChildSource);
+    // A symlink/hardlink module resolves a relative child beside the alias;
+    // a directory junction resolves it inside hostDirectory. Populate both
+    // locations with the same source so each platform exercises its real rule.
+    writeFileSync(join(tmp, "alias-child.js"), aliasChildSource);
+    const realHost = join(hostDirectory, "real-host.js");
+    writeFileSync(
+      realHost,
+      [
+        `// ${aliasMarker}`,
+        "export const boom = () => { const z = null; return z.x; };",
+        'export const loadAliasChild = () => import("./alias-child.js");',
+        "",
+      ].join("\n"),
+    );
+    const aliases: Array<{ path: string; label: string }> = [];
+    if (process.platform === "win32") {
+      const hardlink = join(tmp, "hardlink-host.js");
+      try {
+        linkSync(realHost, hardlink);
+        aliases.push({ path: hardlink, label: "hardlink" });
+      } catch {
+        // The filesystem may not support hardlinks in the CI workspace.
+      }
+      const junctionDirectory = join(tmp, "junction-host");
+      try {
+        symlinkSync(hostDirectory, junctionDirectory, "junction");
+        aliases.push({
+          path: join(junctionDirectory, "real-host.js"),
+          label: "junction",
+        });
+      } catch {
+        // Junction creation can be disabled by the runner's filesystem policy.
+      }
+    } else {
+      const symlink = join(tmp, "symlink-host.js");
+      try {
+        symlinkSync(realHost, symlink);
+        aliases.push({ path: symlink, label: "symlink" });
+      } catch {
+        // Some filesystems disallow symlinks; skip rather than false-fail.
+      }
+    }
+    for (const alias of aliases) {
+      if (!existsSync(alias.path)) continue;
+      const aliasMain = join(tmp, `${alias.label}-main.js`);
+      const relativeAlias = `./${alias.path
+        .slice(tmp.length + 1)
+        .replace(/\\/g, "/")}`;
+      writeFileSync(
+        aliasMain,
+        [`import { boom } from "${relativeAlias}";`, "boom();", ""].join("\n"),
+      );
+      for (const mode of ["", "--mode=bytecode"]) {
+        const run = await $`${LOADER} ${aliasMain} --globals ${realHost} --compat-asi --source-type=module ${mode} 2>&1`.nothrow();
+        const out = run.text();
+        if (out.includes(aliasMarker))
+          throw new Error(
+            `SECURITY: Loader (${mode || "interpreted"}) disclosed a host file's source via a Windows/POSIX ${alias.label}: ${out}`,
+          );
+      }
+
+      const transitiveMain = join(tmp, `${alias.label}-transitive-main.js`);
+      writeFileSync(
+        transitiveMain,
+        [
+          `import { loadAliasChild } from "${relativeAlias}";`,
+          "await loadAliasChild();",
+          "",
+        ].join("\n"),
+      );
+      for (const mode of ["", "--mode=bytecode"]) {
+        const run = await $`${LOADER} ${transitiveMain} --globals ${realHost} --compat-asi --source-type=module ${mode} 2>&1`.nothrow();
+        const out = run.text();
+        if (run.exitCode === 0 || !out.includes("alias-child.js:2:"))
+          throw new Error(
+            `Loader (${mode || "interpreted"}) should locate the ${alias.label} host child failure, got: ${out}`,
+          );
+        if (out.includes(aliasChildMarker))
+          throw new Error(
+            `SECURITY: Loader (${mode || "interpreted"}) disclosed source imported through a host ${alias.label}: ${out}`,
+          );
+      }
+    }
   } finally {
     clean(tmp);
   }

--- a/source/app/Goccia.CLI.Application.pas
+++ b/source/app/Goccia.CLI.Application.pas
@@ -849,7 +849,7 @@ begin
     ManifestLoader.BindRuntime(AEngine.Interpreter.GlobalScope,
       AEngine.ThrowError);
 
-    ManifestModule := ManifestLoader.LoadModule(APath, APath);
+    ManifestModule := ManifestLoader.LoadHostModule(APath, APath);
     if not ManifestModule.TryGetExportValue(KEYWORD_DEFAULT, DefaultValue) then
       raise EArgumentException.Create(
         'Virtual modules manifest module must have a default export.');

--- a/source/app/GocciaBenchmarkRunner.dpr
+++ b/source/app/GocciaBenchmarkRunner.dpr
@@ -551,9 +551,9 @@ begin
       on E: EGocciaBytecodeThrow do
       begin
         if not GIsWorkerThread then
-          WriteLn(ErrOutput, FormatThrowDetail(E.ThrownValue, AFileName, Source, IsColorTerminal));
+          WriteLn(ErrOutput, FormatThrowDetail(E.ThrownValue, AFileName, Source, IsColorTerminal, E.Suggestion));
         MakeErrorFileResult(AFileName,
-          FormatThrowDetail(E.ThrownValue, AFileName, Source, False), AReporter);
+          FormatThrowDetail(E.ThrownValue, AFileName, Source, False, E.Suggestion), AReporter);
       end;
       on E: Exception do
         MakeErrorFileResult(AFileName, E.Message, AReporter);
@@ -767,9 +767,9 @@ begin
     on E: EGocciaBytecodeThrow do
     begin
       if not GIsWorkerThread then
-        WriteLn(ErrOutput, FormatThrowDetail(E.ThrownValue, AFileName, ASource, IsColorTerminal));
+        WriteLn(ErrOutput, FormatThrowDetail(E.ThrownValue, AFileName, ASource, IsColorTerminal, E.Suggestion));
       MakeErrorFileResult(AFileName,
-        FormatThrowDetail(E.ThrownValue, AFileName, ASource, False), AReporter);
+        FormatThrowDetail(E.ThrownValue, AFileName, ASource, False, E.Suggestion), AReporter);
     end;
     on E: Exception do
       MakeErrorFileResult(AFileName, E.Message, AReporter);

--- a/source/app/GocciaBenchmarkRunner.dpr
+++ b/source/app/GocciaBenchmarkRunner.dpr
@@ -341,7 +341,9 @@ var
   ScriptResult: TGocciaObjectValue;
   FileResult: TBenchmarkFileResult;
   BenchStart: Int64;
+  ExpectedPrincipal: Int64;
 begin
+  ExpectedPrincipal := 0;
   Source := nil;
   try
     try
@@ -360,6 +362,7 @@ begin
       try
         Engine := CreateEngine(AFileName, Source, Executor);
         try
+          ExpectedPrincipal := Engine.ModuleLoader.DiagnosticScope.Principal;
           ConfigureBenchmarkRuntime(Engine, AShowProgress, False);
 
           StartExecutionTimeout(EngineOptions.Timeout.ValueOr(0));
@@ -408,9 +411,11 @@ begin
       on E: TGocciaThrowValue do
       begin
         if not GIsWorkerThread then
-          WriteLn(ErrOutput, FormatThrowDetail(E.Value, AFileName, Source, IsColorTerminal, E.Suggestion));
+          WriteLn(ErrOutput, FormatThrowDetail(E.Value, AFileName, Source,
+            IsColorTerminal, ExpectedPrincipal, E.Suggestion));
         MakeErrorFileResult(AFileName,
-          FormatThrowDetail(E.Value, AFileName, Source, False, E.Suggestion), AReporter);
+          FormatThrowDetail(E.Value, AFileName, Source, False,
+            ExpectedPrincipal, E.Suggestion), AReporter);
       end;
       on E: Exception do
         MakeErrorFileResult(AFileName, E.Message, AReporter);
@@ -438,8 +443,10 @@ var
   ScriptResult: TGocciaObjectValue;
   LexStart, CompileStart, CompileEnd, ExecEnd, BenchStart: Int64;
   LexTimeNanoseconds, ParseTimeNanoseconds: Int64;
+  ExpectedPrincipal: Int64;
 begin
   Source := nil;
+  ExpectedPrincipal := 0;
   SourcePipelineResult := nil;
   try
     try
@@ -459,6 +466,7 @@ begin
       try
         Engine := CreateEngine(AFileName, Source, Executor);
         try
+          ExpectedPrincipal := Engine.ModuleLoader.DiagnosticScope.Principal;
           LexStart := GetNanoseconds;
           PipelineOptions := TGocciaSourcePipeline.DefaultOptions;
           PipelineOptions.Preprocessors := Engine.Preprocessors;
@@ -544,16 +552,20 @@ begin
       on E: TGocciaThrowValue do
       begin
         if not GIsWorkerThread then
-          WriteLn(ErrOutput, FormatThrowDetail(E.Value, AFileName, Source, IsColorTerminal, E.Suggestion));
+          WriteLn(ErrOutput, FormatThrowDetail(E.Value, AFileName, Source,
+            IsColorTerminal, ExpectedPrincipal, E.Suggestion));
         MakeErrorFileResult(AFileName,
-          FormatThrowDetail(E.Value, AFileName, Source, False, E.Suggestion), AReporter);
+          FormatThrowDetail(E.Value, AFileName, Source, False,
+            ExpectedPrincipal, E.Suggestion), AReporter);
       end;
       on E: EGocciaBytecodeThrow do
       begin
         if not GIsWorkerThread then
-          WriteLn(ErrOutput, FormatThrowDetail(E.ThrownValue, AFileName, Source, IsColorTerminal, E.Suggestion));
+          WriteLn(ErrOutput, FormatThrowDetail(E.ThrownValue, AFileName,
+            Source, IsColorTerminal, ExpectedPrincipal, E.Suggestion));
         MakeErrorFileResult(AFileName,
-          FormatThrowDetail(E.ThrownValue, AFileName, Source, False, E.Suggestion), AReporter);
+          FormatThrowDetail(E.ThrownValue, AFileName, Source, False,
+            ExpectedPrincipal, E.Suggestion), AReporter);
       end;
       on E: Exception do
         MakeErrorFileResult(AFileName, E.Message, AReporter);
@@ -591,12 +603,15 @@ var
   ScriptResult: TGocciaObjectValue;
   FileResult: TBenchmarkFileResult;
   BenchStart: Int64;
+  ExpectedPrincipal: Int64;
 begin
+  ExpectedPrincipal := 0;
   try
     Executor := TGocciaInterpreterExecutor.Create;
     try
       Engine := CreateEngine(AFileName, ASource, Executor);
       try
+        ExpectedPrincipal := Engine.ModuleLoader.DiagnosticScope.Principal;
         ConfigureBenchmarkRuntime(Engine, AShowProgress, False);
 
         StartExecutionTimeout(EngineOptions.Timeout.ValueOr(0));
@@ -645,9 +660,11 @@ begin
     on E: TGocciaThrowValue do
     begin
       if not GIsWorkerThread then
-        WriteLn(ErrOutput, FormatThrowDetail(E.Value, AFileName, ASource, IsColorTerminal, E.Suggestion));
+        WriteLn(ErrOutput, FormatThrowDetail(E.Value, AFileName, ASource,
+          IsColorTerminal, ExpectedPrincipal, E.Suggestion));
       MakeErrorFileResult(AFileName,
-        FormatThrowDetail(E.Value, AFileName, ASource, False, E.Suggestion), AReporter);
+        FormatThrowDetail(E.Value, AFileName, ASource, False,
+          ExpectedPrincipal, E.Suggestion), AReporter);
     end;
     on E: Exception do
       MakeErrorFileResult(AFileName, E.Message, AReporter);
@@ -669,13 +686,16 @@ var
   ScriptResult: TGocciaObjectValue;
   LexStart, CompileStart, CompileEnd, ExecEnd, BenchStart: Int64;
   LexTimeNanoseconds, ParseTimeNanoseconds: Int64;
+  ExpectedPrincipal: Int64;
 begin
   SourcePipelineResult := nil;
+  ExpectedPrincipal := 0;
   try
     Executor := TGocciaBytecodeExecutor.Create;
     try
       Engine := CreateEngine(AFileName, ASource, Executor);
       try
+        ExpectedPrincipal := Engine.ModuleLoader.DiagnosticScope.Principal;
         LexStart := GetNanoseconds;
         PipelineOptions := TGocciaSourcePipeline.DefaultOptions;
         PipelineOptions.Preprocessors := Engine.Preprocessors;
@@ -760,16 +780,20 @@ begin
     on E: TGocciaThrowValue do
     begin
       if not GIsWorkerThread then
-        WriteLn(ErrOutput, FormatThrowDetail(E.Value, AFileName, ASource, IsColorTerminal, E.Suggestion));
+        WriteLn(ErrOutput, FormatThrowDetail(E.Value, AFileName, ASource,
+          IsColorTerminal, ExpectedPrincipal, E.Suggestion));
       MakeErrorFileResult(AFileName,
-        FormatThrowDetail(E.Value, AFileName, ASource, False, E.Suggestion), AReporter);
+        FormatThrowDetail(E.Value, AFileName, ASource, False,
+          ExpectedPrincipal, E.Suggestion), AReporter);
     end;
     on E: EGocciaBytecodeThrow do
     begin
       if not GIsWorkerThread then
-        WriteLn(ErrOutput, FormatThrowDetail(E.ThrownValue, AFileName, ASource, IsColorTerminal, E.Suggestion));
+        WriteLn(ErrOutput, FormatThrowDetail(E.ThrownValue, AFileName,
+          ASource, IsColorTerminal, ExpectedPrincipal, E.Suggestion));
       MakeErrorFileResult(AFileName,
-        FormatThrowDetail(E.ThrownValue, AFileName, ASource, False, E.Suggestion), AReporter);
+        FormatThrowDetail(E.ThrownValue, AFileName, ASource, False,
+          ExpectedPrincipal, E.Suggestion), AReporter);
     end;
     on E: Exception do
       MakeErrorFileResult(AFileName, E.Message, AReporter);

--- a/source/app/GocciaREPL.dpr
+++ b/source/app/GocciaREPL.dpr
@@ -211,6 +211,7 @@ begin
               else if E is TGocciaThrowValue then
                 WriteLn(FormatThrowDetail(TGocciaThrowValue(E).Value,
                   REPL_FILE_NAME, Source, IsColorTerminal,
+                  Eng.ModuleLoader.DiagnosticScope.Principal,
                   TGocciaThrowValue(E).Suggestion))
               else
                 WriteLn('Error: ', E.Message);
@@ -266,6 +267,7 @@ begin
               else if E is TGocciaThrowValue then
                 WriteLn(FormatThrowDetail(TGocciaThrowValue(E).Value,
                   REPL_FILE_NAME, Source, IsColorTerminal,
+                  Eng.ModuleLoader.DiagnosticScope.Principal,
                   TGocciaThrowValue(E).Suggestion))
               else
                 WriteLn('Error: ', E.Message);

--- a/source/app/GocciaSandboxRunner.dpr
+++ b/source/app/GocciaSandboxRunner.dpr
@@ -18,6 +18,7 @@ uses
   Goccia.CapabilityAudit,
   Goccia.CLI.Application,
   Goccia.CLI.Options,
+  Goccia.Diagnostics.SourceRegistry,
   Goccia.Engine,
   Goccia.Error,
   Goccia.Error.Detail,
@@ -790,6 +791,8 @@ var
   CloneRealm, ExecutionRealm: TGocciaRealm;
   PreviousOutputLines: TStrings;
   PreviousHostEnvironment: TGocciaHostEnvironment;
+  RenderScope: TGocciaDiagnosticSourceScope;
+  ExpectedPrincipal: Int64;
 begin
   FillChar(Result, SizeOf(Result), 0);
   Result.Ok := False;
@@ -842,6 +845,18 @@ begin
         PreviousHostEnvironment);
       ApplyVirtualModulesToEngine(Engine, '');
       FCurrentHostEnvironment := Engine.HostEnvironment;
+
+      { The recipient owns render authorization. A top-level runner invocation
+        explicitly authorizes the engine it just created. During nested
+        runScript, the parent scope is active before the child transition, so
+        the returned error string is authorized only for the parent and the
+        child's excerpt is withheld. Engine.Execute restores that same scope
+        before its exception reaches the formatter below. }
+      RenderScope := TGocciaDiagnosticSourceRegistry.Current;
+      if Assigned(RenderScope) then
+        ExpectedPrincipal := RenderScope.Principal
+      else
+        ExpectedPrincipal := Engine.ModuleLoader.DiagnosticScope.Principal;
 
       try
         PushTimeoutScope(tsFile, EngineOptions.Timeout.ValueOr(0));
@@ -906,7 +921,7 @@ begin
       on E: TGocciaThrowValue do
       begin
         Result.ErrorMessage := FormatThrowDetail(E.Value, AEntryPath, Source,
-          False, E.Suggestion);
+          False, ExpectedPrincipal, E.Suggestion);
         Result.FailureKind := sfkScriptError;
       end;
       { The same guest throw, as the bytecode VM delivers it.  Without this
@@ -916,7 +931,7 @@ begin
       on E: EGocciaBytecodeThrow do
       begin
         Result.ErrorMessage := FormatThrowDetail(E.ThrownValue, AEntryPath,
-          Source, False, E.Suggestion);
+          Source, False, ExpectedPrincipal, E.Suggestion);
         Result.FailureKind := sfkScriptError;
       end;
       { Whatever is left is a native error the engine does not model.

--- a/source/app/GocciaSandboxRunner.dpr
+++ b/source/app/GocciaSandboxRunner.dpr
@@ -916,7 +916,7 @@ begin
       on E: EGocciaBytecodeThrow do
       begin
         Result.ErrorMessage := FormatThrowDetail(E.ThrownValue, AEntryPath,
-          Source, False);
+          Source, False, E.Suggestion);
         Result.FailureKind := sfkScriptError;
       end;
       { Whatever is left is a native error the engine does not model.

--- a/source/app/GocciaScriptLoader.dpr
+++ b/source/app/GocciaScriptLoader.dpr
@@ -834,7 +834,7 @@ begin
           else if E is TGocciaThrowValue then
             WriteLn(FormatThrowDetail(TGocciaThrowValue(E).Value, AFileName, ASource, IsColorTerminal, TGocciaThrowValue(E).Suggestion))
           else if E is EGocciaBytecodeThrow then
-            WriteLn(FormatThrowDetail(EGocciaBytecodeThrow(E).ThrownValue, AFileName, ASource, IsColorTerminal))
+            WriteLn(FormatThrowDetail(EGocciaBytecodeThrow(E).ThrownValue, AFileName, ASource, IsColorTerminal, EGocciaBytecodeThrow(E).Suggestion))
           else
             WriteLn('Fatal error: ', E.Message);
         end;

--- a/source/app/GocciaScriptLoader.dpr
+++ b/source/app/GocciaScriptLoader.dpr
@@ -109,6 +109,7 @@ type
     FGlobalFiles: TRepeatableOption;
     FInlineGlobals: TRepeatableOption;
     FLastPaths: TStringList;
+    FLastDiagnosticPrincipal: Int64;
 
     procedure InitializeRuntime(const AEngine: TGocciaEngine);
     procedure InitializeRuntimeWithUnsafeFFI(const AEngine: TGocciaEngine);
@@ -566,6 +567,7 @@ begin
   try
     Engine := CreateEngine(AFileName, ASource, Executor);
     try
+      FLastDiagnosticPrincipal := Engine.ModuleLoader.DiagnosticScope.Principal;
       Engine.SuppressWarnings := GIsWorkerThread or
         IsJsonOutput;
       ConfigureConsole(RuntimeConsole(Engine), ACapture);
@@ -625,6 +627,7 @@ begin
   try
     Engine := CreateEngine(AFileName, ASource, Executor);
     try
+      FLastDiagnosticPrincipal := Engine.ModuleLoader.DiagnosticScope.Principal;
       ConfigureConsole(RuntimeConsole(Engine), ACapture);
       ApplyDataGlobalsToEngine(Engine);
 
@@ -699,6 +702,7 @@ begin
     try
       Engine := CreateEngine(AFileName, nil, Executor);
       try
+        FLastDiagnosticPrincipal := Engine.ModuleLoader.DiagnosticScope.Principal;
         Engine.RetainModule(Module);
         RetainedModule := Module;
         Module := nil;
@@ -786,6 +790,7 @@ var
   MemoryMeasurement: TCLIJSONMemoryMeasurement;
   StartTime: Int64;
 begin
+  FLastDiagnosticPrincipal := 0;
   FillChar(Report, SizeOf(Report), 0);
   Report.ResultValue := nil;
   Report.MemoryStats := DefaultCLIJSONMemoryStats;
@@ -832,9 +837,13 @@ begin
           else if E is TGocciaError then
             WriteLn(FormatHostErrorDiagnostic(TGocciaError(E), IsColorTerminal))
           else if E is TGocciaThrowValue then
-            WriteLn(FormatThrowDetail(TGocciaThrowValue(E).Value, AFileName, ASource, IsColorTerminal, TGocciaThrowValue(E).Suggestion))
+            WriteLn(FormatThrowDetail(TGocciaThrowValue(E).Value, AFileName,
+              ASource, IsColorTerminal, FLastDiagnosticPrincipal,
+              TGocciaThrowValue(E).Suggestion))
           else if E is EGocciaBytecodeThrow then
-            WriteLn(FormatThrowDetail(EGocciaBytecodeThrow(E).ThrownValue, AFileName, ASource, IsColorTerminal, EGocciaBytecodeThrow(E).Suggestion))
+            WriteLn(FormatThrowDetail(EGocciaBytecodeThrow(E).ThrownValue,
+              AFileName, ASource, IsColorTerminal, FLastDiagnosticPrincipal,
+              EGocciaBytecodeThrow(E).Suggestion))
           else
             WriteLn('Fatal error: ', E.Message);
         end;

--- a/source/app/GocciaScriptLoaderBare.dpr
+++ b/source/app/GocciaScriptLoaderBare.dpr
@@ -1228,7 +1228,9 @@ begin
       Exit(OriginalContent);
 
     Result := TGocciaModuleContent.Create(HarnessPrelude + sLineBreak +
-      OriginalContent.Text, OriginalContent.LastModified);
+      OriginalContent.Text, OriginalContent.LastModified,
+      OriginalContent.CanonicalIdentity, OriginalContent.IdentityRequired);
+    OriginalContent.Free;
   except
     OriginalContent.Free;
     raise;
@@ -1631,13 +1633,17 @@ begin
                 on E: EGocciaBytecodeThrow do
                 begin
                   WriteLn(ErrOutput, FormatThrowDetail(E.ThrownValue,
-                    DisplayName, Source, IsColorTerminal, E.Suggestion));
+                    DisplayName, Source, IsColorTerminal,
+                    Engine.ModuleLoader.DiagnosticScope.Principal,
+                    E.Suggestion));
                   Result := 1;
                 end;
                 on E: TGocciaThrowValue do
                 begin
                   WriteLn(ErrOutput, FormatThrowDetail(E.Value, DisplayName,
-                    Source, IsColorTerminal, E.Suggestion));
+                    Source, IsColorTerminal,
+                    Engine.ModuleLoader.DiagnosticScope.Principal,
+                    E.Suggestion));
                   Result := 1;
                 end;
               end;

--- a/source/app/GocciaScriptLoaderBare.dpr
+++ b/source/app/GocciaScriptLoaderBare.dpr
@@ -1631,7 +1631,7 @@ begin
                 on E: EGocciaBytecodeThrow do
                 begin
                   WriteLn(ErrOutput, FormatThrowDetail(E.ThrownValue,
-                    DisplayName, Source, IsColorTerminal));
+                    DisplayName, Source, IsColorTerminal, E.Suggestion));
                   Result := 1;
                 end;
                 on E: TGocciaThrowValue do

--- a/source/app/GocciaScriptLoaderBare.dpr
+++ b/source/app/GocciaScriptLoaderBare.dpr
@@ -1230,7 +1230,6 @@ begin
     Result := TGocciaModuleContent.Create(HarnessPrelude + sLineBreak +
       OriginalContent.Text, OriginalContent.LastModified,
       OriginalContent.CanonicalIdentity, OriginalContent.IdentityRequired);
-    OriginalContent.Free;
   except
     OriginalContent.Free;
     raise;

--- a/source/app/GocciaTestRunner.dpr
+++ b/source/app/GocciaTestRunner.dpr
@@ -45,6 +45,7 @@ uses
   Goccia.ScriptLoader.Globals,
   Goccia.ScriptLoader.Input,
   Goccia.SourcePipeline,
+  Goccia.VM.Exception,
   Goccia.Builtins.TestingLibrary,
   Goccia.Builtins.Testing.Snapshots,
   Goccia.CLI.JSON.Reporter,
@@ -1098,6 +1099,23 @@ begin
             FormatThrowDetail(TGocciaThrowValue(E).Value, AFileName, Source,
               False, TGocciaThrowValue(E).Suggestion));
         end
+        else if E is EGocciaBytecodeThrow then
+        begin
+          { A JS throw that escapes the bytecode VM is the same verdict as the
+            evaluator's TGocciaThrowValue and must render the same way; without
+            this arm it fell through to the bare "Fatal error:" line and lost
+            the location, code frame and suggestion. }
+          if (not GIsWorkerThread) and (not IsJsonOutput) then
+            WriteLn(FormatThrowDetail(EGocciaBytecodeThrow(E).ThrownValue,
+              AFileName, Source, IsColorTerminal,
+              EGocciaBytecodeThrow(E).Suggestion));
+          MarkLoadError(ScriptResult, AFileName,
+            FormatThrowDetail(EGocciaBytecodeThrow(E).ThrownValue, AFileName,
+              Source, False, EGocciaBytecodeThrow(E).Suggestion));
+          Result := MakeEmptyTestResult(ScriptResult,
+            FormatThrowDetail(EGocciaBytecodeThrow(E).ThrownValue, AFileName,
+              Source, False, EGocciaBytecodeThrow(E).Suggestion));
+        end
         else
         begin
           if (not GIsWorkerThread) and (not IsJsonOutput) then
@@ -1140,6 +1158,11 @@ var
   LexStart, CompileStart, CompileEnd, ExecEnd: Int64;
   LexTimeNanoseconds, ParseTimeNanoseconds: Int64;
   SourceText: string;
+  { The file as written. Source itself gains an appended runTests(...) call
+    below, and quoting that in a code frame showed the runner's own epilogue as
+    if the author had written it — a line the interpreted path, which calls
+    runTests directly instead of appending it, never showed. }
+  DiagnosticSource: TStringList;
 begin
   ScriptResult := CreateDefaultScriptResult;
   ResultValue := nil;
@@ -1150,6 +1173,7 @@ begin
     GC.AddTempRoot(ScriptResult);
 
   Source := nil;
+  DiagnosticSource := nil;
   try
     if Assigned(APreloadedSource) then
       Source := APreloadedSource
@@ -1169,6 +1193,8 @@ begin
       end;
     end;
 
+    DiagnosticSource := TStringList.Create;
+    DiagnosticSource.Assign(Source);
     SourceText := StringListToSourceText(Source);
     if Source.Count > 0 then
       SourceText := SourceText + #10;
@@ -1276,12 +1302,29 @@ begin
         else if E is TGocciaThrowValue then
         begin
           if (not GIsWorkerThread) and (not IsJsonOutput) then
-            WriteLn(FormatThrowDetail(TGocciaThrowValue(E).Value, AFileName, Source, IsColorTerminal, TGocciaThrowValue(E).Suggestion));
+            WriteLn(FormatThrowDetail(TGocciaThrowValue(E).Value, AFileName, DiagnosticSource, IsColorTerminal, TGocciaThrowValue(E).Suggestion));
           MarkLoadError(ScriptResult, AFileName,
-            FormatThrowDetail(TGocciaThrowValue(E).Value, AFileName, Source, False, TGocciaThrowValue(E).Suggestion));
+            FormatThrowDetail(TGocciaThrowValue(E).Value, AFileName, DiagnosticSource, False, TGocciaThrowValue(E).Suggestion));
           Result := MakeEmptyTestResult(ScriptResult,
-            FormatThrowDetail(TGocciaThrowValue(E).Value, AFileName, Source,
+            FormatThrowDetail(TGocciaThrowValue(E).Value, AFileName, DiagnosticSource,
               False, TGocciaThrowValue(E).Suggestion));
+        end
+        else if E is EGocciaBytecodeThrow then
+        begin
+          { A JS throw that escapes the bytecode VM is the same verdict as the
+            evaluator's TGocciaThrowValue and must render the same way; without
+            this arm it fell through to the bare "Fatal error:" line and lost
+            the location, code frame and suggestion. }
+          if (not GIsWorkerThread) and (not IsJsonOutput) then
+            WriteLn(FormatThrowDetail(EGocciaBytecodeThrow(E).ThrownValue,
+              AFileName, DiagnosticSource, IsColorTerminal,
+              EGocciaBytecodeThrow(E).Suggestion));
+          MarkLoadError(ScriptResult, AFileName,
+            FormatThrowDetail(EGocciaBytecodeThrow(E).ThrownValue, AFileName,
+              DiagnosticSource, False, EGocciaBytecodeThrow(E).Suggestion));
+          Result := MakeEmptyTestResult(ScriptResult,
+            FormatThrowDetail(EGocciaBytecodeThrow(E).ThrownValue, AFileName,
+              DiagnosticSource, False, EGocciaBytecodeThrow(E).Suggestion));
         end
         else
         begin
@@ -1298,6 +1341,7 @@ begin
       GC.RemoveTempRoot(ResultValue);
     if Assigned(GC) then
       GC.RemoveTempRoot(ScriptResult);
+    DiagnosticSource.Free;
     Source.Free;
   end;
 end;

--- a/source/app/GocciaTestRunner.dpr
+++ b/source/app/GocciaTestRunner.dpr
@@ -1001,11 +1001,14 @@ var
   EngineResult: TGocciaScriptResult;
   GC: TGarbageCollector;
   EngineResultRooted: Boolean;
+  ExpectedPrincipal: Int64;
+  PlainThrowDetail: string;
 begin
   ScriptResult := CreateDefaultScriptResult;
   GC := TGarbageCollector.Instance;
   EngineResult.Result := nil;
   EngineResultRooted := False;
+  ExpectedPrincipal := 0;
   if Assigned(GC) then
     GC.AddTempRoot(ScriptResult);
 
@@ -1034,6 +1037,7 @@ begin
       try
         Engine := CreateEngine(AFileName, Source, Executor);
         try
+          ExpectedPrincipal := Engine.ModuleLoader.DiagnosticScope.Principal;
           Engine.RegisterGlobal('__gocciaTestRunnerMode',
             TGocciaStringLiteralValue.Create('interpreted'));
           if FSilent.Present or GIsWorkerThread or IsJsonOutput then
@@ -1091,13 +1095,17 @@ begin
         end
         else if E is TGocciaThrowValue then
         begin
+          // Render the plain diagnostic once and reuse it for both result
+          // fields; only the console copy differs (it may be colored).
+          PlainThrowDetail := FormatThrowDetail(TGocciaThrowValue(E).Value,
+            AFileName, Source, False, ExpectedPrincipal,
+            TGocciaThrowValue(E).Suggestion);
           if (not GIsWorkerThread) and (not IsJsonOutput) then
-            WriteLn(FormatThrowDetail(TGocciaThrowValue(E).Value, AFileName, Source, IsColorTerminal, TGocciaThrowValue(E).Suggestion));
-          MarkLoadError(ScriptResult, AFileName,
-            FormatThrowDetail(TGocciaThrowValue(E).Value, AFileName, Source, False, TGocciaThrowValue(E).Suggestion));
-          Result := MakeEmptyTestResult(ScriptResult,
-            FormatThrowDetail(TGocciaThrowValue(E).Value, AFileName, Source,
-              False, TGocciaThrowValue(E).Suggestion));
+            WriteLn(FormatThrowDetail(TGocciaThrowValue(E).Value, AFileName,
+              Source, IsColorTerminal, ExpectedPrincipal,
+              TGocciaThrowValue(E).Suggestion));
+          MarkLoadError(ScriptResult, AFileName, PlainThrowDetail);
+          Result := MakeEmptyTestResult(ScriptResult, PlainThrowDetail);
         end
         else if E is EGocciaBytecodeThrow then
         begin
@@ -1105,16 +1113,16 @@ begin
             evaluator's TGocciaThrowValue and must render the same way; without
             this arm it fell through to the bare "Fatal error:" line and lost
             the location, code frame and suggestion. }
+          PlainThrowDetail := FormatThrowDetail(EGocciaBytecodeThrow(E).ThrownValue,
+            AFileName, Source, False, ExpectedPrincipal,
+            EGocciaBytecodeThrow(E).Suggestion);
           if (not GIsWorkerThread) and (not IsJsonOutput) then
             WriteLn(FormatThrowDetail(EGocciaBytecodeThrow(E).ThrownValue,
               AFileName, Source, IsColorTerminal,
+              ExpectedPrincipal,
               EGocciaBytecodeThrow(E).Suggestion));
-          MarkLoadError(ScriptResult, AFileName,
-            FormatThrowDetail(EGocciaBytecodeThrow(E).ThrownValue, AFileName,
-              Source, False, EGocciaBytecodeThrow(E).Suggestion));
-          Result := MakeEmptyTestResult(ScriptResult,
-            FormatThrowDetail(EGocciaBytecodeThrow(E).ThrownValue, AFileName,
-              Source, False, EGocciaBytecodeThrow(E).Suggestion));
+          MarkLoadError(ScriptResult, AFileName, PlainThrowDetail);
+          Result := MakeEmptyTestResult(ScriptResult, PlainThrowDetail);
         end
         else
         begin
@@ -1155,9 +1163,11 @@ var
   ResultValue: TGocciaValue;
   GC: TGarbageCollector;
   ResultValueRooted: Boolean;
+  ExpectedPrincipal: Int64;
   LexStart, CompileStart, CompileEnd, ExecEnd: Int64;
   LexTimeNanoseconds, ParseTimeNanoseconds: Int64;
   SourceText: string;
+  PlainThrowDetail: string;
   { The file as written. Source itself gains an appended runTests(...) call
     below, and quoting that in a code frame showed the runner's own epilogue as
     if the author had written it — a line the interpreted path, which calls
@@ -1168,6 +1178,7 @@ begin
   ResultValue := nil;
   GC := TGarbageCollector.Instance;
   ResultValueRooted := False;
+  ExpectedPrincipal := 0;
   SourcePipelineResult := nil;
   if Assigned(GC) then
     GC.AddTempRoot(ScriptResult);
@@ -1209,6 +1220,7 @@ begin
       try
         Engine := CreateEngine(AFileName, Source, Executor);
         try
+          ExpectedPrincipal := Engine.ModuleLoader.DiagnosticScope.Principal;
           Engine.RegisterGlobal('__gocciaTestRunnerMode',
             TGocciaStringLiteralValue.Create('bytecode'));
           if FSilent.Present or GIsWorkerThread or IsJsonOutput then
@@ -1302,12 +1314,14 @@ begin
         else if E is TGocciaThrowValue then
         begin
           if (not GIsWorkerThread) and (not IsJsonOutput) then
-            WriteLn(FormatThrowDetail(TGocciaThrowValue(E).Value, AFileName, DiagnosticSource, IsColorTerminal, TGocciaThrowValue(E).Suggestion));
-          MarkLoadError(ScriptResult, AFileName,
-            FormatThrowDetail(TGocciaThrowValue(E).Value, AFileName, DiagnosticSource, False, TGocciaThrowValue(E).Suggestion));
-          Result := MakeEmptyTestResult(ScriptResult,
-            FormatThrowDetail(TGocciaThrowValue(E).Value, AFileName, DiagnosticSource,
-              False, TGocciaThrowValue(E).Suggestion));
+            WriteLn(FormatThrowDetail(TGocciaThrowValue(E).Value, AFileName,
+              DiagnosticSource, IsColorTerminal, ExpectedPrincipal,
+              TGocciaThrowValue(E).Suggestion));
+          PlainThrowDetail := FormatThrowDetail(TGocciaThrowValue(E).Value,
+            AFileName, DiagnosticSource, False, ExpectedPrincipal,
+            TGocciaThrowValue(E).Suggestion);
+          MarkLoadError(ScriptResult, AFileName, PlainThrowDetail);
+          Result := MakeEmptyTestResult(ScriptResult, PlainThrowDetail);
         end
         else if E is EGocciaBytecodeThrow then
         begin
@@ -1318,13 +1332,13 @@ begin
           if (not GIsWorkerThread) and (not IsJsonOutput) then
             WriteLn(FormatThrowDetail(EGocciaBytecodeThrow(E).ThrownValue,
               AFileName, DiagnosticSource, IsColorTerminal,
+              ExpectedPrincipal,
               EGocciaBytecodeThrow(E).Suggestion));
-          MarkLoadError(ScriptResult, AFileName,
-            FormatThrowDetail(EGocciaBytecodeThrow(E).ThrownValue, AFileName,
-              DiagnosticSource, False, EGocciaBytecodeThrow(E).Suggestion));
-          Result := MakeEmptyTestResult(ScriptResult,
-            FormatThrowDetail(EGocciaBytecodeThrow(E).ThrownValue, AFileName,
-              DiagnosticSource, False, EGocciaBytecodeThrow(E).Suggestion));
+          PlainThrowDetail := FormatThrowDetail(EGocciaBytecodeThrow(E).ThrownValue,
+            AFileName, DiagnosticSource, False, ExpectedPrincipal,
+            EGocciaBytecodeThrow(E).Suggestion);
+          MarkLoadError(ScriptResult, AFileName, PlainThrowDetail);
+          Result := MakeEmptyTestResult(ScriptResult, PlainThrowDetail);
         end
         else
         begin

--- a/source/units/Goccia.AST.Expressions.pas
+++ b/source/units/Goccia.AST.Expressions.pas
@@ -891,9 +891,10 @@ type
 { Describes a call/new callee for the shared "not callable"/"not a constructor"
   diagnostics. The tree-walk evaluator calls this at the throw site; the
   bytecode compiler calls it once per call site and stores the result on the
-  function template, so the VM produces the same text without the AST. }
-function CalleeDescriptorFor(
-  const ACallee: TGocciaExpression): TGocciaCalleeDescriptor;
+  function template, so the VM produces the same text without the AST. AKind
+  carries a tagged-template site through to the shared suggestion. }
+function CalleeDescriptorFor(const ACallee: TGocciaExpression;
+  const AKind: TGocciaCalleeKind = cckPlain): TGocciaCalleeDescriptor;
 
 implementation
 
@@ -960,16 +961,20 @@ begin
       TGocciaPrivateMemberExpression(AExpression).ObjectExpr).Cover(Result);
 end;
 
-function CalleeDescriptorFor(
-  const ACallee: TGocciaExpression): TGocciaCalleeDescriptor;
+function CalleeDescriptorFor(const ACallee: TGocciaExpression;
+  const AKind: TGocciaCalleeKind = cckPlain): TGocciaCalleeDescriptor;
 var
   Member: TGocciaMemberExpression;
 begin
   Result := EmptyCalleeDescriptor;
+  Result.Kind := AKind;
   if not Assigned(ACallee) then
     Exit;
   Result.CalleeText := NormalizeCalleeText(FullCalleeSpan(ACallee).Text);
-  if ACallee is TGocciaMemberExpression then
+  // A tagged template's fault is "the tag is not callable", not a missing
+  // method, so its member shape is not carried — the shared suggestion keys on
+  // Kind alone.
+  if (AKind = cckPlain) and (ACallee is TGocciaMemberExpression) then
   begin
     Member := TGocciaMemberExpression(ACallee);
     // Only a non-computed member has a statically known method name, and only

--- a/source/units/Goccia.AST.Expressions.pas
+++ b/source/units/Goccia.AST.Expressions.pas
@@ -13,6 +13,7 @@ uses
   OrderedStringMap,
 
   Goccia.AST.Node,
+  Goccia.Error.CallDiagnostics,
   Goccia.Evaluator.Context,
   Goccia.Modules,
   Goccia.Scope.BindingMap,
@@ -887,6 +888,13 @@ type
 
   TGocciaDecoratorList = array of TGocciaExpression;
 
+{ Describes a call/new callee for the shared "not callable"/"not a constructor"
+  diagnostics. The tree-walk evaluator calls this at the throw site; the
+  bytecode compiler calls it once per call site and stores the result on the
+  function template, so the VM produces the same text without the AST. }
+function CalleeDescriptorFor(
+  const ACallee: TGocciaExpression): TGocciaCalleeDescriptor;
+
 implementation
 
 uses
@@ -934,6 +942,44 @@ begin
     Result := GNextTemplateSiteId;
   finally
     CriticalSectionLeave(GTemplateSiteIdLock);
+  end;
+end;
+
+{ A member expression's own span starts at the '.' or '[' — the parser hangs
+  the accessor off the object expression rather than re-spanning the pair — so
+  naming `obj.method` back to the author means covering the object's span too,
+  recursively for a chain like `o.a.b`. }
+function FullCalleeSpan(const AExpression: TGocciaExpression): TGocciaSourceSpan;
+begin
+  Result := AExpression.Span;
+  if AExpression is TGocciaMemberExpression then
+    Result := FullCalleeSpan(
+      TGocciaMemberExpression(AExpression).ObjectExpr).Cover(Result)
+  else if AExpression is TGocciaPrivateMemberExpression then
+    Result := FullCalleeSpan(
+      TGocciaPrivateMemberExpression(AExpression).ObjectExpr).Cover(Result);
+end;
+
+function CalleeDescriptorFor(
+  const ACallee: TGocciaExpression): TGocciaCalleeDescriptor;
+var
+  Member: TGocciaMemberExpression;
+begin
+  Result := EmptyCalleeDescriptor;
+  if not Assigned(ACallee) then
+    Exit;
+  Result.CalleeText := NormalizeCalleeText(FullCalleeSpan(ACallee).Text);
+  if ACallee is TGocciaMemberExpression then
+  begin
+    Member := TGocciaMemberExpression(ACallee);
+    // Only a non-computed member has a statically known method name, and only
+    // an identifier object can be named back to the author verbatim.
+    if not Member.Computed then
+    begin
+      Result.PropertyName := Member.PropertyName;
+      if Member.ObjectExpr is TGocciaIdentifierExpression then
+        Result.ObjectText := TGocciaIdentifierExpression(Member.ObjectExpr).Name;
+    end;
   end;
 end;
 

--- a/source/units/Goccia.Application.pas
+++ b/source/units/Goccia.Application.pas
@@ -48,9 +48,11 @@ begin
   if AException is TGocciaError then
     WriteLn(FormatHostErrorDiagnostic(TGocciaError(AException), UseColor))
   else if AException is TGocciaThrowValue then
-    WriteLn(FormatThrowDetail(TGocciaThrowValue(AException).Value, '', nil, UseColor, TGocciaThrowValue(AException).Suggestion))
+    WriteLn(FormatThrowDetail(TGocciaThrowValue(AException).Value, '', nil,
+      UseColor, 0, TGocciaThrowValue(AException).Suggestion))
   else if AException is EGocciaBytecodeThrow then
-    WriteLn(FormatThrowDetail(EGocciaBytecodeThrow(AException).ThrownValue, '', nil, UseColor))
+    WriteLn(FormatThrowDetail(EGocciaBytecodeThrow(AException).ThrownValue,
+      '', nil, UseColor, 0))
   else
     WriteLn('Error: ', AException.Message);
 end;

--- a/source/units/Goccia.Builtins.Benchmark.pas
+++ b/source/units/Goccia.Builtins.Benchmark.pas
@@ -12,6 +12,7 @@ uses
 
   Goccia.Arguments.Collection,
   Goccia.Builtins.Base,
+  Goccia.Diagnostics.SourceRegistry,
   Goccia.Error.ThrowErrorCallback,
   Goccia.GarbageCollector,
   Goccia.Modules,
@@ -219,13 +220,21 @@ begin
 end;
 
 function BenchmarkExceptionMessage(const AException: Exception): string;
+var
+  Scope: TGocciaDiagnosticSourceScope;
+  ExpectedPrincipal: Int64;
 begin
+  Scope := TGocciaDiagnosticSourceRegistry.Current;
+  if Assigned(Scope) then
+    ExpectedPrincipal := Scope.Principal
+  else
+    ExpectedPrincipal := 0;
   if AException is TGocciaThrowValue then
     Exit(FormatThrowDetail(TGocciaThrowValue(AException).Value, '', nil, False,
-      TGocciaThrowValue(AException).Suggestion));
+      ExpectedPrincipal, TGocciaThrowValue(AException).Suggestion));
   if AException is EGocciaBytecodeThrow then
     Exit(FormatThrowDetail(EGocciaBytecodeThrow(AException).ThrownValue, '',
-      nil, False));
+      nil, False, ExpectedPrincipal));
   Result := AException.Message;
 end;
 

--- a/source/units/Goccia.Builtins.Globals.pas
+++ b/source/units/Goccia.Builtins.Globals.pas
@@ -453,7 +453,7 @@ begin
     under construction needs a temp root. }
   InitializeTempRoot(ResultRoot);
   try
-    Result := TGocciaObjectValue.Create(AProto);
+    Result := TGocciaErrorObjectValue.Create(AProto);
     AddTempRootIfNeeded(ResultRoot, Result);
     Result.HasErrorData := True;
     MessageText := '';
@@ -471,6 +471,7 @@ begin
     if (TGocciaCallStack.Instance <> nil) then
       Result.ErrorStack :=
         TGocciaCallStack.Instance.CaptureStackTrace(AName, MessageText, 1);
+    AttachErrorSourceProvenance(Result, 1);
 
     if AArgs.Length > 1 then
       InstallErrorCause(Result, AArgs.GetElement(1));
@@ -648,7 +649,7 @@ begin
   InitializeTempRoot(IteratorRoot);
   InitializeTempRoot(ErrorsArrayRoot);
 
-  Result := TGocciaObjectValue.Create(AProto);
+  Result := TGocciaErrorObjectValue.Create(AProto);
   AddTempRootIfNeeded(ResultRoot, Result);
   try
     Result.HasErrorData := True;
@@ -656,6 +657,7 @@ begin
       Result.ErrorStack :=
         TGocciaCallStack.Instance.CaptureStackTrace(AGGREGATE_ERROR_NAME,
           Message, 1);
+    AttachErrorSourceProvenance(Result, 1);
 
     if (AArgs.Length > 1) and not (AArgs.GetElement(1) is TGocciaUndefinedLiteralValue) then
       Result.DefineProperty(PROP_MESSAGE, TGocciaPropertyDescriptorData.Create(
@@ -736,13 +738,14 @@ begin
     fills. }
   InitializeTempRoot(ResultRoot);
   try
-  Result := TGocciaObjectValue.Create(AProto);
+  Result := TGocciaErrorObjectValue.Create(AProto);
   AddTempRootIfNeeded(ResultRoot, Result);
   Result.HasErrorData := True;
   if (TGocciaCallStack.Instance <> nil) then
     Result.ErrorStack :=
       TGocciaCallStack.Instance.CaptureStackTrace(SUPPRESSED_ERROR_NAME,
         Message, 1);
+  AttachErrorSourceProvenance(Result, 1);
 
   if (AArgs.Length > 2) and not (AArgs.GetElement(2) is TGocciaUndefinedLiteralValue) then
     Result.DefineProperty(PROP_MESSAGE, TGocciaPropertyDescriptorData.Create(

--- a/source/units/Goccia.Bytecode.Chunk.pas
+++ b/source/units/Goccia.Bytecode.Chunk.pas
@@ -10,7 +10,8 @@ uses
   CriticalSections,
   OrderedStringMap,
 
-  Goccia.Bytecode.Debug;
+  Goccia.Bytecode.Debug,
+  Goccia.Error.CallDiagnostics;
 
 type
   TGocciaBytecodeConstantKind = (
@@ -154,6 +155,22 @@ type
   end;
   PGocciaProtoReadCacheEntry = ^TGocciaProtoReadCacheEntry;
 
+  // One call/construct site's callee, as the author wrote it. Recorded by the
+  // compiler at emit time and read by the VM only on the throw path, so a
+  // non-callable callee is named identically in both execution modes (see
+  // Goccia.Error.CallDiagnostics).
+  TGocciaCallSiteEntry = record
+    PC: UInt32;
+    Callee: TGocciaCalleeDescriptor;
+    // The call expression's own position, which is where the tree-walk
+    // evaluator points a "not a function" diagnostic. The instruction line map
+    // resolves to the enclosing statement instead, so the position is carried
+    // here rather than read back off the debug info.
+    Line: Integer;
+    Column: Integer;
+    Recorded: Boolean;
+  end;
+
   TGocciaFunctionTemplate = class
   private
     FName: string;
@@ -217,6 +234,11 @@ type
     FPropertyReadCaches: array of TGocciaPropertyReadCacheEntry;
     FProtoReadCaches: array of TGocciaProtoReadCacheEntry;
     FPropertyReadSlotCount: Integer;
+    // Runtime-only, appended in ascending PC order by the compiler and never
+    // serialised to .gbc — a module loaded from binary bytecode simply falls
+    // back to the runtime-type-name form of the "is not a function" message.
+    FCallSites: array of TGocciaCallSiteEntry;
+    FCallSiteCount: Integer;
     function PropertyReadSlot(const AConstIndex: Integer): Integer;
     function GetFunctionCount: Integer;
   public
@@ -226,6 +248,17 @@ type
     function EmitInstruction(const AInstruction: UInt64;
       const AForceWide: Boolean = False): Integer;
     procedure PatchInstruction(const AIndex: Integer; const AInstruction: UInt64);
+    { Records the callee of the call/construct instruction that starts at APC.
+      APC must be the value CodeCount had immediately before the instruction
+      was emitted, which is what the VM sees as the instruction's start IP
+      (an OP_WIDE prefix included). Call sites must be recorded in ascending
+      PC order. }
+    procedure AddCallSite(const APC: UInt32;
+      const ACallee: TGocciaCalleeDescriptor; const ALine, AColumn: Integer);
+    { The call site recorded for the instruction starting at APC. Result.Recorded
+      is False when none was (binary-loaded bytecode, or a call the compiler
+      emits itself rather than from a source call expression). }
+    function CallSiteAt(const APC: UInt32): TGocciaCallSiteEntry;
     function AddConstantNil: UInt16;
     function AddConstantBoolean(const AValue: Boolean): UInt16;
     function AddConstantInteger(const AValue: Int64): UInt16;
@@ -455,6 +488,43 @@ begin
   FCode[FCodeCount] := UInt32(AInstruction and $FFFFFFFF);
   Result := FCodeCount;
   Inc(FCodeCount);
+end;
+
+procedure TGocciaFunctionTemplate.AddCallSite(const APC: UInt32;
+  const ACallee: TGocciaCalleeDescriptor; const ALine, AColumn: Integer);
+begin
+  if FCallSiteCount >= Length(FCallSites) then
+    SetLength(FCallSites, FCallSiteCount * 2 + 8);
+  FCallSites[FCallSiteCount].PC := APC;
+  FCallSites[FCallSiteCount].Callee := ACallee;
+  FCallSites[FCallSiteCount].Line := ALine;
+  FCallSites[FCallSiteCount].Column := AColumn;
+  FCallSites[FCallSiteCount].Recorded := True;
+  Inc(FCallSiteCount);
+end;
+
+function TGocciaFunctionTemplate.CallSiteAt(
+  const APC: UInt32): TGocciaCallSiteEntry;
+var
+  Low, High, Middle: Integer;
+begin
+  Result.PC := APC;
+  Result.Callee := EmptyCalleeDescriptor;
+  Result.Line := 0;
+  Result.Column := 0;
+  Result.Recorded := False;
+  Low := 0;
+  High := FCallSiteCount - 1;
+  while Low <= High do
+  begin
+    Middle := Low + (High - Low) div 2;
+    if FCallSites[Middle].PC = APC then
+      Exit(FCallSites[Middle])
+    else if FCallSites[Middle].PC < APC then
+      Low := Middle + 1
+    else
+      High := Middle - 1;
+  end;
 end;
 
 procedure TGocciaFunctionTemplate.PatchInstruction(const AIndex: Integer;

--- a/source/units/Goccia.CallStack.pas
+++ b/source/units/Goccia.CallStack.pas
@@ -64,6 +64,13 @@ type
       tree-walk evaluator's per-call frame would have carried. }
     procedure SetTopFrameLocation(const AFilePath: string;
       const ALine, AColumn: Integer);
+    { Snapshot / restore the whole top frame, for a caller that stamps the
+      executing frame's location for the duration of a nested operation (an
+      interpreter `new` whose native constructor captures a trace) and must
+      leave it exactly as it found it — otherwise the stamp leaks into the next
+      statement's diagnostics. }
+    function TryGetTopFrame(out AFrame: TGocciaCallFrame): Boolean;
+    procedure SetTopFrame(const AFrame: TGocciaCallFrame);
     procedure Pop;
 
     // Registers the resolver used to materialise deferred template frames.
@@ -74,6 +81,14 @@ type
       AErrorName and AMessage form the first line: "ErrorName: message".
       ASkipTop omits the topmost N frames (e.g. 1 to skip the Error constructor). }
     function CaptureStackTrace(const AErrorName, AMessage: string; const ASkipTop: Integer = 0): string;
+
+    { The resolved source location of the frame CaptureStackTrace would render
+      as the top (after skipping ASkipTop frames) — the engine's own record of
+      where a throw originated. Used to stamp trusted provenance on an error
+      object at creation, so a code frame is bound to real frames and never to
+      a guest-forged `.stack` string. False when there is no such frame. }
+    function TryGetTopThrowLocation(const ASkipTop: Integer;
+      out AFilePath: string; out ALine, AColumn: Integer): Boolean;
 
     property Count: Integer read FCount;
   end;
@@ -160,6 +175,19 @@ begin
   end;
 end;
 
+function TGocciaCallStack.TryGetTopFrame(out AFrame: TGocciaCallFrame): Boolean;
+begin
+  Result := FCount > 0;
+  if Result then
+    AFrame := FFrames[FCount - 1];
+end;
+
+procedure TGocciaCallStack.SetTopFrame(const AFrame: TGocciaCallFrame);
+begin
+  if FCount > 0 then
+    FFrames[FCount - 1] := AFrame;
+end;
+
 procedure TGocciaCallStack.Pop;
 begin
   if FCount > 0 then
@@ -169,6 +197,39 @@ end;
 class procedure TGocciaCallStack.SetTemplateResolver(const AResolver: TGocciaTemplateTraceResolver);
 begin
   FTemplateResolver := AResolver;
+end;
+
+function TGocciaCallStack.TryGetTopThrowLocation(const ASkipTop: Integer;
+  out AFilePath: string; out ALine, AColumn: Integer): Boolean;
+var
+  TopIndex: Integer;
+  Frame: TGocciaCallFrame;
+  ResolvedName, ResolvedPath: string;
+begin
+  AFilePath := '';
+  ALine := 0;
+  AColumn := 0;
+  Result := False;
+  if ASkipTop > 0 then
+    TopIndex := FCount - ASkipTop - 1
+  else
+    TopIndex := FCount - 1;
+  if (TopIndex < 0) or (TopIndex >= FCount) then
+    Exit;
+  Frame := FFrames[TopIndex];
+  // Same resolution CaptureStackTrace uses for a rendered frame.
+  if Assigned(Frame.Template) and Assigned(FTemplateResolver) then
+  begin
+    FTemplateResolver(Frame.Template, ResolvedName, ResolvedPath);
+    if Frame.HasExplicitLocation or (ResolvedPath = '') then
+      ResolvedPath := Frame.FilePath;
+  end
+  else
+    ResolvedPath := Frame.FilePath;
+  AFilePath := ResolvedPath;
+  ALine := Frame.Line;
+  AColumn := Frame.Column;
+  Result := True;
 end;
 
 function TGocciaCallStack.CaptureStackTrace(const AErrorName, AMessage: string; const ASkipTop: Integer = 0): string;

--- a/source/units/Goccia.CallStack.pas
+++ b/source/units/Goccia.CallStack.pas
@@ -24,6 +24,10 @@ type
     FilePath: string;
     Line: Integer;
     Column: Integer;
+    // Set by SetTopFrameLocation: FilePath then names the source the position
+    // was taken from and wins over the template's own source file, which is
+    // what makes a cross-module throw report the module it happened in.
+    HasExplicitLocation: Boolean;
   end;
 
   TGocciaCallFrameArray = array of TGocciaCallFrame;
@@ -50,6 +54,16 @@ type
     // Hot-path push for the bytecode VM: stores the template pointer plus a
     // module-path fallback, deferring all string work to CaptureStackTrace.
     procedure PushTemplate(const ATemplate: Pointer; const AFallbackPath: string);
+    { Stamps the currently executing frame with a source position.
+
+      A deferred bytecode frame is pushed without one (ADR 0074 keeps the hot
+      call path free of debug-map lookups), so its trace reads `file:0:0` and
+      the diagnostic renderer has no line to show a code frame for. The VM
+      calls this on its throw paths only — where a debug-map lookup is already
+      paid for — so a runtime TypeError carries the same file:line:column the
+      tree-walk evaluator's per-call frame would have carried. }
+    procedure SetTopFrameLocation(const AFilePath: string;
+      const ALine, AColumn: Integer);
     procedure Pop;
 
     // Registers the resolver used to materialise deferred template frames.
@@ -115,6 +129,7 @@ begin
   FFrames[FCount].FilePath := AFilePath;
   FFrames[FCount].Line := ALine;
   FFrames[FCount].Column := AColumn;
+  FFrames[FCount].HasExplicitLocation := False;
   Inc(FCount);
 end;
 
@@ -127,7 +142,22 @@ begin
   FFrames[FCount].FilePath := AFallbackPath;
   FFrames[FCount].Line := 0;
   FFrames[FCount].Column := 0;
+  FFrames[FCount].HasExplicitLocation := False;
   Inc(FCount);
+end;
+
+procedure TGocciaCallStack.SetTopFrameLocation(const AFilePath: string;
+  const ALine, AColumn: Integer);
+begin
+  if FCount = 0 then
+    Exit;
+  FFrames[FCount - 1].Line := ALine;
+  FFrames[FCount - 1].Column := AColumn;
+  if AFilePath <> '' then
+  begin
+    FFrames[FCount - 1].FilePath := AFilePath;
+    FFrames[FCount - 1].HasExplicitLocation := True;
+  end;
 end;
 
 procedure TGocciaCallStack.Pop;
@@ -168,7 +198,10 @@ begin
     if Assigned(Frame.Template) and Assigned(FTemplateResolver) then
     begin
       FTemplateResolver(Frame.Template, ResolvedName, ResolvedPath);
-      if ResolvedPath = '' then
+      // An explicitly stamped location names the source the position came
+      // from, which for a cross-module throw is not the frame template's own
+      // source file.
+      if Frame.HasExplicitLocation or (ResolvedPath = '') then
         ResolvedPath := Frame.FilePath;
     end
     else

--- a/source/units/Goccia.Compiler.Expressions.pas
+++ b/source/units/Goccia.Compiler.Expressions.pas
@@ -157,6 +157,7 @@ uses
   Goccia.Constants.ConstructorNames,
   Goccia.Constants.ErrorNames,
   Goccia.Constants.PropertyNames,
+  Goccia.Error.CallDiagnostics,
   Goccia.Error.Messages,
   Goccia.Keywords.Reserved,
   Goccia.Modules,
@@ -3858,10 +3859,11 @@ end;
   immediately before the emission: the key is the instruction's start PC,
   which is CodeCount at this moment. }
 procedure RecordCallSite(const ACtx: TGocciaCompilationContext;
-  const ACallSite: TGocciaExpression; const ACallee: TGocciaExpression);
+  const ACallSite: TGocciaExpression; const ACallee: TGocciaExpression;
+  const AKind: TGocciaCalleeKind = cckPlain);
 begin
   ACtx.Template.AddCallSite(UInt32(CurrentCodePosition(ACtx)),
-    CalleeDescriptorFor(ACallee), ACallSite.Line, ACallSite.Column);
+    CalleeDescriptorFor(ACallee, AKind), ACallSite.Line, ACallSite.Column);
 end;
 
 function TryCompileWithIdentifierCall(const ACtx: TGocciaCompilationContext;
@@ -4363,6 +4365,7 @@ begin
     begin
       ArgsReg := ACtx.Scope.AllocateRegister;
       CompileSpreadArgsArray(ACtx, AExpr, ArgsReg);
+      RecordCallSite(ACtx, AExpr, AExpr.Callee);
       EmitInstruction(ACtx, EncodeABC(OP_CALL_METHOD, BaseReg, ArgsReg, 1));
       ACtx.Scope.FreeRegister;
     end
@@ -4370,6 +4373,7 @@ begin
     begin
       for I := 0 to ArgCount - 1 do
         ACtx.CompileExpression(AExpr.Arguments[I], ACtx.Scope.AllocateRegister);
+      RecordCallSite(ACtx, AExpr, AExpr.Callee);
       EmitInstruction(ACtx, EncodeABC(OP_CALL_METHOD, BaseReg, UInt16(ArgCount), 0));
       for I := 0 to ArgCount - 1 do
         ACtx.Scope.FreeRegister;
@@ -5583,6 +5587,9 @@ begin
   for I := 0 to AExpr.Expressions.Count - 1 do
     ACtx.CompileExpression(AExpr.Expressions[I], ACtx.Scope.AllocateRegister);
 
+  // Record the tag as the callee so a non-callable tag reports the tag by name
+  // and the shared tag-must-be-callable suggestion, matching the evaluator.
+  RecordCallSite(ACtx, AExpr, AExpr.Tag, cckTaggedTemplate);
   if IsMethodCall then
     EmitInstruction(ACtx, EncodeABC(OP_CALL_METHOD, BaseReg, UInt16(ArgCount),
       TailFlag))

--- a/source/units/Goccia.Compiler.Expressions.pas
+++ b/source/units/Goccia.Compiler.Expressions.pas
@@ -825,7 +825,7 @@ begin
   EmitInstruction(ACtx, EncodeABx(OP_GET_GLOBAL, CondReg,
     ACtx.Template.AddConstantString(REFERENCE_ERROR_NAME)));
   EmitInstruction(ACtx, EncodeABx(OP_LOAD_CONST, ArgReg,
-    ACtx.Template.AddConstantString(AExpr.Name + ' is not defined')));
+    ACtx.Template.AddConstantString(Format(SErrorUndefinedVariable, [AExpr.Name]))));
   EmitInstruction(ACtx, EncodeABC(OP_CONSTRUCT, CondReg, CondReg, 1));
   EmitInstruction(ACtx, EncodeABC(OP_THROW, CondReg, 0, 0));
 
@@ -2564,7 +2564,7 @@ begin
   EmitInstruction(ACtx, EncodeABx(OP_GET_GLOBAL, ErrorReg,
     ACtx.Template.AddConstantString(REFERENCE_ERROR_NAME)));
   EmitInstruction(ACtx, EncodeABx(OP_LOAD_CONST, MessageReg,
-    ACtx.Template.AddConstantString(AExpr.Name + ' is not defined')));
+    ACtx.Template.AddConstantString(Format(SErrorUndefinedVariable, [AExpr.Name]))));
   EmitInstruction(ACtx, EncodeABC(OP_CONSTRUCT, ErrorReg, ErrorReg, 1));
   EmitInstruction(ACtx, EncodeABC(OP_THROW, ErrorReg, 0, 0));
   ACtx.Scope.FreeRegister;
@@ -3850,6 +3850,20 @@ begin
   CompileSpreadArgsArrayFromList(ACtx, AExpr.Arguments, AArrayReg);
 end;
 
+{ Records the callee expression as the author wrote it against the call or
+  construct instruction about to be emitted, so that when the VM finds the
+  callee is not callable it can report "obj.method is not a function" rather
+  than "undefined is not a function" — the same text the tree-walk evaluator
+  builds from the AST (Goccia.Error.CallDiagnostics). Must be called
+  immediately before the emission: the key is the instruction's start PC,
+  which is CodeCount at this moment. }
+procedure RecordCallSite(const ACtx: TGocciaCompilationContext;
+  const ACallSite: TGocciaExpression; const ACallee: TGocciaExpression);
+begin
+  ACtx.Template.AddCallSite(UInt32(CurrentCodePosition(ACtx)),
+    CalleeDescriptorFor(ACallee), ACallSite.Line, ACallSite.Column);
+end;
+
 function TryCompileWithIdentifierCall(const ACtx: TGocciaCompilationContext;
   const AExpr: TGocciaCallExpression; const ADest: UInt16;
   const AArgCount: Integer; const AUseSpread: Boolean;
@@ -3880,6 +3894,7 @@ var
     begin
       ArgsReg := ACtx.Scope.AllocateRegister;
       CompileSpreadArgsArray(ACtx, AExpr, ArgsReg);
+      RecordCallSite(ACtx, AExpr, AExpr.Callee);
       if AIsMethodCall then
         EmitInstruction(ACtx, EncodeABC(OP_CALL_METHOD, BaseReg, ArgsReg,
           CALL_FLAG_SPREAD or TailFlag))
@@ -3893,6 +3908,7 @@ var
       for ArgIndex := 0 to AArgCount - 1 do
         ACtx.CompileExpression(AExpr.Arguments[ArgIndex],
           ACtx.Scope.AllocateRegister);
+      RecordCallSite(ACtx, AExpr, AExpr.Callee);
       if AIsMethodCall then
         EmitInstruction(ACtx, EncodeABC(OP_CALL_METHOD, BaseReg,
           UInt16(AArgCount), TailFlag))
@@ -3984,6 +4000,7 @@ var
     begin
       ArgsReg := ACtx.Scope.AllocateRegister;
       CompileSpreadArgsArray(ACtx, AExpr, ArgsReg);
+      RecordCallSite(ACtx, AExpr, AExpr.Callee);
       if AIsMethodCall then
         EmitInstruction(ACtx, EncodeABC(OP_CALL_METHOD, BaseReg, ArgsReg, 1))
       else
@@ -3996,6 +4013,7 @@ var
       for ArgIndex := 0 to ArgCount - 1 do
         ACtx.CompileExpression(AExpr.Arguments[ArgIndex],
           ACtx.Scope.AllocateRegister);
+      RecordCallSite(ACtx, AExpr, AExpr.Callee);
       if AIsMethodCall then
         EmitInstruction(ACtx, EncodeABC(OP_CALL_METHOD, BaseReg,
           UInt16(ArgCount), 0))
@@ -4430,6 +4448,7 @@ begin
     begin
       ArgsReg := ACtx.Scope.AllocateRegister;
       CompileSpreadArgsArray(ACtx, AExpr, ArgsReg);
+      RecordCallSite(ACtx, AExpr, AExpr.Callee);
       EmitInstruction(ACtx, EncodeABC(OP_CALL_METHOD, BaseReg, ArgsReg,
         CALL_FLAG_SPREAD or MethodTailFlag));
       ACtx.Scope.FreeRegister;
@@ -4438,6 +4457,7 @@ begin
     begin
       for I := 0 to ArgCount - 1 do
         ACtx.CompileExpression(AExpr.Arguments[I], ACtx.Scope.AllocateRegister);
+      RecordCallSite(ACtx, AExpr, AExpr.Callee);
       EmitInstruction(ACtx, EncodeABC(OP_CALL_METHOD, BaseReg, UInt16(ArgCount),
         MethodTailFlag));
       for I := 0 to ArgCount - 1 do
@@ -4507,6 +4527,7 @@ begin
       begin
         ArgsReg := ACtx.Scope.AllocateRegister;
         CompileSpreadArgsArray(ACtx, AExpr, ArgsReg);
+        RecordCallSite(ACtx, AExpr, AExpr.Callee);
         EmitInstruction(ACtx, EncodeABC(OP_CALL_METHOD, BaseReg, ArgsReg, 1));
         ACtx.Scope.FreeRegister;
       end
@@ -4514,6 +4535,7 @@ begin
       begin
         for I := 0 to ArgCount - 1 do
           ACtx.CompileExpression(AExpr.Arguments[I], ACtx.Scope.AllocateRegister);
+        RecordCallSite(ACtx, AExpr, AExpr.Callee);
         EmitInstruction(ACtx, EncodeABC(OP_CALL_METHOD, BaseReg, UInt16(ArgCount), 0));
         for I := 0 to ArgCount - 1 do
           ACtx.Scope.FreeRegister;
@@ -4560,6 +4582,7 @@ begin
       begin
         ArgsReg := ACtx.Scope.AllocateRegister;
         CompileSpreadArgsArray(ACtx, AExpr, ArgsReg);
+        RecordCallSite(ACtx, AExpr, AExpr.Callee);
         EmitInstruction(ACtx, EncodeABC(OP_CALL_METHOD, BaseReg, ArgsReg,
           CALL_FLAG_SPREAD or MethodTailFlag));
         ACtx.Scope.FreeRegister;
@@ -4568,6 +4591,7 @@ begin
       begin
         for I := 0 to ArgCount - 1 do
           ACtx.CompileExpression(AExpr.Arguments[I], ACtx.Scope.AllocateRegister);
+        RecordCallSite(ACtx, AExpr, AExpr.Callee);
         EmitInstruction(ACtx, EncodeABC(OP_CALL_METHOD, BaseReg, UInt16(ArgCount),
           MethodTailFlag));
         for I := 0 to ArgCount - 1 do
@@ -4613,6 +4637,7 @@ begin
     begin
       ArgsReg := ACtx.Scope.AllocateRegister;
       CompileSpreadArgsArray(ACtx, AExpr, ArgsReg);
+      RecordCallSite(ACtx, AExpr, AExpr.Callee);
       EmitInstruction(ACtx, EncodeABC(OP_CALL, BaseReg, ArgsReg,
         SpreadCallFlags(ACtx, AExpr, CurrentCodePosition(ACtx)) or MethodTailFlag));
       ACtx.Scope.FreeRegister;
@@ -4621,6 +4646,7 @@ begin
     begin
       for I := 0 to ArgCount - 1 do
         ACtx.CompileExpression(AExpr.Arguments[I], ACtx.Scope.AllocateRegister);
+      RecordCallSite(ACtx, AExpr, AExpr.Callee);
       EmitInstruction(ACtx, EncodeABC(OP_CALL, BaseReg, UInt16(ArgCount),
         CallFlags(ACtx, AExpr, CurrentCodePosition(ACtx)) or MethodTailFlag));
       for I := 0 to ArgCount - 1 do
@@ -5690,6 +5716,7 @@ begin
   begin
     ArgsReg := ACtx.Scope.AllocateRegister;
     CompileSpreadArgsArrayFromList(ACtx, AExpr.Arguments, ArgsReg);
+    RecordCallSite(ACtx, AExpr, AExpr.Callee);
     EmitInstruction(ACtx, EncodeABC(OP_CONSTRUCT_SPREAD, ADest, CtorReg,
       ArgsReg));
     ACtx.Scope.FreeRegister; // ArgsReg
@@ -5701,6 +5728,7 @@ begin
       raise Exception.Create('Compiler error: too many constructor arguments (>65535)');
     for I := 0 to ArgCount - 1 do
       ACtx.CompileExpression(AExpr.Arguments[I], ACtx.Scope.AllocateRegister);
+    RecordCallSite(ACtx, AExpr, AExpr.Callee);
     EmitInstruction(ACtx, EncodeABC(OP_CONSTRUCT, ADest, CtorReg, UInt16(ArgCount)));
     for I := 0 to ArgCount - 1 do
       ACtx.Scope.FreeRegister;
@@ -6048,7 +6076,7 @@ begin
     EmitInstruction(ACtx, EncodeABx(OP_GET_GLOBAL, CondReg,
       ACtx.Template.AddConstantString(REFERENCE_ERROR_NAME)));
     EmitInstruction(ACtx, EncodeABx(OP_LOAD_CONST, ArgReg,
-      ACtx.Template.AddConstantString(AExpr.Name + ' is not defined')));
+      ACtx.Template.AddConstantString(Format(SErrorUndefinedVariable, [AExpr.Name]))));
     EmitInstruction(ACtx, EncodeABC(OP_CONSTRUCT, CondReg, CondReg, 1));
     EmitInstruction(ACtx, EncodeABC(OP_THROW, CondReg, 0, 0));
     PatchJumpTarget(ACtx, OkJump);

--- a/source/units/Goccia.Diagnostics.SourceRegistry.pas
+++ b/source/units/Goccia.Diagnostics.SourceRegistry.pas
@@ -150,9 +150,12 @@ threadvar
   GActiveScope: TGocciaDiagnosticSourceScope;
 
 var
-  // Process-monotonic principal counter. Guarded by an interlocked increment
-  // so engines on separate threads never collide on a principal value.
+  // Process-monotonic principal counter. Guarded by a critical section rather
+  // than InterLockedIncrement64 because FPC 3.2.2 only declares the 64-bit
+  // interlocked helpers under CPU64, and CI also builds i386-win32; a principal
+  // is minted once per module load, so the lock cost is irrelevant.
   GPrincipalCounter: Int64 = 0;
+  GPrincipalLock: TRTLCriticalSection;
 
 type
   TUnicodeStringAllocationHeader = packed record
@@ -164,7 +167,13 @@ type
 
 function NextPrincipal: Int64;
 begin
-  Result := InterLockedIncrement64(GPrincipalCounter);
+  EnterCriticalSection(GPrincipalLock);
+  try
+    Inc(GPrincipalCounter);
+    Result := GPrincipalCounter;
+  finally
+    LeaveCriticalSection(GPrincipalLock);
+  end;
 end;
 
 function DiagnosticStringRetainedBytes(const AText: string): Int64;
@@ -435,5 +444,11 @@ class function TGocciaDiagnosticSourceRegistry.Current:
 begin
   Result := GActiveScope;
 end;
+
+initialization
+  InitCriticalSection(GPrincipalLock);
+
+finalization
+  DoneCriticalSection(GPrincipalLock);
 
 end.

--- a/source/units/Goccia.Diagnostics.SourceRegistry.pas
+++ b/source/units/Goccia.Diagnostics.SourceRegistry.pas
@@ -1,0 +1,439 @@
+{ Engine-owned store of source the engine itself parsed, for capturing a
+  runtime-error code frame at the moment the error is created.
+
+  Security model (audited; see docs/module-resolution.md "Runtime code frames"):
+
+  PRINCIPAL / OWNERSHIP. Each engine's module loader owns exactly one scope
+  (TGocciaDiagnosticSourceScope), whose durable process-monotonic `Principal` is
+  its identity (a value that is never reused, unlike a freed-then-reallocated
+  pointer). Every registered source is tagged guest-owned or host-owned at LOAD
+  time by the caller — ownership travels with the importing module, it is not
+  inferred from ambient state at capture: a virtual/host-injected module is
+  host-owned, every import it initiates is transitively host-owned, and everything
+  the guest imports itself is guest-owned. Entries are keyed on CANONICAL FILE
+  IDENTITY supplied by the content provider from its already-open file handle, so
+  a symlink, junction, hardlink, or case-variant spelling of a registered file
+  resolves to the same entry instead of minting a second, differently-owned
+  copy; since the host preloads before the guest runs, the host registration
+  wins and a guest cannot shadow a host file with a guest-owned copy.
+
+  A code-frame excerpt is captured onto an error ONLY from a GUEST-owned source
+  in the scope ACTIVE at capture time, AND is only rendered when the context
+  doing the rendering is authorized for the excerpt's stamped principal
+  (Goccia.Error.Detail enforces an explicit renderer principal = the error's).
+  Both gates must pass, so neither a capture-time miss nor a
+  render-time cross-principal formatting (a child error printed while its parent
+  is resumed) can leak host or sibling/parent source. The error still shows the
+  fault's location line; only the source excerpt is withheld across a boundary.
+
+  EXECUTING-ENGINE BINDING. Registration always targets the loader's OWN scope,
+  so an engine's loads can never land in another coexisting engine's scope.
+  Capture targets the ACTIVE scope, which the engine activates around its own
+  execution and restores on exit — so a ShadowRealm child that stays alive while
+  its parent resumes never captures into the parent's errors, and teardown out
+  of creation order is safe (a scope is freed by its owning loader, never popped
+  by position).
+
+  BUDGETS. Retained source is charged against the GC's --max-memory budget
+  (TryReserveExternalBytes) and bounded per scope; a source over the per-module
+  cap, or one that would exceed the scope's aggregate budget, is not retained
+  (the frame degrades to location-only). A captured excerpt is bounded in both
+  line count and per-line width, so a minified one-line module cannot copy an
+  unbounded string per error.
+
+  Threading: the active-scope pointer is a threadvar; scopes are owned and freed
+  by their loaders (per thread), so no cross-thread sharing occurs. }
+
+unit Goccia.Diagnostics.SourceRegistry;
+
+{$I Goccia.inc}
+
+interface
+
+uses
+  Classes,
+  Generics.Collections,
+
+  OrderedStringMap;
+
+const
+  { Largest single source retained for code frames. Above this a module
+    contributes no excerpt — bounded, safe degradation. }
+  GOCCIA_DIAGNOSTIC_SOURCE_CAP_BYTES = 256 * 1024;
+  { Largest total source one scope retains. Beyond it, further modules are not
+    retained, so a program importing many modules cannot accumulate unbounded
+    diagnostic copies. Charged against --max-memory as it grows. }
+  GOCCIA_DIAGNOSTIC_SCOPE_CAP_BYTES = 4 * 1024 * 1024;
+  { Bounds on a captured excerpt so one line cannot approach the source cap. }
+  GOCCIA_DIAGNOSTIC_EXCERPT_MAX_LINE_BYTES = 512;
+
+type
+  TGocciaDiagnosticSourceEntry = class
+  public
+    Lines: TStringList;
+    IsGuest: Boolean;
+    Bytes: Int64;
+    destructor Destroy; override;
+  end;
+
+  TGocciaDiagnosticSourceScope = class
+  private
+    // path -> entry (owned). One split per module at load.
+    FEntries: TOrderedStringMap<TGocciaDiagnosticSourceEntry>;
+    FOwned: TObjectList<TGocciaDiagnosticSourceEntry>;
+    FRetainedBytes: Int64;
+    FReservedBytes: Int64;
+    FIdentityResolutionFailed: Boolean;
+    // Durable, process-monotonic identity of this scope. Unlike a scope
+    // pointer it is never reused after the scope is freed, so an excerpt
+    // stamped with a scope's principal can never be mistaken for a later
+    // scope that happened to be allocated at the same address.
+    FPrincipal: Int64;
+  protected
+    { Deterministic allocation-failure seam used by the registry transaction
+      test. Production leaves it empty; a test subclass raises after an index
+      insertion to prove rollback removes every partial commit and charge. }
+    procedure AfterIndexCommit(const AIndex: Integer); virtual;
+  public
+    constructor Create;
+    destructor Destroy; override;
+    { Durable identity token for render-time principal enforcement. }
+    property Principal: Int64 read FPrincipal;
+    property RetainedBytes: Int64 read FRetainedBytes;
+    { Register APath's source text for later code-frame capture. AIsHost tags
+      the source host-owned (never handed to a guest in a frame) vs guest-owned.
+      Ownership is decided by the CALLER at load time (a virtual/host-injected
+      module or an import inheriting a host-owned importer), never inferred from
+      ambient state at capture. Keyed on canonical file identity so aliases of
+      an already-registered file resolve to the same entry rather than minting a
+      second, differently-owned copy. }
+    procedure Register(const APath, AText: string; const AIsHost: Boolean;
+      const ACanonicalIdentity: string = '';
+      const AIdentityRequired: Boolean = False);
+    { Copies the [ALine-ABefore .. ALine+AAfter] window of APath's source into
+      AWindow (cleared first), each line truncated to the per-line byte bound,
+      and sets AFirstLine to the window's first absolute line number. Returns
+      True only when APath is a GUEST-owned source in this scope. }
+    function TryGetGuestWindow(const APath: string; const ALine, ABefore,
+      AAfter: Integer; const AWindow: TStringList;
+      out AFirstLine: Integer): Boolean;
+  end;
+
+  TGocciaDiagnosticSourceRegistry = class
+  public
+    { Make AScope the active capture target, returning the previous active
+      scope; restore it with Deactivate. The engine wraps its own execution in
+      this pair so capture always targets the executing engine's scope. }
+    class function Activate(const AScope: TGocciaDiagnosticSourceScope):
+      TGocciaDiagnosticSourceScope;
+    class procedure Deactivate(
+      const APrevious: TGocciaDiagnosticSourceScope);
+    { The scope currently executing, or nil. Capture uses this. }
+    class function Current: TGocciaDiagnosticSourceScope;
+  end;
+
+{ Bytes retained by one non-empty UTF-16 string allocation, including the
+  runtime header and terminating null code unit. Empty strings have no
+  allocation and retain zero bytes. }
+function DiagnosticStringRetainedBytes(const AText: string): Int64;
+
+implementation
+
+uses
+  SysUtils,
+
+  TextSemantics,
+
+  Goccia.GarbageCollector;
+
+threadvar
+  GActiveScope: TGocciaDiagnosticSourceScope;
+
+var
+  // Process-monotonic principal counter. Guarded by an interlocked increment
+  // so engines on separate threads never collide on a principal value.
+  GPrincipalCounter: Int64 = 0;
+
+type
+  TUnicodeStringAllocationHeader = packed record
+    CodePage: Word;
+    ElementSize: Word;
+    ReferenceCount: LongInt;
+    Length: SizeInt;
+  end;
+
+function NextPrincipal: Int64;
+begin
+  Result := InterLockedIncrement64(GPrincipalCounter);
+end;
+
+function DiagnosticStringRetainedBytes(const AText: string): Int64;
+begin
+  if AText = '' then
+    Exit(0);
+  Result := SizeOf(TUnicodeStringAllocationHeader) +
+    Int64(Length(AText) + 1) * SizeOf(Char);
+end;
+
+function SourceEntryRetainedBytes(
+  const AEntry: TGocciaDiagnosticSourceEntry): Int64;
+var
+  I: Integer;
+begin
+  Result := AEntry.InstanceSize + AEntry.Lines.InstanceSize +
+    Int64(AEntry.Lines.Capacity) * (SizeOf(Pointer) + SizeOf(TObject));
+  for I := 0 to AEntry.Lines.Count - 1 do
+    Inc(Result, DiagnosticStringRetainedBytes(AEntry.Lines[I]));
+end;
+
+{ Longest prefix whose retained UTF-16 allocation, including its string header,
+  is <= AMaxBytes. A supplementary code point is never split between its two
+  surrogate code units. }
+function TruncateToRetainedBytes(const AText: string;
+  const AMaxBytes: Integer): string;
+var
+  MaximumUnits: Integer;
+begin
+  if (AText = '') or
+     (AMaxBytes <= SizeOf(TUnicodeStringAllocationHeader)) then
+    Exit('');
+  MaximumUnits :=
+    (AMaxBytes - SizeOf(TUnicodeStringAllocationHeader)) div SizeOf(Char) - 1;
+  if MaximumUnits <= 0 then
+    Exit('');
+  if MaximumUnits >= Length(AText) then
+    Exit(AText);
+  if (MaximumUnits > 0) and
+     (Word(AText[MaximumUnits]) >= $D800) and
+     (Word(AText[MaximumUnits]) <= $DBFF) then
+    Dec(MaximumUnits);
+  Result := Copy(AText, 1, MaximumUnits);
+end;
+
+{ TGocciaDiagnosticSourceEntry }
+
+destructor TGocciaDiagnosticSourceEntry.Destroy;
+begin
+  Lines.Free;
+  inherited Destroy;
+end;
+
+{ TGocciaDiagnosticSourceScope }
+
+constructor TGocciaDiagnosticSourceScope.Create;
+begin
+  inherited Create;
+  FEntries := TOrderedStringMap<TGocciaDiagnosticSourceEntry>.Create;
+  FOwned := TObjectList<TGocciaDiagnosticSourceEntry>.Create(True);
+  FPrincipal := NextPrincipal;
+end;
+
+destructor TGocciaDiagnosticSourceScope.Destroy;
+var
+  GC: TGarbageCollector;
+begin
+  FEntries.Free;
+  FOwned.Free;
+  // Release the whole scope's charged bytes back to the memory budget.
+  if FReservedBytes > 0 then
+  begin
+    GC := TGarbageCollector.Instance;
+    if Assigned(GC) then
+      GC.ReleaseExternalBytes(FReservedBytes);
+    FReservedBytes := 0;
+  end;
+  inherited Destroy;
+end;
+
+procedure TGocciaDiagnosticSourceScope.Register(const APath, AText: string;
+  const AIsHost: Boolean; const ACanonicalIdentity: string;
+  const AIdentityRequired: Boolean);
+var
+  Entry: TGocciaDiagnosticSourceEntry;
+  Existing: TGocciaDiagnosticSourceEntry;
+  Canonical, Expanded: string;
+  Size: Int64;
+  GC: TGarbageCollector;
+  Reserved: Boolean;
+  CanonicalAdded, LiteralAdded, ExpandedAdded: Boolean;
+begin
+  if APath = '' then
+    Exit;
+
+  { A filesystem provider that could not identify the already-open file must not
+    mint a path key. One unresolved file also disables source lookup for this
+    scope: without an identity there is no safe way to prove that an earlier or
+    later spelling is not an alias of the unresolved host file. }
+  if AIdentityRequired and (ACanonicalIdentity = '') then
+  begin
+    FIdentityResolutionFailed := True;
+    Exit;
+  end;
+
+  if ACanonicalIdentity <> '' then
+    Canonical := ACanonicalIdentity
+  else
+    Canonical := '#path:' + ExpandFileName(APath);
+  // One registration per canonical identity: a later load under an alias finds
+  // this entry and cannot mint a guest-owned copy. Ownership is monotonic: a
+  // host enrollment upgrades an existing guest entry to host-owned, while a
+  // guest load can never downgrade one.
+  if FEntries.TryGetValue(Canonical, Existing) then
+  begin
+    if AIsHost then
+      Existing.IsGuest := False;
+    Exit;
+  end;
+
+  // Build the complete retained representation before checking either cap.
+  // Many short lines retain separate UTF-16 strings and pointer slots, so the
+  // content's code-unit or UTF-8 length is not the amount this registry holds.
+  Entry := TGocciaDiagnosticSourceEntry.Create;
+  try
+    Entry.Lines := CreateECMAScriptSourceLines(AText);
+  except
+    Entry.Free;
+    raise;
+  end;
+  Entry.IsGuest := not AIsHost;
+  Size := SourceEntryRetainedBytes(Entry);
+  Entry.Bytes := Size;
+  if (Size > GOCCIA_DIAGNOSTIC_SOURCE_CAP_BYTES) or
+     (FRetainedBytes + Size > GOCCIA_DIAGNOSTIC_SCOPE_CAP_BYTES) then
+  begin
+    Entry.Free;
+    Exit;
+  end;
+
+  GC := TGarbageCollector.Instance;
+  Reserved := False;
+  if Assigned(GC) then
+  begin
+    if not GC.TryReserveExternalBytes(Size) then
+    begin
+      Entry.Free;
+      Exit;
+    end;
+    Reserved := True;
+  end;
+
+  CanonicalAdded := False;
+  LiteralAdded := False;
+  ExpandedAdded := False;
+  try
+    // Key under the canonical identity plus the literal and expanded spellings,
+    // so a capture lookup resolves whether the frame path arrives canonical,
+    // relative, or absolute. All aliases point at the one owned entry (FOwned
+    // holds it once); ownership is fixed on the first (host-wins) registration.
+    FEntries.Add(Canonical, Entry);
+    CanonicalAdded := True;
+    AfterIndexCommit(1);
+    if (APath <> Canonical) and (not FEntries.ContainsKey(APath)) then
+    begin
+      FEntries.AddOrSetValue(APath, Entry);
+      LiteralAdded := True;
+      AfterIndexCommit(2);
+    end;
+    Expanded := ExpandFileName(APath);
+    if (Expanded <> Canonical) and (Expanded <> APath) and
+       (not FEntries.ContainsKey(Expanded)) then
+    begin
+      FEntries.AddOrSetValue(Expanded, Entry);
+      ExpandedAdded := True;
+      AfterIndexCommit(3);
+    end;
+
+    { Ownership transfers only after every index exists. FOwned.Add is the final
+      allocating operation; on failure the indexes and reservation roll back and
+      Entry remains owned by this frame. }
+    FOwned.Add(Entry);
+    Inc(FRetainedBytes, Size);
+    if Reserved then
+      Inc(FReservedBytes, Size);
+    Entry := nil;
+  except
+    if ExpandedAdded then
+      FEntries.Remove(Expanded);
+    if LiteralAdded then
+      FEntries.Remove(APath);
+    if CanonicalAdded then
+      FEntries.Remove(Canonical);
+    if Reserved then
+      GC.ReleaseExternalBytes(Size);
+    Entry.Free;
+    raise;
+  end;
+end;
+
+procedure TGocciaDiagnosticSourceScope.AfterIndexCommit(const AIndex: Integer);
+begin
+end;
+
+function TGocciaDiagnosticSourceScope.TryGetGuestWindow(const APath: string;
+  const ALine, ABefore, AAfter: Integer; const AWindow: TStringList;
+  out AFirstLine: Integer): Boolean;
+var
+  Entry: TGocciaDiagnosticSourceEntry;
+  Expanded: string;
+  FirstLine, LastLine, I: Integer;
+begin
+  AWindow.Clear;
+  AFirstLine := 0;
+  Result := False;
+  if (APath = '') or (ALine <= 0) then
+    Exit;
+  if FIdentityResolutionFailed then
+    Exit;
+  // Resolve by literal spelling first (the common case; the frame path matches
+  // how the module was registered), then by canonical identity so a symlinked or
+  // case-variant frame path still finds the one owned entry.
+  if not FEntries.TryGetValue(APath, Entry) then
+  begin
+    Expanded := ExpandFileName(APath);
+    if (Expanded = APath) or (not FEntries.TryGetValue(Expanded, Entry)) then
+      Exit;
+  end;
+  // Cross-principal exclusion: host-owned source is never handed to a guest.
+  if not Entry.IsGuest then
+    Exit;
+  if ALine > Entry.Lines.Count then
+    Exit;
+  FirstLine := ALine - ABefore;
+  if FirstLine < 1 then
+    FirstLine := 1;
+  LastLine := ALine + AAfter;
+  if LastLine > Entry.Lines.Count then
+    LastLine := Entry.Lines.Count;
+  for I := FirstLine to LastLine do
+    // Per-line width bound: a minified/one-line module cannot copy a huge string
+    // into the excerpt (and cannot disclose a whole line at once). Bounded on
+    // actual retained UTF-16 bytes, including the per-string header, and cut on
+    // a code-point boundary so truncation never splits a surrogate pair.
+    AWindow.Add(TruncateToRetainedBytes(Entry.Lines[I - 1],
+      GOCCIA_DIAGNOSTIC_EXCERPT_MAX_LINE_BYTES));
+  AFirstLine := FirstLine;
+  Result := True;
+end;
+
+{ TGocciaDiagnosticSourceRegistry }
+
+class function TGocciaDiagnosticSourceRegistry.Activate(
+  const AScope: TGocciaDiagnosticSourceScope): TGocciaDiagnosticSourceScope;
+begin
+  Result := GActiveScope;
+  GActiveScope := AScope;
+end;
+
+class procedure TGocciaDiagnosticSourceRegistry.Deactivate(
+  const APrevious: TGocciaDiagnosticSourceScope);
+begin
+  GActiveScope := APrevious;
+end;
+
+class function TGocciaDiagnosticSourceRegistry.Current:
+  TGocciaDiagnosticSourceScope;
+begin
+  Result := GActiveScope;
+end;
+
+end.

--- a/source/units/Goccia.DisposalTracker.pas
+++ b/source/units/Goccia.DisposalTracker.pas
@@ -171,10 +171,13 @@ begin
     while it fills. }
   InitializeTempRoot(ErrorRoot);
   try
+  // Build the automatic SuppressedError as the error subclass so its genuine
+  // throw provenance (the double-fault site) is captured and its code frame
+  // renders, matching an explicit `throw`.
   if Assigned(SuppressedErrorProto) then
-    ErrorObj := TGocciaObjectValue.Create(SuppressedErrorProto)
+    ErrorObj := TGocciaErrorObjectValue.Create(SuppressedErrorProto)
   else
-    ErrorObj := TGocciaObjectValue.Create(GetErrorProto);
+    ErrorObj := TGocciaErrorObjectValue.Create(GetErrorProto);
   AddTempRootIfNeeded(ErrorRoot, ErrorObj);
   ErrorObj.HasErrorData := True;
   ErrorObj.DefineProperty(PROP_NAME,
@@ -202,6 +205,7 @@ begin
     ErrorObj.AssignProperty(PROP_STACK,
       TGocciaStringLiteralValue.Create(
         TGocciaCallStack.Instance.CaptureStackTrace(SUPPRESSED_ERROR_NAME, AMessage)));
+  AttachErrorSourceProvenance(ErrorObj, 0);
 
   Result := ErrorObj;
   finally

--- a/source/units/Goccia.Engine.pas
+++ b/source/units/Goccia.Engine.pas
@@ -38,6 +38,7 @@ uses
   Goccia.Builtins.Temporal,
   Goccia.CapabilityAudit,
   Goccia.Constants,
+  Goccia.Diagnostics.SourceRegistry,
   Goccia.Evaluator,
   Goccia.Evaluator.Context,
   Goccia.ExecutionContext,
@@ -621,7 +622,10 @@ var
   ExportValue: TGocciaValue;
   Module: TGocciaModule;
 begin
-  Module := FModuleLoader.LoadModule(APath, FSourcePath);
+  // Host enrollment is durable on the root module/address. Every static,
+  // dynamic or deferred import from it inherits host ownership regardless of
+  // when the import resolves.
+  Module := FModuleLoader.LoadHostModule(APath, FSourcePath);
   ExportNames := Module.GetExportNames;
   for ExportName in ExportNames do
     if Module.TryGetExportValue(ExportName, ExportValue) then
@@ -764,7 +768,9 @@ var
   DefaultValue: TGocciaValue;
   Module: TGocciaModule;
 begin
-  Module := FModuleLoader.LoadModule(APath, FSourcePath);
+  // The manifest module is host-provided config. Durable ownership also covers
+  // imports its exported code may initiate after manifest evaluation returns.
+  Module := FModuleLoader.LoadHostModule(APath, FSourcePath);
   if not Module.TryGetExportValue(KEYWORD_DEFAULT, DefaultValue) then
     raise EArgumentException.Create(
       'Virtual modules manifest module must have a default export.');
@@ -1634,8 +1640,13 @@ end;
 function TGocciaEngine.ActivateRealmExecutionContext:
   TGocciaExecutionContextScope;
 begin
+  // Switching into this engine's realm (ShadowRealm evaluate/importValue/wrapped
+  // function) also makes this engine's diagnostic scope the active capture
+  // target, so a code frame captured while this engine runs comes from its own
+  // source — never the caller engine's — and is restored when the scope pops.
   Result := TGocciaExecutionContextScope.Create(
-    CreateExecutionContext(FRealm, FInterpreter.GlobalScope, FSourcePath));
+    CreateExecutionContext(FRealm, FInterpreter.GlobalScope, FSourcePath),
+    FModuleLoader.DiagnosticScope);
 end;
 
 procedure TGocciaEngine.RegisterGocciaScriptGlobal;
@@ -2379,19 +2390,28 @@ function TGocciaEngine.RunModuleForSourceType(
   const AFileName: string): TGocciaValue;
 var
   ModuleScope: TGocciaScope;
+  PrevScope: TGocciaDiagnosticSourceScope;
 begin
-  if FSourceType = stModule then
-  begin
-    ModuleScope := FInterpreter.GlobalScope.CreateChild(skModule,
-      'Module:' + AFileName);
-    ModuleScope.ThisValue := TGocciaUndefinedLiteralValue.UndefinedValue;
-    ModuleScope.NonStrictMode := False;
-    ModuleScope.ArgumentsObjectEnabled :=
-      cfArgumentsObject in FCompatibility;
-    Result := RunModuleInScope(AModule, ModuleScope);
-  end
-  else
-    Result := RunModule(AModule);
+  // Bytecode execution entry (the interpreter path uses Execute). Bind
+  // code-frame capture to this engine's own scope for the run, as Execute does.
+  PrevScope := TGocciaDiagnosticSourceRegistry.Activate(
+    FModuleLoader.DiagnosticScope);
+  try
+    if FSourceType = stModule then
+    begin
+      ModuleScope := FInterpreter.GlobalScope.CreateChild(skModule,
+        'Module:' + AFileName);
+      ModuleScope.ThisValue := TGocciaUndefinedLiteralValue.UndefinedValue;
+      ModuleScope.NonStrictMode := False;
+      ModuleScope.ArgumentsObjectEnabled :=
+        cfArgumentsObject in FCompatibility;
+      Result := RunModuleInScope(AModule, ModuleScope);
+    end
+    else
+      Result := RunModule(AModule);
+  finally
+    TGocciaDiagnosticSourceRegistry.Deactivate(PrevScope);
+  end;
 end;
 
 procedure TGocciaEngine.DiscardRuntimePending;
@@ -2413,6 +2433,7 @@ begin
     raise EInvalidOperation.CreateFmt(
       'Host module "%s" conflicts with a configured virtual module.',
       [AName]);
+  AModule.IsHostOwned := True;
   FInterpreter.GlobalModules.AddOrSetValue(AName, AModule);
 end;
 
@@ -2461,7 +2482,19 @@ var
   SavedVMGlobalScope: TGocciaScope;
   GC: TGarbageCollector;
   FloatingPointState: TGocciaFloatingPointState;
+  PrevDiagScope: TGocciaDiagnosticSourceScope;
 begin
+  // Bind runtime-error code-frame capture to THIS engine's source scope for the
+  // duration of its execution, restoring the caller's on exit. The previous
+  // scope is a per-invocation LOCAL (never an instance field): a host callback
+  // that re-enters this same engine's Execute must not overwrite an outer
+  // invocation's saved scope, or the outer restore would dangle after the
+  // engine is freed (use-after-free). Capture targets the active scope, so a
+  // nested (sandbox/ShadowRealm) child, a parent that resumes while a child
+  // stays alive, and a later sequential run each capture only their own guest
+  // source. See Goccia.Diagnostics.SourceRegistry.
+  PrevDiagScope := TGocciaDiagnosticSourceRegistry.Activate(
+    FModuleLoader.DiagnosticScope);
   EnterGocciaFloatingPointScope(FloatingPointState);
   try
   FillChar(FLastTiming, SizeOf(FLastTiming), 0);
@@ -2667,6 +2700,7 @@ begin
   Result := FLastTiming;
   finally
     LeaveGocciaFloatingPointScope(FloatingPointState);
+    TGocciaDiagnosticSourceRegistry.Deactivate(PrevDiagScope);
   end;
 end;
 
@@ -2680,7 +2714,10 @@ function TGocciaEngine.ExecuteProgram(const AProgram: TGocciaProgram): TGocciaVa
 var
   GC: TGarbageCollector;
   FloatingPointState: TGocciaFloatingPointState;
+  PrevScope: TGocciaDiagnosticSourceScope;
 begin
+  PrevScope := TGocciaDiagnosticSourceRegistry.Activate(
+    FModuleLoader.DiagnosticScope);
   EnterGocciaFloatingPointScope(FloatingPointState);
   try
     Result := FExecutor.ExecuteProgram(AProgram);
@@ -2695,6 +2732,7 @@ begin
     end;
   finally
     LeaveGocciaFloatingPointScope(FloatingPointState);
+    TGocciaDiagnosticSourceRegistry.Deactivate(PrevScope);
   end;
 end;
 

--- a/source/units/Goccia.Engine.pas
+++ b/source/units/Goccia.Engine.pas
@@ -2749,6 +2749,14 @@ begin
     WriteLn(Format('  --> %s:%d:%d', [FSourcePath, Warning.Line,
       Warning.Column]));
   end;
+  { Standard output is block-buffered when it is not a terminal, and the hosts
+    that print these warnings also write diagnostics to the unbuffered
+    ErrOutput. With both redirected to one file, whatever is still sitting in
+    the stdout buffer surfaces after the next stderr write — which is how a
+    warning's `--> <path>` line came out cut mid-path with other output spliced
+    into it. Flushing at the end of the block keeps a warning whole. }
+  if APipelineResult.WarningCount > 0 then
+    Flush(Output);
 end;
 
 function TGocciaEngine.SpeciesGetter(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;

--- a/source/units/Goccia.Error.CallDiagnostics.pas
+++ b/source/units/Goccia.Error.CallDiagnostics.pas
@@ -1,0 +1,206 @@
+unit Goccia.Error.CallDiagnostics;
+
+{$I Goccia.inc}
+
+{ Shared "value is not callable / not a constructor" diagnostics.
+
+  Both executors have to name the callee the way the author wrote it — the
+  tree-walk evaluator reads it off the call expression's source span, the
+  bytecode VM off the per-call-site descriptor its compiler records. Building
+  the message and the suggestion here is what keeps the two modes textually
+  identical: neither executor formats these strings itself. }
+
+interface
+
+type
+  { A call site's callee, described well enough to build the same diagnostic
+    from either executor.
+
+    CalleeText is the callee expression's source text, normalized (see
+    NormalizeCalleeText); '' when it is unavailable or unreasonably long, in
+    which case the diagnostics fall back to the runtime type name.
+
+    ObjectText and PropertyName are filled only for a non-computed member
+    callee whose object is a plain identifier (`obj.method()`), which is the
+    one shape that supports the "does not have method" suggestion. }
+  TGocciaCalleeDescriptor = record
+    CalleeText: string;
+    ObjectText: string;
+    PropertyName: string;
+  end;
+
+{ Longest callee text carried into a diagnostic. A callee spanning more than
+  this is a multi-line chain whose text would swamp the message, so it is
+  dropped and the type-name form is used instead. The limit is shared so both
+  executors drop the same texts. }
+const
+  GOCCIA_MAX_CALLEE_TEXT_LENGTH = 96;
+
+function EmptyCalleeDescriptor: TGocciaCalleeDescriptor;
+
+{ Collapses interior whitespace runs (including newlines) to single spaces and
+  trims the ends, then drops the text entirely when it is longer than
+  GOCCIA_MAX_CALLEE_TEXT_LENGTH. }
+function NormalizeCalleeText(const AText: string): string;
+
+{ True when AText is a single plain identifier — the shape whose suggestion
+  reads "'name' is of type '...' and cannot be called as a function". }
+function IsPlainIdentifierText(const AText: string): Boolean;
+
+{ "obj.method is not a function" / "<type> is not a function". }
+function NotCallableMessage(const ADescriptor: TGocciaCalleeDescriptor;
+  const ACalleeTypeName: string): string;
+
+{ The matching suggestion line. AReceiverTypeName is the type of the member
+  callee's receiver and is ignored for the non-member shapes. }
+function NotCallableSuggestion(const ADescriptor: TGocciaCalleeDescriptor;
+  const AReceiverTypeName, ACalleeTypeName: string): string;
+
+{ "obj.Klass is not a constructor" / "<type> is not a constructor". }
+function NotConstructorMessage(const ADescriptor: TGocciaCalleeDescriptor;
+  const ACalleeTypeName: string): string;
+
+{ The matching suggestion line for a failed `new`. }
+function NotConstructorSuggestion(const ADescriptor: TGocciaCalleeDescriptor;
+  const ACalleeTypeName: string): string;
+
+implementation
+
+uses
+  SysUtils,
+
+  Goccia.Error.Messages,
+  Goccia.Error.Suggestions;
+
+resourcestring
+  SSuggestMemberNotMethod =
+    '''%s'' is of type ''%s'' which does not have method ''%s''';
+  SSuggestIdentifierNotCallable =
+    '''%s'' is of type ''%s'' and cannot be called as a function';
+  SSuggestIdentifierNotConstructor =
+    '''%s'' is of type ''%s'' and cannot be used with ''new''';
+  SSuggestValueNotConstructor =
+    'values of type ''%s'' cannot be used with ''new''';
+
+function EmptyCalleeDescriptor: TGocciaCalleeDescriptor;
+begin
+  Result.CalleeText := '';
+  Result.ObjectText := '';
+  Result.PropertyName := '';
+end;
+
+function NormalizeCalleeText(const AText: string): string;
+var
+  I, Written: Integer;
+  PendingSpace: Boolean;
+  Ch: Char;
+begin
+  Result := '';
+  // Collapsing only ever shrinks the text, so anything this far over the limit
+  // cannot come back under it — and walking it would be wasted compile time,
+  // since every call site in a program runs through here.
+  if Length(AText) > GOCCIA_MAX_CALLEE_TEXT_LENGTH * 8 then
+    Exit;
+  SetLength(Result, Length(AText));
+  Written := 0;
+  PendingSpace := False;
+  for I := 1 to Length(AText) do
+  begin
+    Ch := AText[I];
+    if (Ch = ' ') or (Ch = #9) or (Ch = #10) or (Ch = #13) then
+    begin
+      PendingSpace := Written > 0;
+      Continue;
+    end;
+    if PendingSpace then
+    begin
+      Inc(Written);
+      Result[Written] := ' ';
+      PendingSpace := False;
+    end;
+    Inc(Written);
+    Result[Written] := Ch;
+  end;
+  if Written > GOCCIA_MAX_CALLEE_TEXT_LENGTH then
+    Result := ''
+  else
+    SetLength(Result, Written);
+end;
+
+function IsPlainIdentifierText(const AText: string): Boolean;
+var
+  I: Integer;
+  Ch: Char;
+begin
+  Result := False;
+  if AText = '' then
+    Exit;
+  for I := 1 to Length(AText) do
+  begin
+    Ch := AText[I];
+    if (Ch >= 'a') and (Ch <= 'z') then
+      Continue;
+    if (Ch >= 'A') and (Ch <= 'Z') then
+      Continue;
+    if (Ch = '_') or (Ch = '$') then
+      Continue;
+    if (Ch >= '0') and (Ch <= '9') then
+    begin
+      if I = 1 then
+        Exit;
+      Continue;
+    end;
+    // Non-ASCII identifier parts (the lexer already decoded any \u escapes)
+    // are accepted: they cannot be operators or punctuation.
+    if Ch >= #128 then
+      Continue;
+    Exit;
+  end;
+  Result := True;
+end;
+
+function NotCallableMessage(const ADescriptor: TGocciaCalleeDescriptor;
+  const ACalleeTypeName: string): string;
+begin
+  if ADescriptor.CalleeText <> '' then
+    Result := Format(SErrorValueNotFunction, [ADescriptor.CalleeText])
+  else
+    Result := Format(SErrorValueNotFunction, [ACalleeTypeName]);
+end;
+
+function NotCallableSuggestion(const ADescriptor: TGocciaCalleeDescriptor;
+  const AReceiverTypeName, ACalleeTypeName: string): string;
+begin
+  if (ADescriptor.PropertyName <> '') and (ADescriptor.ObjectText <> '') then
+    Result := Format(SSuggestMemberNotMethod,
+      [ADescriptor.ObjectText, AReceiverTypeName, ADescriptor.PropertyName])
+  else if ADescriptor.PropertyName <> '' then
+    Result := Format(SSuggestMemberNotMethod,
+      [AReceiverTypeName, AReceiverTypeName, ADescriptor.PropertyName])
+  else if IsPlainIdentifierText(ADescriptor.CalleeText) then
+    Result := Format(SSuggestIdentifierNotCallable,
+      [ADescriptor.CalleeText, ACalleeTypeName])
+  else
+    Result := SSuggestNotFunctionType;
+end;
+
+function NotConstructorMessage(const ADescriptor: TGocciaCalleeDescriptor;
+  const ACalleeTypeName: string): string;
+begin
+  if ADescriptor.CalleeText <> '' then
+    Result := Format(SErrorValueNotConstructor, [ADescriptor.CalleeText])
+  else
+    Result := Format(SErrorValueNotConstructor, [ACalleeTypeName]);
+end;
+
+function NotConstructorSuggestion(const ADescriptor: TGocciaCalleeDescriptor;
+  const ACalleeTypeName: string): string;
+begin
+  if IsPlainIdentifierText(ADescriptor.CalleeText) then
+    Result := Format(SSuggestIdentifierNotConstructor,
+      [ADescriptor.CalleeText, ACalleeTypeName])
+  else
+    Result := Format(SSuggestValueNotConstructor, [ACalleeTypeName]);
+end;
+
+end.

--- a/source/units/Goccia.Error.CallDiagnostics.pas
+++ b/source/units/Goccia.Error.CallDiagnostics.pas
@@ -13,6 +13,11 @@ unit Goccia.Error.CallDiagnostics;
 interface
 
 type
+  { What kind of call site produced a non-callable fault. Selects the
+    suggestion: an ordinary call/new gets the shape-based suggestion, a tagged
+    template gets the tag-must-be-callable hint that both executors share. }
+  TGocciaCalleeKind = (cckPlain, cckTaggedTemplate);
+
   { A call site's callee, described well enough to build the same diagnostic
     from either executor.
 
@@ -27,6 +32,7 @@ type
     CalleeText: string;
     ObjectText: string;
     PropertyName: string;
+    Kind: TGocciaCalleeKind;
   end;
 
 { Longest callee text carried into a diagnostic. A callee spanning more than
@@ -72,6 +78,9 @@ uses
   Goccia.Error.Messages,
   Goccia.Error.Suggestions;
 
+// SSuggestTaggedTemplateCallable is declared in Goccia.Error.Suggestions and
+// used by NotCallableSuggestion below.
+
 resourcestring
   SSuggestMemberNotMethod =
     '''%s'' is of type ''%s'' which does not have method ''%s''';
@@ -87,6 +96,7 @@ begin
   Result.CalleeText := '';
   Result.ObjectText := '';
   Result.PropertyName := '';
+  Result.Kind := cckPlain;
 end;
 
 function NormalizeCalleeText(const AText: string): string;
@@ -171,7 +181,9 @@ end;
 function NotCallableSuggestion(const ADescriptor: TGocciaCalleeDescriptor;
   const AReceiverTypeName, ACalleeTypeName: string): string;
 begin
-  if (ADescriptor.PropertyName <> '') and (ADescriptor.ObjectText <> '') then
+  if ADescriptor.Kind = cckTaggedTemplate then
+    Result := SSuggestTaggedTemplateCallable
+  else if (ADescriptor.PropertyName <> '') and (ADescriptor.ObjectText <> '') then
     Result := Format(SSuggestMemberNotMethod,
       [ADescriptor.ObjectText, AReceiverTypeName, ADescriptor.PropertyName])
   else if ADescriptor.PropertyName <> '' then

--- a/source/units/Goccia.Error.Detail.pas
+++ b/source/units/Goccia.Error.Detail.pas
@@ -133,6 +133,26 @@ begin
   Result := True;
 end;
 
+{ Loads the frame file's own source so the code frame quotes the file the
+  header names. The caller only ever has the entry file's lines; when a module
+  throws during evaluation the frame belongs to the imported module, and using
+  the entry's lines silently printed unrelated code at the same line number.
+  Returns nil when the file cannot be read, which falls the caller back to the
+  lines it was given. }
+function TryLoadFrameSourceLines(const APath: string): TStringList;
+begin
+  Result := nil;
+  if (APath = '') or (not FileExists(APath)) then
+    Exit;
+  Result := TStringList.Create;
+  try
+    Result.LoadFromFile(APath);
+  except
+    on E: Exception do
+      FreeAndNil(Result);
+  end;
+end;
+
 function FormatThrowDetail(const AThrown: TGocciaValue;
   const AFileName: string; const ASourceLines: TStringList;
   const AUseColor: Boolean; const ASuggestion: string = ''): string;
@@ -141,20 +161,35 @@ var
   Line, Col: Integer;
   EffectiveFileName: string;
   StackText, MessageText, NameText: string;
+  FrameSourceLines, ContextLines: TStringList;
 begin
   if ExtractThrowLocation(AThrown, ErrorName, ErrorMessage, FrameFileName, Line, Col) and
-     Assigned(ASourceLines) and (Line > 0) and (Line <= ASourceLines.Count) then
+     (Line > 0) then
   begin
     if FrameFileName <> '' then
       EffectiveFileName := FrameFileName
     else
       EffectiveFileName := AFileName;
 
-    Result := FormatErrorWithSourceContext(
-      ErrorName, ErrorMessage, EffectiveFileName, Line, Col, ASourceLines,
-      AUseColor, ASuggestion);
-  end
-  else
+    FrameSourceLines := nil;
+    try
+      ContextLines := ASourceLines;
+      if (FrameFileName <> '') and (FrameFileName <> AFileName) then
+      begin
+        FrameSourceLines := TryLoadFrameSourceLines(FrameFileName);
+        if Assigned(FrameSourceLines) then
+          ContextLines := FrameSourceLines;
+      end;
+
+      if Assigned(ContextLines) and (Line <= ContextLines.Count) then
+        Exit(FormatErrorWithSourceContext(
+          ErrorName, ErrorMessage, EffectiveFileName, Line, Col, ContextLines,
+          AUseColor, ASuggestion));
+    finally
+      FrameSourceLines.Free;
+    end;
+  end;
+
   begin
     // Fallback when no parseable stack frame is available. Use the stack
     // string if present; otherwise render a static debug representation that

--- a/source/units/Goccia.Error.Detail.pas
+++ b/source/units/Goccia.Error.Detail.pas
@@ -9,26 +9,28 @@ uses
 
   Goccia.Values.Primitives;
 
-{ Extracts the first stack frame's line, column, and filename from a JS error
-  object's stack trace string. Returns True if a location was found. }
-function ExtractThrowLocation(const AThrown: TGocciaValue;
-  out AErrorName, AErrorMessage, AFrameFileName: string;
-  out ALine, AColumn: Integer): Boolean;
-
 { Formats a detailed error message for a TGocciaThrowValue, including source
-  context with caret pointer when source lines and location are available.
-  Falls back to the stack trace or a debug-format placeholder when context is
-  unavailable. The fallback never invokes user toString()/valueOf() — by the
-  time this is called the bytecode VM has unwound and re-entering it would
-  raise a Pascal range-check error. }
+  context with caret pointer when the engine recorded source provenance for the
+  error. Falls back to the error's own message/stack text otherwise. The
+  fallback never invokes user toString()/valueOf() — by the time this is called
+  the bytecode VM has unwound and re-entering it would raise a Pascal
+  range-check error.
+
+  Security: the code frame is rendered ONLY from provenance the engine captured
+  onto the error object at creation (Goccia.Values.ErrorHelper), never from the
+  thrown value's guest-writable `stack` string. A forged error object gets no
+  code frame. See docs/module-resolution.md "Runtime code frames". }
 function FormatThrowDetail(const AThrown: TGocciaValue;
   const AFileName: string; const ASourceLines: TStringList;
-  const AUseColor: Boolean; const ASuggestion: string = ''): string;
+  const AUseColor: Boolean; const AExpectedPrincipal: Int64;
+  const ASuggestion: string = ''): string;
 
 implementation
 
 uses
   SysUtils,
+
+  TextSemantics,
 
   Goccia.Constants.PropertyNames,
   Goccia.Error,
@@ -75,150 +77,107 @@ begin
   end;
 end;
 
-function ExtractThrowLocation(const AThrown: TGocciaValue;
-  out AErrorName, AErrorMessage, AFrameFileName: string;
-  out ALine, AColumn: Integer): Boolean;
-var
-  TextValue: string;
-  StackStr: string;
-  AtPos, ParenPos, ColonPos1, ColonPos2, I: Integer;
-begin
-  Result := False;
-  ALine := 0;
-  AColumn := 0;
-  AErrorName := 'Error';
-  AErrorMessage := '';
-  AFrameFileName := '';
-
-  if not (AThrown is TGocciaObjectValue) then Exit;
-
-  if TryGetStringDataProperty(TGocciaObjectValue(AThrown), PROP_NAME, TextValue) then
-    AErrorName := TextValue;
-  if TryGetStringDataProperty(TGocciaObjectValue(AThrown), PROP_MESSAGE, TextValue) then
-    AErrorMessage := TextValue;
-
-  if not TryGetStringDataProperty(TGocciaObjectValue(AThrown), PROP_STACK, StackStr) then Exit;
-
-  // Find first "at ... (file:line:col)" frame
-  AtPos := Pos('    at ', StackStr);
-  if AtPos = 0 then Exit;
-
-  ParenPos := Pos('(', Copy(StackStr, AtPos, MaxInt));
-  if ParenPos = 0 then Exit;
-  ParenPos := AtPos + ParenPos - 1;
-
-  // Find file:line:col within parentheses — scan backwards from closing paren
-  I := Pos(')', Copy(StackStr, ParenPos, MaxInt));
-  if I = 0 then Exit;
-  I := ParenPos + I - 2; // position of last char before ')'
-
-  // Parse ":col" from the end
-  ColonPos2 := I;
-  while (ColonPos2 > ParenPos) and (StackStr[ColonPos2] <> ':') do
-    Dec(ColonPos2);
-  if ColonPos2 <= ParenPos then Exit;
-
-  if not TryStrToInt(Copy(StackStr, ColonPos2 + 1, I - ColonPos2), AColumn) then Exit;
-
-  // Parse ":line" before that
-  ColonPos1 := ColonPos2 - 1;
-  while (ColonPos1 > ParenPos) and (StackStr[ColonPos1] <> ':') do
-    Dec(ColonPos1);
-  if ColonPos1 <= ParenPos then Exit;
-
-  if not TryStrToInt(Copy(StackStr, ColonPos1 + 1, ColonPos2 - ColonPos1 - 1), ALine) then Exit;
-
-  // Extract filename between '(' and the first ':'
-  AFrameFileName := Copy(StackStr, ParenPos + 1, ColonPos1 - ParenPos - 1);
-  Result := True;
-end;
-
-{ Loads the frame file's own source so the code frame quotes the file the
-  header names. The caller only ever has the entry file's lines; when a module
-  throws during evaluation the frame belongs to the imported module, and using
-  the entry's lines silently printed unrelated code at the same line number.
-  Returns nil when the file cannot be read, which falls the caller back to the
-  lines it was given. }
-function TryLoadFrameSourceLines(const APath: string): TStringList;
-begin
-  Result := nil;
-  if (APath = '') or (not FileExists(APath)) then
-    Exit;
-  Result := TStringList.Create;
-  try
-    Result.LoadFromFile(APath);
-  except
-    on E: Exception do
-      FreeAndNil(Result);
-  end;
-end;
-
 function FormatThrowDetail(const AThrown: TGocciaValue;
   const AFileName: string; const ASourceLines: TStringList;
-  const AUseColor: Boolean; const ASuggestion: string = ''): string;
+  const AUseColor: Boolean; const AExpectedPrincipal: Int64;
+  const ASuggestion: string = ''): string;
 var
-  ErrorName, ErrorMessage, FrameFileName: string;
-  Line, Col: Integer;
-  EffectiveFileName: string;
+  ErrorObject: TGocciaErrorObjectValue;
+  ErrorName, ErrorMessage: string;
   StackText, MessageText, NameText: string;
-  FrameSourceLines, ContextLines: TStringList;
+  ExcerptLines: TStringList;
+  SourceAuthorized: Boolean;
 begin
-  if ExtractThrowLocation(AThrown, ErrorName, ErrorMessage, FrameFileName, Line, Col) and
-     (Line > 0) then
+  // A code frame is rendered ONLY from the engine's own recorded provenance,
+  // captured onto the error object when the engine created it (see
+  // Goccia.Values.ErrorHelper.AttachErrorSourceProvenance). The thrown value's
+  // `stack` string is guest-writable and is never used to choose a file or a
+  // line, so a forged `{ stack: "...at f (/etc/passwd:1:1)" }` object — which
+  // carries no engine provenance — gets no code frame and cannot disclose any
+  // file. The captured excerpt travels on the error, so this renders correctly
+  // even after the throwing engine has been freed.
+  if (AThrown is TGocciaErrorObjectValue) and
+     TGocciaErrorObjectValue(AThrown).HasErrorData and
+     TGocciaErrorObjectValue(AThrown).HasErrorSourceLocation then
   begin
-    if FrameFileName <> '' then
-      EffectiveFileName := FrameFileName
-    else
-      EffectiveFileName := AFileName;
+    ErrorObject := TGocciaErrorObjectValue(AThrown);
+    ErrorName := 'Error';
+    if TryGetStringDataProperty(ErrorObject, PROP_NAME, NameText) then
+      ErrorName := NameText;
+    ErrorMessage := '';
+    if TryGetStringDataProperty(ErrorObject, PROP_MESSAGE, MessageText) then
+      ErrorMessage := MessageText;
 
-    FrameSourceLines := nil;
-    try
-      ContextLines := ASourceLines;
-      if (FrameFileName <> '') and (FrameFileName <> AFileName) then
-      begin
-        FrameSourceLines := TryLoadFrameSourceLines(FrameFileName);
-        if Assigned(FrameSourceLines) then
-          ContextLines := FrameSourceLines;
-      end;
+    // RENDER-TIME PRINCIPAL ENFORCEMENT. Authorization comes only from the host
+    // that owns this render operation, explicitly threaded through every
+    // formatter call. Ambient execution state is not authority: after Execute
+    // unwinds there is normally no active scope, and treating that absence as
+    // authorization disclosed retained cross-engine errors. Zero means the
+    // caller supplied no principal and therefore authorizes source from none.
+    SourceAuthorized := (AExpectedPrincipal <> 0) and
+      (AExpectedPrincipal = ErrorObject.ErrorSourcePrincipal);
 
-      if Assigned(ContextLines) and (Line <= ContextLines.Count) then
-        Exit(FormatErrorWithSourceContext(
-          ErrorName, ErrorMessage, EffectiveFileName, Line, Col, ContextLines,
-          AUseColor, ASuggestion));
-    finally
-      FrameSourceLines.Free;
-    end;
-  end;
-
-  begin
-    // Fallback when no parseable stack frame is available. Use the stack
-    // string if present; otherwise render a static debug representation that
-    // does not touch user toString()/valueOf() — the bytecode VM has already
-    // unwound by the time this runs and re-entry is unsafe.
-    if AThrown is TGocciaObjectValue then
+    if SourceAuthorized and (ErrorObject.ErrorSourceExcerpt <> '') then
     begin
-      if TryGetStringDataProperty(TGocciaObjectValue(AThrown), PROP_STACK, StackText) and
-         (StackText <> '') then
-        Result := StackText
-      else if TryGetStringDataProperty(TGocciaObjectValue(AThrown), PROP_MESSAGE, MessageText) and
-              (MessageText <> '') then
-      begin
-        if TryGetStringDataProperty(TGocciaObjectValue(AThrown), PROP_NAME, NameText) and
-           (NameText <> '') then
-          Result := Format('%s: %s', [NameText, MessageText])
-        else
-          Result := MessageText;
-      end
-      else
-        Result := Format('[object %s]', [TGocciaObjectValue(AThrown).ToStringTag]);
+      // Render from the ±context window captured at throw time. No file is
+      // read and no path is looked up here.
+      ExcerptLines := CreateECMAScriptSourceLines(ErrorObject.ErrorSourceExcerpt);
+      try
+        Exit(FormatErrorWithSourceContext(ErrorName, ErrorMessage,
+          ErrorObject.ErrorSourcePath, ErrorObject.ErrorSourceLine,
+          ErrorObject.ErrorSourceColumn, ExcerptLines, AUseColor, ASuggestion,
+          ErrorObject.ErrorSourceExcerptFirstLine));
+      finally
+        ExcerptLines.Free;
+      end;
     end
-    else if AThrown is TGocciaSymbolValue then
-      Result := TGocciaSymbolValue(AThrown).ToDisplayString.Value
-    else
-      // Primitive non-Symbol values: ToStringLiteral cannot invoke user code
-      // and cannot throw, so it is safe to call here.
-      Result := AThrown.ToStringLiteral.Value;
+    else if SourceAuthorized and (ErrorObject.ErrorSourcePath = AFileName) and
+            Assigned(ASourceLines) then
+      // Entry file: no excerpt was captured (the entry is not a loaded module),
+      // but the host still holds its full lines. The path is the engine-recorded
+      // one, matched against the current run's entry — never a guest path. The
+      // same principal gate applies: a parent formatting a child's entry error
+      // (child source passed as ASourceLines) is not authorized, so the entry
+      // lines are withheld and only the location is shown.
+      Exit(FormatErrorWithSourceContext(ErrorName, ErrorMessage,
+        ErrorObject.ErrorSourcePath, ErrorObject.ErrorSourceLine,
+        ErrorObject.ErrorSourceColumn, ASourceLines, AUseColor, ASuggestion))
+    else if ErrorObject.ErrorSourceLine > 0 then
+      // Provenance recorded, but the source is unavailable (not the entry, not
+      // a captured module). Show the header/location without a code frame rather
+      // than quoting any other file.
+      Exit(FormatErrorWithSourceContext(ErrorName, ErrorMessage,
+        ErrorObject.ErrorSourcePath, ErrorObject.ErrorSourceLine,
+        ErrorObject.ErrorSourceColumn, nil, AUseColor, ASuggestion));
   end;
+
+  // Fallback: forged error object, thrown non-error object, or a primitive —
+  // no engine provenance, so no code frame. Echo the value's own message/stack
+  // text (the guest's own data; no file is read). Never invokes user
+  // toString()/valueOf(): the bytecode VM has already unwound.
+  if AThrown is TGocciaObjectValue then
+  begin
+    if TryGetStringDataProperty(TGocciaObjectValue(AThrown), PROP_STACK, StackText) and
+       (StackText <> '') then
+      Result := StackText
+    else if TryGetStringDataProperty(TGocciaObjectValue(AThrown), PROP_MESSAGE, MessageText) and
+            (MessageText <> '') then
+    begin
+      if TryGetStringDataProperty(TGocciaObjectValue(AThrown), PROP_NAME, NameText) and
+         (NameText <> '') then
+        Result := Format('%s: %s', [NameText, MessageText])
+      else
+        Result := MessageText;
+    end
+    else
+      Result := Format('[object %s]', [TGocciaObjectValue(AThrown).ToStringTag]);
+  end
+  else if AThrown is TGocciaSymbolValue then
+    Result := TGocciaSymbolValue(AThrown).ToDisplayString.Value
+  else
+    // Primitive non-Symbol values: ToStringLiteral cannot invoke user code
+    // and cannot throw, so it is safe to call here.
+    Result := AThrown.ToStringLiteral.Value;
 end;
 
 end.

--- a/source/units/Goccia.Error.Messages.pas
+++ b/source/units/Goccia.Error.Messages.pas
@@ -9,11 +9,18 @@ resourcestring
   SErrorIdentifierAlreadyDeclared = 'Identifier ''%s'' has already been declared';
   SErrorCannotAccessBeforeInit = 'Cannot access ''%s'' before initialization';
   SErrorAssignToConstant = 'Assignment to constant variable ''%s''';
-  SErrorUndefinedVariable = 'Undefined variable: %s';
+  // Node's wording. The bytecode VM already emitted this form, so the
+  // tree-walk evaluator uses the same constant and the two modes report an
+  // unresolved identifier identically.
+  SErrorUndefinedVariable = '%s is not defined';
 
-  // Type errors — function calls
-  SErrorMemberNotFunction = '%s.%s is not a function';
-  SErrorNotFunction = '''%s'' is not a function';
+  // Type errors — function calls.
+  // One form for every non-callable callee: what goes in the slot is the
+  // callee as the author wrote it when that is known, and the runtime type
+  // name otherwise. Both executors build it through
+  // Goccia.Error.CallDiagnostics so the text cannot drift between modes; the
+  // older per-shape variants ('obj.m is not a function' assembled from two
+  // parts, and a quoted-identifier form) were retired for that reason.
   SErrorValueNotFunction = '%s is not a function';
   SErrorSymbolToNumber = 'Cannot convert a Symbol value to a number';
   SErrorSymbolToString = 'Cannot convert a Symbol value to a string';
@@ -31,8 +38,11 @@ resourcestring
 
   SErrorNotANumber = 'Value is not a Number';
 
-  // Type errors — property access
-  SErrorCannotReadPropertyOf = 'Cannot read property ''%s'' of %s';
+  // Type errors — property access.
+  // Both executors use the "Cannot read properties of X (reading 'k')" form —
+  // Node's wording — so a nullish-base fault reads identically in interpreter
+  // and bytecode mode. The older "Cannot read property 'k' of X" phrasing was
+  // retired for that reason; do not reintroduce it.
   SErrorCannotReadPropertiesOf = 'Cannot read properties of %s (reading ''%s'')';
 
   // Type errors — constructors

--- a/source/units/Goccia.Error.Messages.pas
+++ b/source/units/Goccia.Error.Messages.pas
@@ -45,8 +45,11 @@ resourcestring
   // retired for that reason; do not reintroduce it.
   SErrorCannotReadPropertiesOf = 'Cannot read properties of %s (reading ''%s'')';
 
-  // Type errors — constructors
-  SErrorNotConstructor = '''%s'' is not a constructor';
+  // Type errors — constructors.
+  // One Node-form (unquoted) constant for both modes; the slot holds the callee
+  // as written when known (via Goccia.Error.CallDiagnostics), else the type or
+  // constructor name. The quoted `'%s' is not a constructor` variant was
+  // retired so the two executors cannot drift.
   SErrorValueNotConstructor = '%s is not a constructor';
   SErrorSuperNotConstructor = 'Super constructor is not a constructor';
 

--- a/source/units/Goccia.Error.Test.pas
+++ b/source/units/Goccia.Error.Test.pas
@@ -8,7 +8,11 @@ uses
 
   TestingPascalLibrary,
 
-  Goccia.Error;
+  Goccia.Diagnostics.SourceRegistry,
+  Goccia.Error,
+  Goccia.Error.Detail,
+  Goccia.Values.ObjectValue,
+  Goccia.Values.Primitives;
 
 type
   TErrorTests = class(TTestSuite)
@@ -30,6 +34,7 @@ type
     procedure TestErrorDisplayNameMapsTypeErrorCorrectly;
     procedure TestErrorDisplayNameMapsReferenceErrorCorrectly;
     procedure TestGetDetailedMessageHandlesSingleSourceLine;
+    procedure TestFormatThrowDetailRequiresExpectedPrincipal;
   public
     procedure SetupTests; override;
   end;
@@ -82,6 +87,9 @@ begin
     TestErrorDisplayNameMapsReferenceErrorCorrectly);
   Test('GetDetailedMessage handles single source line',
     TestGetDetailedMessageHandlesSingleSourceLine);
+  Test('FormatThrowDetail withholds a retained foreign excerpt without an ' +
+    'explicit matching principal',
+    TestFormatThrowDetailRequiresExpectedPrincipal);
 end;
 
 procedure TErrorTests.TestGetDetailedMessageShowsJSFriendlyErrorName;
@@ -371,6 +379,56 @@ begin
     end;
   finally
     SourceLines.Free;
+  end;
+end;
+
+procedure TErrorTests.TestFormatThrowDetailRequiresExpectedPrincipal;
+const
+  SecretMarker = 'A_ENGINE_PRIVATE_SOURCE_MARKER';
+var
+  ErrorObject: TGocciaErrorObjectValue;
+  ScopeA, ScopeB: TGocciaDiagnosticSourceScope;
+  Output: string;
+begin
+  ScopeA := TGocciaDiagnosticSourceScope.Create;
+  ScopeB := TGocciaDiagnosticSourceScope.Create;
+  ErrorObject := TGocciaErrorObjectValue.Create;
+  try
+    ErrorObject.HasErrorData := True;
+    ErrorObject.AssignProperty('name',
+      TGocciaStringLiteralValue.Create('Error'));
+    ErrorObject.AssignProperty('message',
+      TGocciaStringLiteralValue.Create('held across engines'));
+    ErrorObject.HasErrorSourceLocation := True;
+    ErrorObject.ErrorSourcePath := 'engine-a-secret.js';
+    ErrorObject.ErrorSourceLine := 2;
+    ErrorObject.ErrorSourceColumn := 3;
+    ErrorObject.ErrorSourceExcerpt := '// first' + sLineBreak +
+      SecretMarker + sLineBreak + '// third';
+    ErrorObject.ErrorSourceExcerptFirstLine := 1;
+    ErrorObject.ErrorSourcePrincipal := ScopeA.Principal;
+
+    { Execute has already restored the active scope before a host renders a
+      retained throw. Absence of ambient execution state must never authorize
+      the source stamped by another engine. }
+    Expect<Boolean>(TGocciaDiagnosticSourceRegistry.Current = nil).ToBe(True);
+    Output := FormatThrowDetail(ErrorObject, 'engine-b.js', nil, False,
+      ScopeB.Principal);
+    Expect<Boolean>(Pos('engine-a-secret.js:2:3', Output) > 0).ToBe(True);
+    Expect<Boolean>(Pos(SecretMarker, Output) > 0).ToBe(False);
+
+    Output := FormatThrowDetail(ErrorObject, 'engine-b.js', nil, False, 0);
+    Expect<Boolean>(Pos('engine-a-secret.js:2:3', Output) > 0).ToBe(True);
+    Expect<Boolean>(Pos(SecretMarker, Output) > 0).ToBe(False);
+
+    { The owning renderer still gets the retained code frame. }
+    Output := FormatThrowDetail(ErrorObject, 'engine-a-secret.js', nil, False,
+      ScopeA.Principal);
+    Expect<Boolean>(Pos(SecretMarker, Output) > 0).ToBe(True);
+  finally
+    ErrorObject.Free;
+    ScopeB.Free;
+    ScopeA.Free;
   end;
 end;
 

--- a/source/units/Goccia.Error.pas
+++ b/source/units/Goccia.Error.pas
@@ -59,7 +59,8 @@ function FormatErrorWithSourceContext(
   const ALine, AColumn: Integer;
   const ASourceLines: TStringList;
   const AUseColor: Boolean = False;
-  const ASuggestion: string = ''): string;
+  const ASuggestion: string = '';
+  const AFirstLineNumber: Integer = 1): string;
 
 implementation
 
@@ -153,11 +154,12 @@ function FormatErrorWithSourceContext(
   const ALine, AColumn: Integer;
   const ASourceLines: TStringList;
   const AUseColor: Boolean = False;
-  const ASuggestion: string = ''): string;
+  const ASuggestion: string = '';
+  const AFirstLineNumber: Integer = 1): string;
 var
   Buffer: TStringBuffer;
   GutterWidth, LineNum, I: Integer;
-  FirstContextLine, LastContextLine: Integer;
+  FirstContextLine, LastContextLine, LastAbsLine: Integer;
   LineStr, Gutter, CaretStr: string;
 begin
   Buffer := TStringBuffer.Create(512);
@@ -180,15 +182,23 @@ begin
   Buffer.Append(Colorize(Format('--> %s:%d:%d', [AFileName, ALine, AColumn]), ANSI_CYAN, AUseColor));
   Buffer.Append(sLineBreak);
 
-  // Source context lines
-  if Assigned(ASourceLines) and (ALine > 0) and (ALine <= ASourceLines.Count) then
+  // Source context lines. ASourceLines may be either the whole file
+  // (AFirstLineNumber = 1) or a captured window whose first entry is absolute
+  // line AFirstLineNumber, so every access maps absolute line -> index via the
+  // base offset.
+  if Assigned(ASourceLines) then
+    LastAbsLine := AFirstLineNumber + ASourceLines.Count - 1
+  else
+    LastAbsLine := 0;
+  if Assigned(ASourceLines) and (ALine >= AFirstLineNumber) and
+     (ALine <= LastAbsLine) then
   begin
     FirstContextLine := ALine - CONTEXT_LINES_BEFORE;
-    if FirstContextLine < 1 then
-      FirstContextLine := 1;
+    if FirstContextLine < AFirstLineNumber then
+      FirstContextLine := AFirstLineNumber;
     LastContextLine := ALine + CONTEXT_LINES_AFTER;
-    if LastContextLine > ASourceLines.Count then
-      LastContextLine := ASourceLines.Count;
+    if LastContextLine > LastAbsLine then
+      LastContextLine := LastAbsLine;
 
     // Calculate gutter width based on largest line number
     GutterWidth := Length(IntToStr(LastContextLine));
@@ -200,12 +210,12 @@ begin
     begin
       Gutter := Format('%' + IntToStr(GutterWidth) + 'd | ', [LineNum]);
       Buffer.Append(Colorize(Gutter, ANSI_DIM, AUseColor));
-      Buffer.Append(ASourceLines[LineNum - 1]);
+      Buffer.Append(ASourceLines[LineNum - AFirstLineNumber]);
       Buffer.Append(sLineBreak);
     end;
 
     // Error line (bold)
-    LineStr := ASourceLines[ALine - 1];
+    LineStr := ASourceLines[ALine - AFirstLineNumber];
     Gutter := Format('%' + IntToStr(GutterWidth) + 'd | ', [ALine]);
     Buffer.Append(Colorize(Gutter, ANSI_DIM, AUseColor));
     Buffer.Append(Colorize(LineStr, ANSI_BOLD, AUseColor));
@@ -229,7 +239,7 @@ begin
     begin
       Gutter := Format('%' + IntToStr(GutterWidth) + 'd | ', [LineNum]);
       Buffer.Append(Colorize(Gutter, ANSI_DIM, AUseColor));
-      Buffer.Append(ASourceLines[LineNum - 1]);
+      Buffer.Append(ASourceLines[LineNum - AFirstLineNumber]);
       Buffer.Append(sLineBreak);
     end;
   end;

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -202,6 +202,7 @@ uses
   Goccia.DisposalTracker,
   Goccia.EngineFault,
   Goccia.Error,
+  Goccia.Error.CallDiagnostics,
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
   Goccia.Evaluator.Assignment,
@@ -4115,6 +4116,7 @@ var
   Roots: TGocciaActiveRootFrame;
   DirectEvalResult: TGocciaValue;
   PreviousCallSite: TGocciaCallSite;
+  CalleeDescriptor: TGocciaCalleeDescriptor;
   function TryGetParenthesizedMemberReference(
     const AExpression: TGocciaExpression;
     out AMemberExpression: TGocciaMemberExpression): Boolean;
@@ -4527,35 +4529,13 @@ begin
       end
       else
       begin
-        MemberExpr := nil;
-        if ACallExpression.Callee is TGocciaMemberExpression then
-          MemberExpr := TGocciaMemberExpression(ACallExpression.Callee);
-
-        if Assigned(MemberExpr) and (MemberExpr.ObjectExpr is TGocciaIdentifierExpression) then
-          ThrowTypeError(
-            Format(SErrorMemberNotFunction,
-              [TGocciaIdentifierExpression(MemberExpr.ObjectExpr).Name,
-               MemberExpr.PropertyName]),
-            Format('''%s'' is of type ''%s'' which does not have method ''%s''',
-              [TGocciaIdentifierExpression(MemberExpr.ObjectExpr).Name,
-               ThisValue.TypeName,
-               MemberExpr.PropertyName]))
-        else if Assigned(MemberExpr) then
-          ThrowTypeError(
-            Format(SErrorMemberNotFunction,
-              [ThisValue.TypeName, MemberExpr.PropertyName]),
-            Format('''%s'' is of type ''%s'' which does not have method ''%s''',
-              [ThisValue.TypeName, ThisValue.TypeName, MemberExpr.PropertyName]))
-        else if ACallExpression.Callee is TGocciaIdentifierExpression then
-          ThrowTypeError(
-            Format(SErrorNotFunction,
-              [TGocciaIdentifierExpression(ACallExpression.Callee).Name]),
-            Format('''%s'' is of type ''%s'' and cannot be called as a function',
-              [TGocciaIdentifierExpression(ACallExpression.Callee).Name,
-               Callee.TypeName]))
-        else
-          ThrowTypeError(Format(SErrorValueNotFunction, [Callee.TypeName]),
-            SSuggestNotFunctionType);
+        { Same descriptor the bytecode compiler records per call site, so both
+          executors name the callee identically (Goccia.Error.CallDiagnostics). }
+        CalleeDescriptor := CalleeDescriptorFor(ACallExpression.Callee);
+        ThrowTypeError(
+          NotCallableMessage(CalleeDescriptor, Callee.TypeName),
+          NotCallableSuggestion(CalleeDescriptor, ThisValue.TypeName,
+            Callee.TypeName));
       end;
     finally
       if (TGocciaCallStack.Instance <> nil) then
@@ -4924,24 +4904,16 @@ begin
     end
     else if (Obj is TGocciaNullLiteralValue) or (Obj is TGocciaUndefinedLiteralValue) then
     begin
-      if AMemberExpression.ObjectExpr is TGocciaMemberExpression then
+      { Node's wording, shared with the bytecode VM's nullish-base path
+        (Goccia.VM.ThrowNullishBasePropertyAccess) so the two executors report
+        an identical message and suggestion for the same fault. }
+      if Obj is TGocciaNullLiteralValue then
         ThrowTypeError(
-          Format(SErrorCannotReadPropertyOf,
-            [PropertyName, Obj.ToStringLiteral.Value]),
-          Format('''%s'' evaluated to %s and does not have property ''%s''',
-            [TGocciaMemberExpression(AMemberExpression.ObjectExpr).PropertyName,
-             Obj.ToStringLiteral.Value, PropertyName]))
-      else if AMemberExpression.ObjectExpr is TGocciaIdentifierExpression then
-        ThrowTypeError(
-          Format(SErrorCannotReadPropertyOf,
-            [PropertyName, Obj.ToStringLiteral.Value]),
-          Format('''%s'' is %s and does not have property ''%s''',
-            [TGocciaIdentifierExpression(AMemberExpression.ObjectExpr).Name,
-             Obj.ToStringLiteral.Value, PropertyName]))
+          Format(SErrorCannotReadPropertiesOfNull, [PropertyName]),
+          SSuggestCheckNullBeforeAccess)
       else
-        ThrowTypeError(Format(
-          SErrorCannotReadPropertyOf,
-          [PropertyName, Obj.ToStringLiteral.Value]),
+        ThrowTypeError(
+          Format(SErrorCannotReadPropertiesOfUndefined, [PropertyName]),
           SSuggestCheckNullBeforeAccess);
     end
     else
@@ -8681,6 +8653,7 @@ var
   ReceiverInstance: TGocciaObjectValue;
   Roots: TGocciaActiveRootFrame;
   PreviousCallSite: TGocciaCallSite;
+  NewCalleeDescriptor: TGocciaCalleeDescriptor;
 begin
   Roots.Initialize;
   CheckExecutionTimeout;
@@ -8720,6 +8693,12 @@ begin
 
     if (TGocciaCallStack.Instance <> nil) then
     begin
+      { A constructor that captures a stack trace (`new Error(...)`) skips its
+        own frame, so the position the diagnostic ends up showing comes from
+        the caller's frame. Point that frame at the `new` expression, matching
+        what the bytecode VM stamps at its construct site. }
+      TGocciaCallStack.Instance.SetTopFrameLocation(AContext.CurrentFilePath,
+        ANewExpression.Line, ANewExpression.Column);
       TGocciaCallStack.Instance.Push(CalleeName, AContext.CurrentFilePath,
         ANewExpression.Line, ANewExpression.Column);
     end;
@@ -8815,18 +8794,12 @@ begin
       end
       else
       begin
-        if ANewExpression.Callee is TGocciaIdentifierExpression then
-          ThrowTypeError(
-            Format(SErrorNotConstructor,
-              [TGocciaIdentifierExpression(ANewExpression.Callee).Name]),
-            Format('''%s'' is of type ''%s'' and cannot be used with ''new''',
-              [TGocciaIdentifierExpression(ANewExpression.Callee).Name,
-               Callee.TypeName]))
-        else
-          ThrowTypeError(
-            Format(SErrorValueNotConstructor, [Callee.TypeName]),
-            Format('values of type ''%s'' cannot be used with ''new''',
-              [Callee.TypeName]));
+        { Same descriptor the bytecode compiler records per construct site, so
+          both executors name the callee identically. }
+        NewCalleeDescriptor := CalleeDescriptorFor(ANewExpression.Callee);
+        ThrowTypeError(
+          NotConstructorMessage(NewCalleeDescriptor, Callee.TypeName),
+          NotConstructorSuggestion(NewCalleeDescriptor, Callee.TypeName));
       end;
     finally
       if (TGocciaCallStack.Instance <> nil) then

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -259,6 +259,33 @@ function HasAsyncDisposals(const ATracker: TGocciaDisposalTracker): Boolean; for
 function CollectDeclaredPrivateNames(
   const AContext: TGocciaEvaluationContext): TStringList; forward;
 
+// Stamp the executing call-stack frame with a runtime fault's own source
+// position, so an error created here traces to the failing expression rather
+// than to the enclosing function's call site. The bytecode VM does the same on
+// its throw paths (Goccia.VM.StampThrowLocation); doing it here keeps a nested
+// runtime error's `--> file:line:column` and code frame identical between the
+// two executors. Called only on throw paths, where the frame is about to unwind.
+procedure StampInterpreterThrowLocation(
+  const AContext: TGocciaEvaluationContext; const ALine, AColumn: Integer); {$IFDEF FPC}inline;{$ENDIF}
+begin
+  if TGocciaCallStack.Instance <> nil then
+    TGocciaCallStack.Instance.SetTopFrameLocation(AContext.CurrentFilePath,
+      ALine, AColumn);
+end;
+
+// The position the bytecode line map resolves a member-read fault to: the
+// base-most expression of the access chain. The compiler emits a line-map entry
+// as it descends to the base and none for the individual property reads, so a
+// read anywhere along `a.b.c` traces to `a`'s column. Walking to the same base
+// here keeps the interpreter's code-frame caret byte-identical with the VM's.
+function MemberChainBaseExpression(
+  const AExpr: TGocciaExpression): TGocciaExpression;
+begin
+  Result := AExpr;
+  while Result is TGocciaMemberExpression do
+    Result := TGocciaMemberExpression(Result).ObjectExpr;
+end;
+
 // A class value that carries its own [[Construct]] implementation — a typed
 // array, or a bytecode-compiled class whose constructor is a closure rather
 // than an AST method — cannot be built by InstantiateClass, which drives
@@ -3853,10 +3880,9 @@ begin
   begin
     if TGocciaNativeFunctionValue(AConstructor).NotConstructable then
       ThrowTypeError(
-        Format(SErrorNotConstructor,
+        Format(SErrorValueNotConstructor,
           [TGocciaNativeFunctionValue(AConstructor).Name]),
-        Format('''%s'' is not a constructor',
-          [TGocciaNativeFunctionValue(AConstructor).Name]));
+        SSuggestNotConstructorType);
     SuperResult := TGocciaNativeFunctionValue(AConstructor).Construct(
       AArguments, EffectiveNewTarget);
   end
@@ -4117,6 +4143,7 @@ var
   DirectEvalResult: TGocciaValue;
   PreviousCallSite: TGocciaCallSite;
   CalleeDescriptor: TGocciaCalleeDescriptor;
+  CalleeTypeName, ReceiverTypeName: string;
   function TryGetParenthesizedMemberReference(
     const AExpression: TGocciaExpression;
     out AMemberExpression: TGocciaMemberExpression): Boolean;
@@ -4530,12 +4557,22 @@ begin
       else
       begin
         { Same descriptor the bytecode compiler records per call site, so both
-          executors name the callee identically (Goccia.Error.CallDiagnostics). }
+          executors name the callee identically (Goccia.Error.CallDiagnostics).
+          This arm is also reached when Callee is nil, so its type name is read
+          through a nil guard, mirroring the VM's ValueTypeNameOrUndefined. }
         CalleeDescriptor := CalleeDescriptorFor(ACallExpression.Callee);
+        if Assigned(Callee) then
+          CalleeTypeName := Callee.TypeName
+        else
+          CalleeTypeName := 'undefined';
+        if Assigned(ThisValue) then
+          ReceiverTypeName := ThisValue.TypeName
+        else
+          ReceiverTypeName := CalleeTypeName;
         ThrowTypeError(
-          NotCallableMessage(CalleeDescriptor, Callee.TypeName),
-          NotCallableSuggestion(CalleeDescriptor, ThisValue.TypeName,
-            Callee.TypeName));
+          NotCallableMessage(CalleeDescriptor, CalleeTypeName),
+          NotCallableSuggestion(CalleeDescriptor, ReceiverTypeName,
+            CalleeTypeName));
       end;
     finally
       if (TGocciaCallStack.Instance <> nil) then
@@ -4736,6 +4773,7 @@ var
   ObjectEvaluated: Boolean;
   ShortCircuited: Boolean;
   Roots: TGocciaActiveRootFrame;
+  MemberBaseExpr: TGocciaExpression;
 begin
   Roots.Initialize;
   try
@@ -4906,7 +4944,13 @@ begin
     begin
       { Node's wording, shared with the bytecode VM's nullish-base path
         (Goccia.VM.ThrowNullishBasePropertyAccess) so the two executors report
-        an identical message and suggestion for the same fault. }
+        an identical message and suggestion for the same fault. Stamp the
+        executing frame with the access chain's base-most position so the trace
+        points at the access rather than the enclosing function's call site, and
+        so the caret column matches the VM's line map (MemberChainBaseExpression). }
+      MemberBaseExpr := MemberChainBaseExpression(AMemberExpression);
+      StampInterpreterThrowLocation(AContext, MemberBaseExpr.Line,
+        MemberBaseExpr.Column);
       if Obj is TGocciaNullLiteralValue then
         ThrowTypeError(
           Format(SErrorCannotReadPropertiesOfNull, [PropertyName]),
@@ -8611,10 +8655,9 @@ begin
     begin
       if TGocciaNativeFunctionValue(Target).NotConstructable then
         ThrowTypeError(
-          Format(SErrorNotConstructor,
+          Format(SErrorValueNotConstructor,
             [TGocciaNativeFunctionValue(Target).Name]),
-          Format('''%s'' is not a constructor',
-            [TGocciaNativeFunctionValue(Target).Name]));
+          SSuggestNotConstructorType);
       Result := TGocciaNativeFunctionValue(Target).Construct(BoundArgs,
         Target);
     end
@@ -8654,6 +8697,8 @@ var
   Roots: TGocciaActiveRootFrame;
   PreviousCallSite: TGocciaCallSite;
   NewCalleeDescriptor: TGocciaCalleeDescriptor;
+  SavedCallerFrame: TGocciaCallFrame;
+  CallerFrameStamped: Boolean;
 begin
   Roots.Initialize;
   CheckExecutionTimeout;
@@ -8691,14 +8736,25 @@ begin
     else
       CalleeName := '';
 
+    { One descriptor for every not-a-constructor throw below, so the message and
+      suggestion match the bytecode VM's construct-site diagnostics for the same
+      fault (Goccia.Error.CallDiagnostics). }
+    NewCalleeDescriptor := CalleeDescriptorFor(ANewExpression.Callee);
+
     if (TGocciaCallStack.Instance <> nil) then
     begin
       { A constructor that captures a stack trace (`new Error(...)`) skips its
         own frame, so the position the diagnostic ends up showing comes from
-        the caller's frame. Point that frame at the `new` expression, matching
-        what the bytecode VM stamps at its construct site. }
-      TGocciaCallStack.Instance.SetTopFrameLocation(AContext.CurrentFilePath,
-        ANewExpression.Line, ANewExpression.Column);
+        the caller's frame. Point that frame at the `new` expression for the
+        duration of the construction, matching what the bytecode VM stamps at
+        its construct site — but snapshot it first and restore it in the
+        finally, so the stamp does not leak into a later throw in the same
+        function (AE.g. `const m = new Map(); AReturn m.missing.x;`). }
+      CallerFrameStamped := TGocciaCallStack.Instance.TryGetTopFrame(
+        SavedCallerFrame);
+      if CallerFrameStamped then
+        TGocciaCallStack.Instance.SetTopFrameLocation(AContext.CurrentFilePath,
+          ANewExpression.Line, ANewExpression.Column);
       TGocciaCallStack.Instance.Push(CalleeName, AContext.CurrentFilePath,
         ANewExpression.Line, ANewExpression.Column);
     end;
@@ -8733,10 +8789,8 @@ begin
       begin
         if TGocciaNativeFunctionValue(Callee).NotConstructable then
           ThrowTypeError(
-            Format(SErrorNotConstructor,
-              [TGocciaNativeFunctionValue(Callee).Name]),
-            Format('''%s'' is not a constructor',
-              [TGocciaNativeFunctionValue(Callee).Name]));
+            NotConstructorMessage(NewCalleeDescriptor, Callee.TypeName),
+            NotConstructorSuggestion(NewCalleeDescriptor, Callee.TypeName));
         EnterGocciaCallSite(AContext.CurrentFilePath,
           ANewExpression.Line, ANewExpression.Column, PreviousCallSite);
         try
@@ -8757,8 +8811,9 @@ begin
         // the bound wrapper itself has no own `prototype` data property.
         FunctionCallee := TGocciaFunctionBase(Callee);
         if not FunctionCallee.IsConstructable then
-          ThrowTypeError(Format(SErrorNotConstructor, [CalleeName]),
-            SSuggestNotConstructorType);
+          ThrowTypeError(
+            NotConstructorMessage(NewCalleeDescriptor, Callee.TypeName),
+            NotConstructorSuggestion(NewCalleeDescriptor, Callee.TypeName));
         PrototypeTarget := FunctionCallee;
         while PrototypeTarget is TGocciaBoundFunctionValue do
           PrototypeTarget := TGocciaBoundFunctionValue(PrototypeTarget).OriginalFunction;
@@ -8793,17 +8848,18 @@ begin
         end
       end
       else
-      begin
-        { Same descriptor the bytecode compiler records per construct site, so
-          both executors name the callee identically. }
-        NewCalleeDescriptor := CalleeDescriptorFor(ANewExpression.Callee);
         ThrowTypeError(
           NotConstructorMessage(NewCalleeDescriptor, Callee.TypeName),
           NotConstructorSuggestion(NewCalleeDescriptor, Callee.TypeName));
-      end;
     finally
       if (TGocciaCallStack.Instance <> nil) then
+      begin
         TGocciaCallStack.Instance.Pop;
+        // Restore the caller frame's own location; the stamp above was scoped
+        // to this construction only.
+        if CallerFrameStamped then
+          TGocciaCallStack.Instance.SetTopFrame(SavedCallerFrame);
+      end;
     end;
     AddValueRoot(Roots, Result);
     CollectInterpreterMemoryPressure(Result);
@@ -11262,10 +11318,9 @@ var
     begin
       if TGocciaNativeFunctionValue(AConstructor).NotConstructable then
         ThrowTypeError(
-          Format(SErrorNotConstructor,
+          Format(SErrorValueNotConstructor,
             [TGocciaNativeFunctionValue(AConstructor).Name]),
-          Format('''%s'' is not a constructor',
-            [TGocciaNativeFunctionValue(AConstructor).Name]));
+          SSuggestNotConstructorType);
       ConstructedValue := TGocciaNativeFunctionValue(AConstructor).Construct(
         AArguments, EffectiveNewTarget);
     end
@@ -11781,6 +11836,7 @@ var
   I: Integer;
   CalleeName: string;
   TemplateKey: string;
+  TagCalleeDescriptor: TGocciaCalleeDescriptor;
 begin
   CheckExecutionTimeout;
   IncrementInstructionCounter;
@@ -11885,9 +11941,17 @@ begin
       if Assigned(Callee) and Callee.IsCallable then
         Result := DispatchCall(Callee, Arguments, ThisValue)
       else
+      begin
+        { Same descriptor the bytecode compiler records for a tagged-template
+          call site, so both executors name the tag and share the
+          tag-must-be-callable suggestion (Goccia.Error.CallDiagnostics). }
+        TagCalleeDescriptor := CalleeDescriptorFor(
+          ATaggedTemplateExpression.Tag, cckTaggedTemplate);
         ThrowTypeError(
-          Format(SErrorValueNotFunction, [Callee.TypeName]),
-          SSuggestTaggedTemplateCallable);
+          NotCallableMessage(TagCalleeDescriptor, Callee.TypeName),
+          NotCallableSuggestion(TagCalleeDescriptor, Callee.TypeName,
+            Callee.TypeName));
+      end;
     finally
       if (TGocciaCallStack.Instance <> nil) then
         TGocciaCallStack.Instance.Pop;

--- a/source/units/Goccia.ExecutionContext.pas
+++ b/source/units/Goccia.ExecutionContext.pas
@@ -5,6 +5,7 @@ unit Goccia.ExecutionContext;
 interface
 
 uses
+  Goccia.Diagnostics.SourceRegistry,
   Goccia.Realm,
   Goccia.Scope,
   Goccia.Values.Primitives;
@@ -33,8 +34,16 @@ type
   TGocciaExecutionContextScope = class
   private
     FPopped: Boolean;
+    FHasDiagnostic: Boolean;
+    FPrevDiagnosticScope: TGocciaDiagnosticSourceScope;
   public
-    constructor Create(const AContext: TGocciaExecutionContext);
+    { When ADiagnosticScope is assigned, this scope also makes it the active
+      diagnostic capture target for its lifetime and restores the previous one
+      on Pop — so a cross-engine transition (ShadowRealm evaluate/importValue/
+      wrapped function) captures code frames from the engine actually running,
+      not from whichever engine happened to be active before the switch. }
+    constructor Create(const AContext: TGocciaExecutionContext;
+      const ADiagnosticScope: TGocciaDiagnosticSourceScope = nil);
     destructor Destroy; override;
     procedure Pop;
   end;
@@ -196,11 +205,16 @@ end;
 { TGocciaExecutionContextScope }
 
 constructor TGocciaExecutionContextScope.Create(
-  const AContext: TGocciaExecutionContext);
+  const AContext: TGocciaExecutionContext;
+  const ADiagnosticScope: TGocciaDiagnosticSourceScope);
 begin
   inherited Create;
   FPopped := False;
   TGocciaExecutionContextStack.Push(AContext);
+  FHasDiagnostic := Assigned(ADiagnosticScope);
+  if FHasDiagnostic then
+    FPrevDiagnosticScope :=
+      TGocciaDiagnosticSourceRegistry.Activate(ADiagnosticScope);
 end;
 
 destructor TGocciaExecutionContextScope.Destroy;
@@ -213,6 +227,12 @@ procedure TGocciaExecutionContextScope.Pop;
 begin
   if FPopped then
     Exit;
+  // Restore the diagnostic scope before unwinding the context, mirroring Create.
+  if FHasDiagnostic then
+  begin
+    TGocciaDiagnosticSourceRegistry.Deactivate(FPrevDiagnosticScope);
+    FHasDiagnostic := False;
+  end;
   TGocciaExecutionContextStack.Pop;
   FPopped := True;
 end;

--- a/source/units/Goccia.HostEnvironment.JavaScript.pas
+++ b/source/units/Goccia.HostEnvironment.JavaScript.pas
@@ -259,7 +259,8 @@ begin
   if not Assigned(AEngine) then
     raise EArgumentNilException.Create('AEngine');
 
-  Module := AEngine.ModuleLoader.LoadModule(AModulePath, AEngine.SourcePath);
+  Module := AEngine.ModuleLoader.LoadHostModule(AModulePath,
+    AEngine.SourcePath);
   EpochNanosecondsProvider := RequireCallableExport(Module,
     'epochNanoseconds');
   MonotonicNanosecondsProvider := RequireCallableExport(Module,

--- a/source/units/Goccia.MemoryLimit.Test.pas
+++ b/source/units/Goccia.MemoryLimit.Test.pas
@@ -11,6 +11,7 @@ uses
 
   Goccia.Arguments.Collection,
   Goccia.CapabilityAudit,
+  Goccia.Diagnostics.SourceRegistry,
   Goccia.Engine,
   Goccia.Executor,
   Goccia.Executor.Bytecode,
@@ -119,6 +120,18 @@ type
     property GatedElements: TCollectingElementList read FGatedElements;
   end;
 
+  { Raises at a deterministic index insertion, standing in for an allocator
+    failure during the registry's commit phase. }
+  TFailingDiagnosticSourceScope = class(TGocciaDiagnosticSourceScope)
+  private
+    FFailAtIndex: Integer;
+  protected
+    procedure AfterIndexCommit(const AIndex: Integer); override;
+  public
+    constructor Create(const AFailAtIndex: Integer);
+    property FailAtIndex: Integer read FFailAtIndex write FFailAtIndex;
+  end;
+
   TMemoryLimitTests = class(TTestSuite)
   private
     { The class the sandbox injection points raise, or nil for "raise nothing".
@@ -211,6 +224,10 @@ type
     procedure TestSandboxFsPromiseCannotSwallowIntegrityFault;
     procedure TestSandboxFsPromiseErrorsStayCatchable;
     procedure TestResponseJsonCannotSwallowAuditDeliveryFailure;
+    procedure TestDiagnosticIdentityFailureFailsClosed;
+    procedure TestDiagnosticCanonicalIdentityKeepsHostOwnership;
+    procedure TestDiagnosticSourceAccountingUsesRetainedBytes;
+    procedure TestDiagnosticRegistryCommitRollsBack;
   protected
     procedure BeforeEach; override;
   public
@@ -342,8 +359,31 @@ begin
   TGarbageCollector.Initialize;
 end;
 
+constructor TFailingDiagnosticSourceScope.Create(
+  const AFailAtIndex: Integer);
+begin
+  inherited Create;
+  FFailAtIndex := AFailAtIndex;
+end;
+
+procedure TFailingDiagnosticSourceScope.AfterIndexCommit(
+  const AIndex: Integer);
+begin
+  inherited AfterIndexCommit(AIndex);
+  if AIndex = FFailAtIndex then
+    raise EOutOfMemory.Create('injected diagnostic registry allocation failure');
+end;
+
 procedure TMemoryLimitTests.SetupTests;
 begin
+  Test('Diagnostic file identity failure disables source disclosure',
+    TestDiagnosticIdentityFailureFailsClosed);
+  Test('Diagnostic canonical identity preserves first host ownership',
+    TestDiagnosticCanonicalIdentityKeepsHostOwnership);
+  Test('Diagnostic source caps and reservations use retained UTF-16 bytes',
+    TestDiagnosticSourceAccountingUsesRetainedBytes);
+  Test('Diagnostic registry commit rolls back indexes and reservation',
+    TestDiagnosticRegistryCommitRollsBack);
   Test('The gate refuses a request larger than the remaining budget',
     TestGateRefusesOverBudgetRequest);
   Test('The gate permits a request that fits the remaining budget',
@@ -1784,6 +1824,193 @@ begin
   finally
     FInstallFailingAuditSink := False;
   end;
+end;
+
+procedure TMemoryLimitTests.TestDiagnosticIdentityFailureFailsClosed;
+var
+  FirstLine: Integer;
+  Scope: TGocciaDiagnosticSourceScope;
+  Window: TStringList;
+begin
+  Scope := TGocciaDiagnosticSourceScope.Create;
+  Window := TStringList.Create;
+  try
+    { A filesystem content provider explicitly requires a handle-derived
+      identity. Blank means that lookup failed; retaining it under a lexical
+      spelling would let a later alias bypass host ownership. }
+    Scope.Register('unidentified-host.js', 'HOST_SECRET', True, '', True);
+    Expect<Int64>(Scope.RetainedBytes).ToBe(0);
+
+    { Once any filesystem identity is unresolved, no source in this scope is
+      disclosed: a later successfully-identified path could still alias the
+      unknown host file. Locations remain available outside this registry. }
+    Scope.Register('apparently-guest.js', 'GUEST_SOURCE', False,
+      '#test:guest-file', True);
+    Expect<Boolean>(Scope.TryGetGuestWindow('apparently-guest.js', 1, 0, 0,
+      Window, FirstLine)).ToBe(False);
+    Expect<Integer>(Window.Count).ToBe(0);
+  finally
+    Window.Free;
+    Scope.Free;
+  end;
+end;
+
+procedure TMemoryLimitTests.TestDiagnosticCanonicalIdentityKeepsHostOwnership;
+var
+  FirstLine: Integer;
+  RetainedAfterHost: Int64;
+  Scope: TGocciaDiagnosticSourceScope;
+  Window: TStringList;
+begin
+  Scope := TGocciaDiagnosticSourceScope.Create;
+  Window := TStringList.Create;
+  try
+    Scope.Register('host-spelling.js', 'HOST_ALIAS_SECRET', True,
+      '#test:volume-and-file-index', True);
+    RetainedAfterHost := Scope.RetainedBytes;
+    Expect<Boolean>(RetainedAfterHost > 0).ToBe(True);
+
+    { The same opened-file identity under another spelling is not enrolled as
+      a second guest entry. First registration wins, so the host classification
+      is durable across symlinks, junctions, hardlinks, and case aliases. }
+    Scope.Register('guest-alias.js', 'HOST_ALIAS_SECRET', False,
+      '#test:volume-and-file-index', True);
+    Expect<Int64>(Scope.RetainedBytes).ToBe(RetainedAfterHost);
+    Expect<Boolean>(Scope.TryGetGuestWindow('guest-alias.js', 1, 0, 0,
+      Window, FirstLine)).ToBe(False);
+    Expect<Boolean>(Scope.TryGetGuestWindow('host-spelling.js', 1, 0, 0,
+      Window, FirstLine)).ToBe(False);
+  finally
+    Window.Free;
+    Scope.Free;
+  end;
+end;
+
+procedure TMemoryLimitTests.TestDiagnosticSourceAccountingUsesRetainedBytes;
+var
+  AccountedBytes, BaselineBytes: Int64;
+  GC: TGarbageCollector;
+  ManyLines: TStringList;
+  ManyLinesText, OneUnit, TwoUnits: string;
+  PreviousMaxBytes: Int64;
+  Probe, Scope: TGocciaDiagnosticSourceScope;
+  I: Integer;
+begin
+  OneUnit := UnicodeString(WideChar($00E9));
+  TwoUnits := UnicodeString(WideChar($D83D)) + WideChar($DE00);
+  Expect<Integer>(Length(OneUnit)).ToBe(1);
+  Expect<Integer>(Length(TwoUnits)).ToBe(2);
+  Expect<Int64>(DiagnosticStringRetainedBytes(TwoUnits) -
+    DiagnosticStringRetainedBytes(OneUnit)).ToBe(SizeOf(Char));
+
+  { Measure the exact retained representation once, then prove the same figure
+    is both the registry counter and the collector reservation. }
+  GC := TGarbageCollector.Instance;
+  GC.Collect;
+  BaselineBytes := GC.BytesAllocated;
+  Scope := TGocciaDiagnosticSourceScope.Create;
+  try
+    Scope.Register('unicode.js', OneUnit + TwoUnits + sLineBreak + OneUnit,
+      False, '#test:unicode-source', True);
+    AccountedBytes := Scope.RetainedBytes;
+    Expect<Boolean>(AccountedBytes >
+      DiagnosticStringRetainedBytes(OneUnit + TwoUnits + sLineBreak +
+        OneUnit)).ToBe(True);
+    Expect<Int64>(GC.BytesAllocated - BaselineBytes).ToBe(AccountedBytes);
+  finally
+    Scope.Free;
+  end;
+  Expect<Int64>(GC.BytesAllocated).ToBe(BaselineBytes);
+
+  { One byte less than the measured retained figure must refuse the source and
+    must not leave any uncharged representation behind. }
+  Probe := TGocciaDiagnosticSourceScope.Create;
+  try
+    Probe.Register('probe.js', OneUnit + TwoUnits + sLineBreak + OneUnit,
+      False, '#test:probe-source', True);
+    AccountedBytes := Probe.RetainedBytes;
+  finally
+    Probe.Free;
+  end;
+  GC.Collect;
+  BaselineBytes := GC.BytesAllocated;
+  PreviousMaxBytes := GC.MaxBytes;
+  Scope := TGocciaDiagnosticSourceScope.Create;
+  try
+    GC.MaxBytes := BaselineBytes + AccountedBytes - 1;
+    Scope.Register('refused.js', OneUnit + TwoUnits + sLineBreak + OneUnit,
+      False, '#test:refused-source', True);
+    Expect<Int64>(Scope.RetainedBytes).ToBe(0);
+  finally
+    Scope.Free;
+    GC.MaxBytes := PreviousMaxBytes;
+  end;
+
+  { UTF-16 content length alone is below the per-module cap, but splitting
+    many short lines retains a header plus container slots for every line. The
+    actual representation crosses the cap and must therefore be rejected. }
+  ManyLines := TStringList.Create;
+  try
+    for I := 1 to 20000 do
+      ManyLines.Add(OneUnit);
+    ManyLinesText := ManyLines.Text;
+  finally
+    ManyLines.Free;
+  end;
+  Expect<Boolean>(DiagnosticStringRetainedBytes(ManyLinesText) <
+    GOCCIA_DIAGNOSTIC_SOURCE_CAP_BYTES).ToBe(True);
+  Scope := TGocciaDiagnosticSourceScope.Create;
+  try
+    Scope.Register('many-lines.js', ManyLinesText, False,
+      '#test:many-lines-source', True);
+    Expect<Int64>(Scope.RetainedBytes).ToBe(0);
+  finally
+    Scope.Free;
+  end;
+end;
+
+procedure TMemoryLimitTests.TestDiagnosticRegistryCommitRollsBack;
+var
+  BaselineBytes: Int64;
+  FirstLine: Integer;
+  GC: TGarbageCollector;
+  Raised: Boolean;
+  Scope: TFailingDiagnosticSourceScope;
+  Window: TStringList;
+begin
+  GC := TGarbageCollector.Instance;
+  GC.Collect;
+  BaselineBytes := GC.BytesAllocated;
+  Scope := TFailingDiagnosticSourceScope.Create(2);
+  Window := TStringList.Create;
+  try
+    Raised := False;
+    try
+      Scope.Register('transaction.js', 'const transaction = true;', False,
+        '#test:transaction-source', True);
+    except
+      on E: EOutOfMemory do
+        Raised := True;
+    end;
+    Expect<Boolean>(Raised).ToBe(True);
+    Expect<Int64>(Scope.RetainedBytes).ToBe(0);
+    Expect<Int64>(GC.BytesAllocated).ToBe(BaselineBytes);
+    Expect<Boolean>(Scope.TryGetGuestWindow('transaction.js', 1, 0, 0,
+      Window, FirstLine)).ToBe(False);
+
+    { A retry of the same identity succeeds after disarming the injected
+      failure, proving the failed transaction left no inaccessible map entry. }
+    Scope.FailAtIndex := 0;
+    Scope.Register('transaction.js', 'const transaction = true;', False,
+      '#test:transaction-source', True);
+    Expect<Boolean>(Scope.RetainedBytes > 0).ToBe(True);
+    Expect<Boolean>(Scope.TryGetGuestWindow('transaction.js', 1, 0, 0,
+      Window, FirstLine)).ToBe(True);
+  finally
+    Window.Free;
+    Scope.Free;
+  end;
+  Expect<Int64>(GC.BytesAllocated).ToBe(BaselineBytes);
 end;
 
 begin

--- a/source/units/Goccia.Modules.ContentProvider.pas
+++ b/source/units/Goccia.Modules.ContentProvider.pas
@@ -12,16 +12,25 @@ type
   TGocciaModuleContent = class
   private
     FByteLength: Integer;
+    FCanonicalIdentity: string;
+    FIdentityRequired: Boolean;
     FLastModified: TDateTime;
     FSourceLines: TStringList;
     FText: string;
     function GetByteLength: Integer;
     function GetText: string;
   public
-    constructor Create(const AText: string; const ALastModified: TDateTime);
+    constructor Create(const AText: string; const ALastModified: TDateTime;
+      const ACanonicalIdentity: string = '';
+      const AIdentityRequired: Boolean = False);
     destructor Destroy; override;
 
     property ByteLength: Integer read GetByteLength;
+    { Stable file-object identity captured from the same open handle used to
+      read Text. Empty with IdentityRequired=True means identity acquisition
+      failed and diagnostics must not retain the source under a path key. }
+    property CanonicalIdentity: string read FCanonicalIdentity;
+    property IdentityRequired: Boolean read FIdentityRequired;
     property LastModified: TDateTime read FLastModified;
     property SourceLines: TStringList read FSourceLines;
     property Text: string read GetText;
@@ -61,6 +70,13 @@ type
 implementation
 
 uses
+{$IFDEF UNIX}
+  BaseUnix,
+{$ENDIF}
+{$IFDEF WINDOWS}
+  Windows,
+{$ENDIF}
+
   TextEncoding,
   TextSemantics,
 
@@ -83,10 +99,13 @@ end;
 { TGocciaModuleContent }
 
 constructor TGocciaModuleContent.Create(const AText: string;
-  const ALastModified: TDateTime);
+  const ALastModified: TDateTime; const ACanonicalIdentity: string;
+  const AIdentityRequired: Boolean);
 begin
   inherited Create;
   FByteLength := Length(EncodeUTF8WithReplacement(AText));
+  FCanonicalIdentity := ACanonicalIdentity;
+  FIdentityRequired := AIdentityRequired;
   FLastModified := ALastModified;
   FText := AText;
   FSourceLines := CreateFileTextLines(FText);
@@ -164,13 +183,48 @@ end;
 function TGocciaFileSystemModuleContentProvider.LoadContent(
   const APath: string): TGocciaModuleContent;
 var
+  Bytes: TBytes;
+  CanonicalIdentity: string;
+  ErrorOffset: Integer;
+{$IFDEF UNIX}
+  Information: Stat;
+{$ENDIF}
+{$IFDEF WINDOWS}
+  Information: BY_HANDLE_FILE_INFORMATION;
+{$ENDIF}
   LastModified: TDateTime;
   SourceText: string;
+  Stream: TFileStream;
 begin
-  SourceText := ReadUTF8FileText(APath);
+  CanonicalIdentity := '';
+  Stream := TFileStream.Create(APath, fmOpenRead or fmShareDenyWrite);
+  try
+{$IFDEF UNIX}
+    if fpFStat(Stream.Handle, Information) = 0 then
+      CanonicalIdentity := '#id:' + IntToStr(Int64(Information.st_dev)) + ':' +
+        IntToStr(Int64(Information.st_ino));
+{$ENDIF}
+{$IFDEF WINDOWS}
+    if GetFileInformationByHandle(Windows.THandle(Stream.Handle),
+       Information) then
+      CanonicalIdentity := '#id:' +
+        IntToStr(Int64(Information.dwVolumeSerialNumber)) + ':' +
+        IntToStr(Int64(Information.nFileIndexHigh)) + ':' +
+        IntToStr(Int64(Information.nFileIndexLow));
+{$ENDIF}
+    SetLength(Bytes, Stream.Size);
+    if Length(Bytes) > 0 then
+      Stream.ReadBuffer(Bytes[0], Length(Bytes));
+  finally
+    Stream.Free;
+  end;
+  if not TryDecodeUTF8(Bytes, SourceText, ErrorOffset) then
+    raise EConvertError.CreateFmt('Invalid UTF-8 at byte %d in file "%s"',
+      [ErrorOffset, APath]);
   if not TryGetFileLastModified(APath, LastModified) then
     LastModified := 0;
-  Result := TGocciaModuleContent.Create(SourceText, LastModified);
+  Result := TGocciaModuleContent.Create(SourceText, LastModified,
+    CanonicalIdentity, True);
 end;
 
 function TGocciaFileSystemModuleContentProvider.LoadContentBytes(

--- a/source/units/Goccia.Modules.Loader.pas
+++ b/source/units/Goccia.Modules.Loader.pas
@@ -13,6 +13,7 @@ uses
   OrderedStringMap,
 
   Goccia.AST.Node,
+  Goccia.Diagnostics.SourceRegistry,
   Goccia.Error.ThrowErrorCallback,
   Goccia.Evaluator.Context,
   Goccia.MicrotaskQueue,
@@ -56,6 +57,14 @@ type
     FFailedModuleErrorModifiedTimes: TOrderedStringMap<TDateTime>;
     FGlobalModules: TOrderedStringMap<TGocciaModule>;
     FGlobalModuleProviders: TOrderedStringMap<TGocciaGlobalModuleProvider>;
+    { Durable ownership by resolved module address. A host-owned import marks
+      its target here before reading it, so static, dynamic and deferred imports
+      inherit ownership even when they resolve long after host enrollment. }
+    FHostOwnedModuleAddresses: TOrderedStringMap<Boolean>;
+    { The address map propagates through ordinary imports; this identity map
+      makes a path alias of a host file inherit the same ownership before that
+      aliased module can import anything of its own. }
+    FHostOwnedModuleIdentities: TOrderedStringMap<Boolean>;
     FGlobalScope: TGocciaGlobalScope;
     FLinkingDepth: Integer;
     FLoadingModules: TOrderedStringMap<Boolean>;
@@ -65,6 +74,11 @@ type
     FRetiredModules: TGocciaModuleList;
     FVirtualModules: TGocciaVirtualModuleRegistry;
     FWarnedVirtualCollisions: TOrderedStringMap<Boolean>;
+    // This engine's own diagnostic source scope (its principal). Modules load
+    // into it; runtime errors capture their code frame from it when it is the
+    // active scope. Owned here so registration always targets the loading
+    // engine's scope, never a coexisting engine's.
+    FDiagnosticScope: TGocciaDiagnosticSourceScope;
     FOnError: TGocciaThrowErrorCallback;
     FOwnsContentProvider: Boolean;
     FOwnsResolver: Boolean;
@@ -79,15 +93,16 @@ type
     function InstantiateModule(const AModulePath,
       AImportingFilePath: string): TGocciaModule;
     function LoadJSONModule(const AResolvedPath, ACacheKey,
-      ASpecifier: string): TGocciaModule;
+      ASpecifier: string; var AIsHostOwned: Boolean): TGocciaModule;
     function LoadTextModule(const AResolvedPath,
-      ACacheKey: string; const ADefaultOnly: Boolean): TGocciaModule;
+      ACacheKey: string; const ADefaultOnly: Boolean;
+      var AIsHostOwned: Boolean): TGocciaModule;
     function LoadBytesModule(const AResolvedPath,
-      ACacheKey: string): TGocciaModule;
+      ACacheKey: string; const AIsHostOwned: Boolean): TGocciaModule;
     function ResolveModuleRequestWithAttribute(const AModulePath,
       AAttributeType, AImportingFilePath: string): string;
-    function LoadResolvedContent(
-      const AResolvedPath: string): TGocciaModuleContent;
+    function LoadResolvedContent(const AResolvedPath: string;
+      var AIsHostOwned: Boolean): TGocciaModuleContent;
     function LoadResolvedContentBytes(const AResolvedPath: string): TBytes;
     function TryGetResolvedLastModified(const AResolvedPath: string;
       out ALastModified: TDateTime): Boolean;
@@ -99,6 +114,9 @@ type
     function TryGetCachedFailedModuleError(const AResolvedPath,
       ACacheKey: string; out AValue: TGocciaValue): Boolean;
     function HasGlobalModuleRequest(const AModulePath: string): Boolean;
+    function IsHostOwnedLoad(const AResolvedPath,
+      AImportingFilePath: string): Boolean;
+    procedure MarkHostOwnedAddress(const AAddress: string);
     function HasModuleStateForAddress(const AAddress: string): Boolean;
     function TryLoadGlobalModule(const AModulePath: string;
       out AModule: TGocciaModule): Boolean;
@@ -143,6 +161,10 @@ type
     procedure ValidateStaticNamedImports(const AProgram: TGocciaProgram;
       const AModule: TGocciaModule);
     function LoadModule(const AModulePath,
+      AImportingFilePath: string): TGocciaModule;
+    { Host enrollment entry point. Ownership is stamped on the resolved root and
+      then inherited transitively from module/address context by every import. }
+    function LoadHostModule(const AModulePath,
       AImportingFilePath: string): TGocciaModule;
     function LoadModuleSourceValue(const AModulePath,
       AImportingFilePath: string): TGocciaValue;
@@ -208,6 +230,10 @@ type
       read FRuntimeModuleLoader write FRuntimeModuleLoader;
     property VirtualModules: TGocciaVirtualModuleRegistry
       read FVirtualModules;
+    { This engine's diagnostic source scope, activated by the engine around its
+      own execution so runtime-error code frames capture from it. }
+    property DiagnosticScope: TGocciaDiagnosticSourceScope
+      read FDiagnosticScope;
   end;
 
 implementation
@@ -448,9 +474,12 @@ begin
   FRetiredModules := TGocciaModuleList.Create;
   FVirtualModules := TGocciaVirtualModuleRegistry.Create;
   FWarnedVirtualCollisions := TOrderedStringMap<Boolean>.Create;
+  FDiagnosticScope := TGocciaDiagnosticSourceScope.Create;
   FLoadingModules := TOrderedStringMap<Boolean>.Create;
   FGlobalModules := TOrderedStringMap<TGocciaModule>.Create;
   FGlobalModuleProviders := TOrderedStringMap<TGocciaGlobalModuleProvider>.Create;
+  FHostOwnedModuleAddresses := TOrderedStringMap<Boolean>.Create;
+  FHostOwnedModuleIdentities := TOrderedStringMap<Boolean>.Create;
 
   if Assigned(AResolver) then
   begin
@@ -527,9 +556,12 @@ begin
   FRetiredModules.Free;
   FVirtualModules.Free;
   FWarnedVirtualCollisions.Free;
+  FDiagnosticScope.Free;
   FLoadingModules.Free;
   FGlobalModuleProviders.Free;
   FGlobalModules.Free;
+  FHostOwnedModuleIdentities.Free;
+  FHostOwnedModuleAddresses.Free;
   if FOwnsResolver then
     FResolver.Free;
   if FOwnsContentProvider then
@@ -741,12 +773,34 @@ begin
     'No module resolver configured and cannot resolve "%s"', [AModulePath]);
 end;
 
-function TGocciaModuleLoader.LoadResolvedContent(
-  const AResolvedPath: string): TGocciaModuleContent;
+function TGocciaModuleLoader.LoadResolvedContent(const AResolvedPath: string;
+  var AIsHostOwned: Boolean): TGocciaModuleContent;
 begin
   if FVirtualModules.Contains(AResolvedPath) then
-    Exit(FVirtualModules.LoadContent(AResolvedPath));
-  Result := FContentProvider.LoadContent(AResolvedPath);
+    Result := FVirtualModules.LoadContent(AResolvedPath)
+  else
+    Result := FContentProvider.LoadContent(AResolvedPath);
+  if Assigned(Result) and (Result.CanonicalIdentity <> '') then
+  begin
+    if FHostOwnedModuleIdentities.ContainsKey(Result.CanonicalIdentity) then
+      AIsHostOwned := True;
+    if AIsHostOwned then
+      FHostOwnedModuleIdentities.AddOrSetValue(Result.CanonicalIdentity, True);
+  end;
+  if AIsHostOwned then
+    MarkHostOwnedAddress(AResolvedPath);
+  // Record this module's already-read text in THIS engine's OWN scope (never a
+  // coexisting engine's). Ownership is decided HERE, at load: a virtual module
+  // is always host-injected (the guest has no API to add one), and any
+  // import whose importing module/address is host-owned is host source too —
+  // both are host-owned and never handed to a guest in a code frame. Everything
+  // else is the guest's own import, guest-owned. A runtime error captures its ±context
+  // window from here at creation, only for guest-owned source in the active
+  // scope — never from a guest-supplied stack string (see
+  // Goccia.Diagnostics.SourceRegistry).
+  if Assigned(Result) then
+    FDiagnosticScope.Register(AResolvedPath, Result.Text,
+      AIsHostOwned, Result.CanonicalIdentity, Result.IdentityRequired);
 end;
 
 function TGocciaModuleLoader.LoadResolvedContentBytes(
@@ -912,6 +966,42 @@ begin
     FGlobalModuleProviders.ContainsKey(AModulePath);
 end;
 
+procedure TGocciaModuleLoader.MarkHostOwnedAddress(const AAddress: string);
+begin
+  if AAddress = '' then
+    Exit;
+  FHostOwnedModuleAddresses.AddOrSetValue(AAddress, True);
+  FHostOwnedModuleAddresses.AddOrSetValue(ExpandFileName(AAddress), True);
+end;
+
+function TGocciaModuleLoader.IsHostOwnedLoad(const AResolvedPath,
+  AImportingFilePath: string): Boolean;
+var
+  ImportingModule: TGocciaModule;
+begin
+  Result := StartsStr('goccia:', AResolvedPath) or
+    FVirtualModules.Contains(AResolvedPath) or
+    FHostOwnedModuleAddresses.ContainsKey(AResolvedPath) or
+    FHostOwnedModuleAddresses.ContainsKey(ExpandFileName(AResolvedPath));
+  if Result then
+    Exit;
+
+  Result := FHostOwnedModuleAddresses.ContainsKey(AImportingFilePath) or
+    FHostOwnedModuleAddresses.ContainsKey(ExpandFileName(AImportingFilePath));
+  if Result then
+    Exit;
+
+  if FModules.TryGetValue(AImportingFilePath, ImportingModule) or
+     FModules.TryGetValue(ExpandFileName(AImportingFilePath),
+       ImportingModule) then
+    Result := ImportingModule.IsHostOwned
+  else if FGlobalModules.TryGetValue(AImportingFilePath,
+          ImportingModule) then
+    Result := ImportingModule.IsHostOwned
+  else
+    Result := False;
+end;
+
 function TGocciaModuleLoader.HasModuleStateForAddress(
   const AAddress: string): Boolean;
 const
@@ -945,7 +1035,11 @@ var
   Provider: TGocciaGlobalModuleProvider;
 begin
   if FGlobalModules.TryGetValue(AModulePath, AModule) then
+  begin
+    AModule.IsHostOwned := True;
+    MarkHostOwnedAddress(AModulePath);
     Exit(True);
+  end;
 
   if not FGlobalModuleProviders.TryGetValue(AModulePath, Provider) then
   begin
@@ -960,6 +1054,8 @@ begin
       0, 0, AModulePath, nil);
 
   FGlobalModules.AddOrSetValue(AModulePath, AModule);
+  AModule.IsHostOwned := True;
+  MarkHostOwnedAddress(AModulePath);
   Result := True;
 end;
 
@@ -1059,6 +1155,8 @@ begin
   FModules.AddOrSetValue(CacheKey, AModule);
   if CacheKey <> AResolvedPath then
     FModules.AddOrSetValue(AResolvedPath, AModule);
+  if AModule.IsHostOwned then
+    MarkHostOwnedAddress(AResolvedPath);
 end;
 
 procedure TGocciaModuleLoader.CopyModuleContents(const ASourceModule,
@@ -1137,6 +1235,21 @@ begin
   finally
     PreservedStates.Free;
   end;
+end;
+
+function TGocciaModuleLoader.LoadHostModule(const AModulePath,
+  AImportingFilePath: string): TGocciaModule;
+var
+  ResolvedPath: string;
+begin
+  if HasGlobalModuleRequest(AModulePath) then
+    ResolvedPath := AModulePath
+  else
+    ResolvedPath := ResolveModuleAddress(AModulePath, AImportingFilePath);
+  MarkHostOwnedAddress(ResolvedPath);
+  Result := LoadModule(AModulePath, AImportingFilePath);
+  if Assigned(Result) then
+    Result.IsHostOwned := True;
 end;
 
 procedure TGocciaModuleLoader.EvaluateLinkedModule(
@@ -1320,6 +1433,7 @@ var
   I: Integer;
   ImportingFilePath: string;
   IsDeferredEvaluation: Boolean;
+  IsHostOwned: Boolean;
   LoadState: TGocciaModuleLoadState;
   LoadSucceeded: Boolean;
   Module: TGocciaModule;
@@ -1766,6 +1880,10 @@ begin
       raise TGocciaRuntimeError.Create(E.Message, 0, 0, ImportingFilePath, nil);
   end;
 
+  IsHostOwned := IsHostOwnedLoad(ResolvedPath, ImportingFilePath);
+  if IsHostOwned then
+    MarkHostOwnedAddress(ResolvedPath);
+
   CacheKey := ResolvedPath;
   if AttributeType <> '' then
     CacheKey := EncodeImportSpecifierAttribute(ResolvedPath, AttributeType);
@@ -1794,19 +1912,20 @@ begin
 
   if AttributeType = 'json' then
   begin
-    Result := LoadJSONModule(ResolvedPath, CacheKey, RequestedModulePath);
+    Result := LoadJSONModule(ResolvedPath, CacheKey, RequestedModulePath,
+      IsHostOwned);
     Exit;
   end;
 
   if AttributeType = 'text' then
   begin
-    Result := LoadTextModule(ResolvedPath, CacheKey, True);
+    Result := LoadTextModule(ResolvedPath, CacheKey, True, IsHostOwned);
     Exit;
   end;
 
   if AttributeType = 'bytes' then
   begin
-    Result := LoadBytesModule(ResolvedPath, CacheKey);
+    Result := LoadBytesModule(ResolvedPath, CacheKey, IsHostOwned);
     Exit;
   end;
 
@@ -1816,17 +1935,19 @@ begin
     case VirtualContentType of
       vmctJSON:
         begin
-          Result := LoadJSONModule(ResolvedPath, CacheKey, RequestedModulePath);
+          Result := LoadJSONModule(ResolvedPath, CacheKey,
+            RequestedModulePath, IsHostOwned);
           Exit;
         end;
       vmctText:
         begin
-          Result := LoadTextModule(ResolvedPath, CacheKey, False);
+          Result := LoadTextModule(ResolvedPath, CacheKey, False,
+            IsHostOwned);
           Exit;
         end;
       vmctBytes:
         begin
-          Result := LoadBytesModule(ResolvedPath, CacheKey);
+          Result := LoadBytesModule(ResolvedPath, CacheKey, IsHostOwned);
           Exit;
         end;
     end;
@@ -1834,13 +1955,14 @@ begin
 
   if LowerCase(ExtractFileExt(ResolvedPath)) = EXT_JSON then
   begin
-    Result := LoadJSONModule(ResolvedPath, CacheKey, RequestedModulePath);
+    Result := LoadJSONModule(ResolvedPath, CacheKey, RequestedModulePath,
+      IsHostOwned);
     Exit;
   end;
 
   if IsTextAssetExtension(ExtractFileExt(ResolvedPath)) then
   begin
-    Result := LoadTextModule(ResolvedPath, CacheKey, False);
+    Result := LoadTextModule(ResolvedPath, CacheKey, False, IsHostOwned);
     Exit;
   end;
 
@@ -1850,6 +1972,7 @@ begin
   begin
     if Assigned(Module) then
     begin
+      Module.IsHostOwned := IsHostOwned;
       try
         FModules.Add(CacheKey, Module);
         ClearFailedModuleError(CacheKey);
@@ -1862,7 +1985,7 @@ begin
     end;
   end;
 
-  Content := LoadResolvedContent(ResolvedPath);
+  Content := LoadResolvedContent(ResolvedPath, IsHostOwned);
   try
     PipelineOptions := TGocciaSourcePipeline.DefaultOptions;
     PipelineOptions.Preprocessors := FPreprocessors;
@@ -1891,6 +2014,7 @@ begin
       LoadState := nil;
       try
         Module := TGocciaModule.Create(ResolvedPath);
+        Module.IsHostOwned := IsHostOwned;
         Module.LastModified := Content.LastModified;
         FModules.Add(CacheKey, Module);
         FLoadingModules.AddOrSetValue(CacheKey, True);
@@ -1983,6 +2107,7 @@ var
   CacheKey: string;
   Content: TGocciaModuleContent;
   I: Integer;
+  IsHostOwned: Boolean;
   ModuleParseResult: TGocciaSourcePipelineModuleResult;
   ModuleWarning: TGocciaSourcePipelineWarning;
   PipelineOptions: TGocciaSourcePipelineOptions;
@@ -2034,6 +2159,10 @@ begin
       raise TGocciaRuntimeError.Create(E.Message, 0, 0, AImportingFilePath, nil);
   end;
 
+  IsHostOwned := IsHostOwnedLoad(ResolvedPath, AImportingFilePath);
+  if IsHostOwned then
+    MarkHostOwnedAddress(ResolvedPath);
+
   CacheKey := ResolvedPath;
   if AttributeType <> '' then
     CacheKey := EncodeImportSpecifierAttribute(ResolvedPath, AttributeType);
@@ -2058,7 +2187,7 @@ begin
       'JavaScript ModuleSource objects require --experimental-js-module-source',
       0, 0, AImportingFilePath, nil);
 
-  Content := LoadResolvedContent(ResolvedPath);
+  Content := LoadResolvedContent(ResolvedPath, IsHostOwned);
   try
     PipelineOptions := TGocciaSourcePipeline.DefaultOptions;
     PipelineOptions.Preprocessors := FPreprocessors;
@@ -2103,6 +2232,7 @@ var
   Content: TGocciaModuleContent;
   ExistingModule: TGocciaModule;
   ExistingPromise: TGocciaPromiseValue;
+  IsHostOwned: Boolean;
   ModuleParseResult: TGocciaSourcePipelineModuleResult;
   PhysicalPath: string;
   PipelineOptions: TGocciaSourcePipelineOptions;
@@ -2139,7 +2269,10 @@ begin
   if not IsJavaScriptModuleResource(PhysicalPath) then
     Exit(False);
 
-  Content := LoadResolvedContent(PhysicalPath);
+  IsHostOwned := IsHostOwnedLoad(PhysicalPath, '');
+  if IsHostOwned then
+    MarkHostOwnedAddress(PhysicalPath);
+  Content := LoadResolvedContent(PhysicalPath, IsHostOwned);
   try
     PipelineOptions := TGocciaSourcePipeline.DefaultOptions;
     PipelineOptions.Preprocessors := FPreprocessors;
@@ -2198,6 +2331,7 @@ procedure TGocciaModuleLoader.EvaluateDeferredAsyncDependencies(
 var
   AttributeType: string;
   Content: TGocciaModuleContent;
+  IsHostOwned: Boolean;
   LoadedModule: TGocciaModule;
   ModuleParseResult: TGocciaSourcePipelineModuleResult;
   PhysicalPath: string;
@@ -2221,7 +2355,10 @@ begin
   if not IsJavaScriptModuleResource(PhysicalPath) then
     Exit;
 
-  Content := LoadResolvedContent(PhysicalPath);
+  IsHostOwned := IsHostOwnedLoad(PhysicalPath, AImportingFilePath);
+  if IsHostOwned then
+    MarkHostOwnedAddress(PhysicalPath);
+  Content := LoadResolvedContent(PhysicalPath, IsHostOwned);
   try
     PipelineOptions := TGocciaSourcePipeline.DefaultOptions;
     PipelineOptions.Preprocessors := FPreprocessors;
@@ -2292,6 +2429,7 @@ var
   AttributeType: string;
   Content: TGocciaModuleContent;
   ImportDecl: TGocciaImportDeclaration;
+  IsHostOwned: Boolean;
   ModuleParseResult: TGocciaSourcePipelineModuleResult;
   PhysicalPath: string;
   PipelineOptions: TGocciaSourcePipelineOptions;
@@ -2315,7 +2453,10 @@ begin
   if not IsJavaScriptModuleResource(PhysicalPath) then
     Exit;
 
-  Content := LoadResolvedContent(PhysicalPath);
+  IsHostOwned := IsHostOwnedLoad(PhysicalPath, AImportingFilePath);
+  if IsHostOwned then
+    MarkHostOwnedAddress(PhysicalPath);
+  Content := LoadResolvedContent(PhysicalPath, IsHostOwned);
   try
     PipelineOptions := TGocciaSourcePipeline.DefaultOptions;
     PipelineOptions.Preprocessors := FPreprocessors;
@@ -2378,6 +2519,7 @@ var
   AttributeType: string;
   CacheKey: string;
   DeferredModulePath: string;
+  IsHostOwned: Boolean;
   RequestedModulePath: string;
   ResolvedPath: string;
   Seen: TOrderedStringMap<Boolean>;
@@ -2412,6 +2554,10 @@ begin
           nil);
     end;
   end;
+
+  IsHostOwned := IsHostOwnedLoad(ResolvedPath, AImportingFilePath);
+  if IsHostOwned then
+    MarkHostOwnedAddress(ResolvedPath);
 
   CacheKey := ResolvedPath;
   if AttributeType <> '' then
@@ -2502,7 +2648,7 @@ begin
 end;
 
 function TGocciaModuleLoader.LoadJSONModule(const AResolvedPath, ACacheKey,
-  ASpecifier: string): TGocciaModule;
+  ASpecifier: string; var AIsHostOwned: Boolean): TGocciaModule;
 var
   Content: TGocciaModuleContent;
   HasDefaultKey: Boolean;
@@ -2513,7 +2659,7 @@ var
   JSONParser: TGocciaJSONParser;
   LoadSucceeded: Boolean;
 begin
-  Content := LoadResolvedContent(AResolvedPath);
+  Content := LoadResolvedContent(AResolvedPath, AIsHostOwned);
   try
     JSONParser := TGocciaJSONParser.Create;
     try
@@ -2537,6 +2683,7 @@ begin
       TGarbageCollector.Instance.AddTempRoot(ParsedValue);
     try
       Module := TGocciaModule.Create(AResolvedPath);
+      Module.IsHostOwned := AIsHostOwned;
       Module.LastModified := Content.LastModified;
       LoadSucceeded := False;
       try
@@ -2571,7 +2718,8 @@ begin
 end;
 
 function TGocciaModuleLoader.LoadTextModule(const AResolvedPath,
-  ACacheKey: string; const ADefaultOnly: Boolean): TGocciaModule;
+  ACacheKey: string; const ADefaultOnly: Boolean;
+  var AIsHostOwned: Boolean): TGocciaModule;
 var
   Content: TGocciaModuleContent;
   LoadSucceeded: Boolean;
@@ -2582,7 +2730,7 @@ var
   TextRoot: TGocciaTempRoot;
   MetadataRoot: TGocciaTempRoot;
 begin
-  Content := LoadResolvedContent(AResolvedPath);
+  Content := LoadResolvedContent(AResolvedPath, AIsHostOwned);
   try
     NormalizedText := NormalizeNewlinesToLF(Content.Text);
     { The metadata strings below are GC safe points; the content string (which
@@ -2613,6 +2761,7 @@ begin
     end;
 
     Module := TGocciaModule.Create(AResolvedPath);
+    Module.IsHostOwned := AIsHostOwned;
     Module.LastModified := Content.LastModified;
     LoadSucceeded := False;
     try
@@ -2644,7 +2793,7 @@ end;
 // backed by an immutable ArrayBuffer. Named imports are rejected naturally
 // because the synthetic module declares only the default export.
 function TGocciaModuleLoader.LoadBytesModule(const AResolvedPath,
-  ACacheKey: string): TGocciaModule;
+  ACacheKey: string; const AIsHostOwned: Boolean): TGocciaModule;
 var
   Buffer: TGocciaArrayBufferValue;
   Bytes: TBytes;
@@ -2665,6 +2814,7 @@ begin
     TGarbageCollector.Instance.AddTempRoot(TypedArray);
   try
     Module := TGocciaModule.Create(AResolvedPath);
+    Module.IsHostOwned := AIsHostOwned;
     Module.LastModified := LastModified;
     LoadSucceeded := False;
     try

--- a/source/units/Goccia.Modules.pas
+++ b/source/units/Goccia.Modules.pas
@@ -86,6 +86,7 @@ type
     FExportBindings: TGocciaModuleExportBindingMap;
     FExportsTable: TGocciaValueMap;
     FLastModified: TDateTime;
+    FIsHostOwned: Boolean;
     FNamespaceObject: TGocciaObjectValue;
     FEvaluationPromise: TGocciaValue;
     FAsyncCycleRoot: TGocciaModule;
@@ -143,6 +144,9 @@ type
     property AsyncCycleRoot: TGocciaModule read FAsyncCycleRoot
       write FAsyncCycleRoot;
     property LastModified: TDateTime read FLastModified write FLastModified;
+    { Diagnostic ownership stamped at host enrollment and inherited by every
+      module this module imports, including later dynamic/deferred imports. }
+    property IsHostOwned: Boolean read FIsHostOwned write FIsHostOwned;
   end;
 
   TGocciaModuleNamespaceObject = class(TGocciaObjectValue)

--- a/source/units/Goccia.SourceSpan.pas
+++ b/source/units/Goccia.SourceSpan.pas
@@ -48,6 +48,10 @@ type
       AEndOffset: Integer): TGocciaSourceSpan;
     function Cover(const AOther: TGocciaSourceSpan): TGocciaSourceSpan;
     function Length: Integer;
+    { The exact source text this span covers, or '' when the span carries no
+      coordinates (synthetic nodes, shim-generated AST). Used by runtime
+      diagnostics that name an expression the way the author wrote it. }
+    function Text: string;
     function OffsetAtPosition(const ALine, AColumn: Integer): Integer;
     property StartOffset: Integer read FStartOffset;
     property EndOffset: Integer read FEndOffset;
@@ -105,6 +109,25 @@ end;
 function TGocciaSourceSpan.Length: Integer;
 begin
   Result := FEndOffset - FStartOffset;
+end;
+
+function TGocciaSourceSpan.Text: string;
+var
+  SourceText: string;
+  Count, SourceLength: Integer;
+begin
+  Result := '';
+  if not Assigned(FCoordinates) then
+    Exit;
+  SourceText := FCoordinates.Source;
+  SourceLength := System.Length(SourceText);
+  if (FStartOffset < 0) or (FStartOffset >= SourceLength) or
+     (FEndOffset <= FStartOffset) then
+    Exit;
+  Count := FEndOffset - FStartOffset;
+  if FStartOffset + Count > SourceLength then
+    Count := SourceLength - FStartOffset;
+  Result := Copy(SourceText, FStartOffset + 1, Count);
 end;
 
 function TGocciaSourceSpan.GetStartLine: Integer;

--- a/source/units/Goccia.VM.Exception.pas
+++ b/source/units/Goccia.VM.Exception.pas
@@ -42,9 +42,16 @@ type
   EGocciaBytecodeThrow = class(Exception)
   private
     FThrownValue: TGocciaValue;
+    FSuggestion: string;
   public
-    constructor Create(const AThrownValue: TGocciaValue);
+    constructor Create(const AThrownValue: TGocciaValue;
+      const ASuggestion: string = '');
     property ThrownValue: TGocciaValue read FThrownValue;
+    { The engine-authored "Suggestion:" line of the diagnostic, carried across
+      the VM unwind so a throw that escapes to a host runner renders the same
+      hint the tree-walk evaluator's TGocciaThrowValue would. Empty for a
+      user-authored `throw`. }
+    property Suggestion: string read FSuggestion;
   end;
 
 // A JS throw escaping the bytecode VM through a native builtin arrives as
@@ -64,7 +71,8 @@ uses
 procedure ReraiseBytecodeThrow(const AException: Exception);
 begin
   if AException is EGocciaBytecodeThrow then
-    raise TGocciaThrowValue.Create(EGocciaBytecodeThrow(AException).ThrownValue);
+    raise TGocciaThrowValue.Create(EGocciaBytecodeThrow(AException).ThrownValue,
+      EGocciaBytecodeThrow(AException).Suggestion);
 end;
 
 procedure TGocciaBytecodeHandlerStack.Push(const ACatchIP: Integer;
@@ -132,7 +140,8 @@ begin
   Result := FCount = 0;
 end;
 
-constructor EGocciaBytecodeThrow.Create(const AThrownValue: TGocciaValue);
+constructor EGocciaBytecodeThrow.Create(const AThrownValue: TGocciaValue;
+  const ASuggestion: string);
 var
   MessageText: string;
   ErrorObject: TGocciaObjectValue;
@@ -156,6 +165,7 @@ begin
   end;
   inherited Create(MessageText);
   FThrownValue := AThrownValue;
+  FSuggestion := ASuggestion;
 end;
 
 end.

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -197,6 +197,14 @@ type
     FCurrentConstructorSuperCalled: Boolean;
     FPrivateInitializerReceiver: TGocciaValue;
     FPrivateInitializerPreserveExisting: Boolean;
+    // Probe into the innermost running dispatch loop's `Template` and
+    // `InstructionStartIP` locals, saved/restored once per native re-entry.
+    // Pointers, not copies: the dispatch loop must not pay a store per
+    // instruction just so a throw can find out where it happened, and both
+    // locals are live for exactly as long as the probe points at them.
+    // Read only on throw paths (StampThrowLocation).
+    FActiveTemplateProbe: PPointer;
+    FActiveInstructionIPProbe: PInteger;
     FStackRoot: TGocciaVMStackRoot;
     FStackRootRegistered: Boolean;
     FTempSavedStateRoots: TGocciaVMSavedStateRootArray;
@@ -279,6 +287,13 @@ type
     function ResolveDynamicUpvalueScope(const AIndex: Integer;
       const AName: string): TGocciaScope;
     function KeyDisplaySafe(const AKey: TGocciaRegister): string;
+    { Stamps the executing call-stack frame with the source position of the
+      instruction the VM is currently on, so an error created from here carries
+      a usable `file:line:column` in its stack trace. Deferred bytecode frames
+      are pushed without a position (ADR 0074); this recovers it on the throw
+      path only, where the debug-map lookup is free of hot-path cost. No-op
+      when the VM is not executing bytecode. }
+    procedure StampThrowLocation;
     procedure ThrowNullishBasePropertyAccess(const ABaseKind: TGocciaRegisterKind;
       const AKeyReg: TGocciaRegister; const AForWrite: Boolean);
     procedure RequireCoercibleBaseRegister(const ABaseReg,
@@ -448,7 +463,8 @@ type
       const AInitialFrameStackCount, AInitialClosedNumericFrameCount,
       ASavedHandlerCount: Integer;
       var AFrame: TGocciaVMCallFrame; var ATemplate: TGocciaFunctionTemplate;
-      var APrevCovLine: UInt32; var AProfileTimestamp: Int64);
+      var APrevCovLine: UInt32; var AProfileTimestamp: Int64;
+      const ASuggestion: string = '');
     procedure ExecuteGeneratorParameterPreamble(const AGenerator: TObject);
     function ExecuteClosureRegistersInternal(const AClosure: TGocciaBytecodeClosure;
       const AThisValue: TGocciaRegister; const AArguments: TGocciaRegisterArray;
@@ -531,6 +547,7 @@ uses
   Goccia.DisposalTracker,
   Goccia.EngineFault,
   Goccia.Error,
+  Goccia.Error.CallDiagnostics,
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
   Goccia.Evaluator,
@@ -8963,12 +8980,31 @@ end;
 // Throw path only. Kept out of RequireCoercibleBaseRegister — and deliberately
 // not inlined — so the managed string local and its implicit exception frame stay
 // off every computed member access.
+procedure TGocciaVM.StampThrowLocation;
+var
+  ActiveTemplate: TGocciaFunctionTemplate;
+  PC: UInt32;
+begin
+  if (TGocciaCallStack.Instance = nil) or
+     (FActiveTemplateProbe = nil) or (FActiveInstructionIPProbe = nil) then
+    Exit;
+  ActiveTemplate := TGocciaFunctionTemplate(FActiveTemplateProbe^);
+  if (not Assigned(ActiveTemplate)) or (not Assigned(ActiveTemplate.DebugInfo)) then
+    Exit;
+  PC := UInt32(FActiveInstructionIPProbe^);
+  TGocciaCallStack.Instance.SetTopFrameLocation(
+    ActiveTemplate.DebugInfo.SourceFile,
+    Integer(ActiveTemplate.DebugInfo.GetLineForPC(PC)),
+    Integer(ActiveTemplate.DebugInfo.GetColumnForPC(PC)));
+end;
+
 procedure TGocciaVM.ThrowNullishBasePropertyAccess(
   const ABaseKind: TGocciaRegisterKind; const AKeyReg: TGocciaRegister;
   const AForWrite: Boolean);
 var
   KeyText: string;
 begin
+  StampThrowLocation;
   // The key has not been coerced yet, so it must be named without invoking user
   // code (ES2026 §6.2.5.5 GetValue step 3.a runs before step 3.c ToPropertyKey).
   KeyText := KeyDisplaySafe(AKeyReg);
@@ -12555,6 +12591,9 @@ var
   BrandValue: TGocciaValue;
   EmptyArgs: TGocciaArgumentsCollection;
 begin
+  if (AObject is TGocciaNullLiteralValue) or
+     (AObject is TGocciaUndefinedLiteralValue) then
+    StampThrowLocation;
   if AObject is TGocciaNullLiteralValue then
     ThrowTypeError(Format(SErrorCannotReadPropertiesOfNull, [AKey]),
       SSuggestCheckNullBeforeAccess);
@@ -13216,7 +13255,7 @@ begin
   if not BindingObject.HasProperty(KeyStr) then
   begin
     if AStrict then
-      ThrowReferenceError(KeyStr + ' is not defined');
+      ThrowReferenceError(Format(SErrorUndefinedVariable, [KeyStr]));
     Exit(TGocciaUndefinedLiteralValue.UndefinedValue);
   end;
 
@@ -13244,7 +13283,7 @@ begin
     StillExists := BindingObject.HasProperty(KeyStr);
 
     if AStrict and not StillExists then
-      ThrowReferenceError(KeyStr + ' is not defined');
+      ThrowReferenceError(Format(SErrorUndefinedVariable, [KeyStr]));
 
     if AStrict then
       SetPropertyValue(BindingObject, KeyStr, AValue)
@@ -14134,7 +14173,8 @@ procedure TGocciaVM.HandleExceptionUnwind(const AErrorValue: TGocciaValue;
   const AInitialFrameStackCount, AInitialClosedNumericFrameCount,
   ASavedHandlerCount: Integer;
   var AFrame: TGocciaVMCallFrame; var ATemplate: TGocciaFunctionTemplate;
-  var APrevCovLine: UInt32; var AProfileTimestamp: Int64);
+  var APrevCovLine: UInt32; var AProfileTimestamp: Int64;
+  const ASuggestion: string);
 var
   Handler: TGocciaBytecodeHandlerEntry;
   TargetHandlerCount: Integer;
@@ -14161,9 +14201,11 @@ begin
       SetRegister(Handler.CatchRegister, AErrorValue);
       Exit;
     end;
-    // Outermost frame: let the finally block handle teardown
+    // Outermost frame: let the finally block handle teardown. The suggestion
+    // travels with the throw so a host runner can render the same
+    // "Suggestion:" line the tree-walk evaluator's TGocciaThrowValue carries.
     if FFrameStackCount <= AInitialFrameStackCount then
-      raise EGocciaBytecodeThrow.Create(AErrorValue);
+      raise EGocciaBytecodeThrow.Create(AErrorValue, ASuggestion);
     // Intermediate trampoline frame: tear down and pop to parent
     TeardownCurrentFrame(ATemplate, AProfileTimestamp,
       FFrameStack[FFrameStackCount - 1].HandlerCount);
@@ -14298,6 +14340,8 @@ var
   // and then re-enter guest code (key coercion / custom-matcher lookup) before
   // consuming it. Re-Initialized per use, so sharing one record is safe.
   OperandRoots: TGocciaActiveRootFrame;
+  SavedActiveTemplateProbe: PPointer;
+  SavedActiveInstructionIPProbe: PInteger;
 
   procedure CurrentInstructionDebugLocation(out ALine, AColumn: Integer);
   begin
@@ -14320,6 +14364,114 @@ var
     else
       SourcePath := '';
     EnterGocciaCallSite(SourcePath, DebugLine, DebugColumn, APrevious);
+  end;
+
+  { Throw path only. Stamps the executing frame with this instruction's source
+    position so the error object's stack trace — and therefore the runner's
+    `--> file:line:column` header and code frame — matches what the tree-walk
+    evaluator reports for the same fault. Deferred frames carry no position of
+    their own (ADR 0074); paying the debug-map lookup here costs nothing on the
+    hot path. }
+  procedure StampCurrentInstructionLocation;
+  var
+    SourcePath: string;
+  begin
+    if TGocciaCallStack.Instance = nil then
+      Exit;
+    CurrentInstructionDebugLocation(DebugLine, DebugColumn);
+    if Assigned(Template) and Assigned(Template.DebugInfo) then
+      SourcePath := Template.DebugInfo.SourceFile
+    else
+      SourcePath := '';
+    TGocciaCallStack.Instance.SetTopFrameLocation(SourcePath, DebugLine,
+      DebugColumn);
+  end;
+
+  function CurrentCallSite: TGocciaCallSiteEntry;
+  begin
+    if Assigned(Template) then
+      Result := Template.CallSiteAt(UInt32(InstructionStartIP))
+    else
+    begin
+      Result.PC := 0;
+      Result.Callee := EmptyCalleeDescriptor;
+      Result.Line := 0;
+      Result.Column := 0;
+      Result.Recorded := False;
+    end;
+  end;
+
+  { Stamps the frame with the call expression's own position when the compiler
+    recorded one, which is what the tree-walk evaluator's per-call frame
+    carries; the instruction line map only resolves to the enclosing
+    statement. }
+  procedure StampCallSiteLocation(const ACallSite: TGocciaCallSiteEntry);
+  var
+    SourcePath: string;
+  begin
+    if not ACallSite.Recorded then
+    begin
+      StampCurrentInstructionLocation;
+      Exit;
+    end;
+    if TGocciaCallStack.Instance = nil then
+      Exit;
+    if Assigned(Template) and Assigned(Template.DebugInfo) then
+      SourcePath := Template.DebugInfo.SourceFile
+    else
+      SourcePath := '';
+    TGocciaCallStack.Instance.SetTopFrameLocation(SourcePath, ACallSite.Line,
+      ACallSite.Column);
+  end;
+
+  function ValueTypeNameOrUndefined(const AValue: TGocciaValue): string;
+  begin
+    if Assigned(AValue) then
+      Result := AValue.TypeName
+    else
+      Result := 'undefined';
+  end;
+
+  { The callee of the call instruction being executed is not callable. Uses the
+    descriptor the compiler recorded for this call site so the message names the
+    callee exactly as the evaluator's AST-derived one does. AReceiver is the
+    method call's `this` (nil for a plain call). }
+  procedure ThrowNotCallableHere(const ACallee, AReceiver: TGocciaValue);
+  var
+    CallSite: TGocciaCallSiteEntry;
+    CalleeTypeName, ReceiverTypeName: string;
+  begin
+    CallSite := CurrentCallSite;
+    CalleeTypeName := ValueTypeNameOrUndefined(ACallee);
+    if Assigned(AReceiver) then
+      ReceiverTypeName := AReceiver.TypeName
+    else
+      ReceiverTypeName := CalleeTypeName;
+    StampCallSiteLocation(CallSite);
+    ThrowTypeError(NotCallableMessage(CallSite.Callee, CalleeTypeName),
+      NotCallableSuggestion(CallSite.Callee, ReceiverTypeName, CalleeTypeName));
+  end;
+
+  procedure ThrowNotConstructorHere(const ACallee: TGocciaValue);
+  var
+    CallSite: TGocciaCallSiteEntry;
+    CalleeTypeName: string;
+  begin
+    CallSite := CurrentCallSite;
+    CalleeTypeName := ValueTypeNameOrUndefined(ACallee);
+    StampCallSiteLocation(CallSite);
+    ThrowTypeError(NotConstructorMessage(CallSite.Callee, CalleeTypeName),
+      NotConstructorSuggestion(CallSite.Callee, CalleeTypeName));
+  end;
+
+  { ES2026 §7.2.5 IsConstructor, restricted to the shapes this VM can build:
+    everything else reaches the same "is not a constructor" rejection the
+    ConstructValue tail performs, only with the call site's own wording. }
+  function MayBeConstructor(const AValue: TGocciaValue): Boolean;
+  begin
+    Result := Assigned(AValue) and (AValue is TGocciaObjectValue) and
+      (AValue.IsCallable or (AValue is TGocciaClassValue) or
+       (AValue is TGocciaProxyValue));
   end;
 
 begin
@@ -14361,6 +14513,10 @@ begin
       SetCurrentRealm(ExecutionRealm);
     try
       Inc(FNativeExecutionDepth);
+      SavedActiveTemplateProbe := FActiveTemplateProbe;
+      SavedActiveInstructionIPProbe := FActiveInstructionIPProbe;
+      FActiveTemplateProbe := PPointer(@Template);
+      FActiveInstructionIPProbe := @InstructionStartIP;
       SetupNewFrame(AClosure, AThisValue, AArguments, AArgCount,
         AArg0, AArg1, AArg2, AUseFixedArgs, APushExecutionContext,
         Frame, Template, PrevCovLine, ProfileEntryTimestamp);
@@ -14752,7 +14908,7 @@ begin
         if Assigned(FGlobalScope) and
            not FGlobalScope.TryAssignExistingBinding(GlobalName,
              RegisterToValue(FRegisters[A])) then
-          ThrowReferenceError(GlobalName + ' is not defined');
+          ThrowReferenceError(Format(SErrorUndefinedVariable, [GlobalName]));
       end;
 
       OP_CLOSE_UPVALUE:
@@ -16801,6 +16957,10 @@ begin
           else
             for I := 0 to B - 1 do
               CallArgs.Add(GetRegister(A + 1 + I));
+          if not (Assigned(GetRegister(A)) and
+                  (GetRegister(A).IsCallable or
+                   (GetRegister(A) is TGocciaProxyValue))) then
+            ThrowNotCallableHere(GetRegister(A), nil);
           if (GetRegister(A) is TGocciaNativeFunctionValue) or
              (GetRegister(A) is TGocciaFunctionConstructorClassValue) or
              (GetRegister(A) is TGocciaBoundFunctionValue) or
@@ -17096,6 +17256,10 @@ begin
           else
             for I := 0 to B - 1 do
               CallArgs.Add(GetRegister(A + 1 + I));
+          if not (Assigned(GetRegister(A)) and
+                  (GetRegister(A).IsCallable or
+                   (GetRegister(A) is TGocciaProxyValue))) then
+            ThrowNotCallableHere(GetRegister(A), GetRegister(A - 1));
           if (GetRegister(A) is TGocciaNativeFunctionValue) or
              (GetRegister(A) is TGocciaFunctionConstructorClassValue) or
              (GetRegister(A) is TGocciaBoundFunctionValue) or
@@ -17130,6 +17294,13 @@ begin
         end
         else
         begin
+          if not MayBeConstructor(GetRegister(B)) then
+            ThrowNotConstructorHere(GetRegister(B));
+          { A native constructor can capture a stack trace (`new Error(...)`),
+            and this frame carries no position of its own. Stamp the construct
+            site first so the captured trace — and the diagnostic rendered from
+            it — locates the `new` expression. }
+          StampCallSiteLocation(CurrentCallSite);
           CallArgs := AcquireArguments(C);
           try
             for I := 0 to C - 1 do
@@ -17161,6 +17332,9 @@ begin
         end
         else
         begin
+          if not MayBeConstructor(GetRegister(B)) then
+            ThrowNotConstructorHere(GetRegister(B));
+          StampCallSiteLocation(CurrentCallSite);
           CallArgs := AcquireArguments(SpreadArray.Elements.Count);
           try
             for I := 0 to SpreadArray.Elements.Count - 1 do
@@ -17515,7 +17689,7 @@ begin
                 DebugLine, DebugColumn,
                 '', nil, SSuggestUseLetNotConst);
             end;
-            ThrowReferenceError(GlobalName + ' is not defined');
+            ThrowReferenceError(Format(SErrorUndefinedVariable, [GlobalName]));
           end;
         end;
       end;
@@ -18308,24 +18482,24 @@ begin
           HandleExceptionUnwind(E.ThrownValue,
             InitialFrameStackCount, InitialClosedNumericFrameCount,
             SavedHandlerCount,
-            Frame, Template, PrevCovLine, ProfileEntryTimestamp);
+            Frame, Template, PrevCovLine, ProfileEntryTimestamp, E.Suggestion);
         on E: TGocciaThrowValue do
           HandleExceptionUnwind(E.Value,
             InitialFrameStackCount, InitialClosedNumericFrameCount,
             SavedHandlerCount,
-            Frame, Template, PrevCovLine, ProfileEntryTimestamp);
+            Frame, Template, PrevCovLine, ProfileEntryTimestamp, E.Suggestion);
         on E: TGocciaTypeError do
           HandleExceptionUnwind(
             CreateErrorObject(TYPE_ERROR_NAME, E.Message),
             InitialFrameStackCount, InitialClosedNumericFrameCount,
             SavedHandlerCount,
-            Frame, Template, PrevCovLine, ProfileEntryTimestamp);
+            Frame, Template, PrevCovLine, ProfileEntryTimestamp, E.Suggestion);
         on E: TGocciaReferenceError do
           HandleExceptionUnwind(
             CreateErrorObject(REFERENCE_ERROR_NAME, E.Message),
             InitialFrameStackCount, InitialClosedNumericFrameCount,
             SavedHandlerCount,
-            Frame, Template, PrevCovLine, ProfileEntryTimestamp);
+            Frame, Template, PrevCovLine, ProfileEntryTimestamp, E.Suggestion);
         on E: TGocciaSyntaxError do
           HandleExceptionUnwind(
             CreateErrorObject(SYNTAX_ERROR_NAME, E.Message),
@@ -18337,12 +18511,14 @@ begin
             CreateErrorObject(ERROR_NAME, E.Message),
             InitialFrameStackCount, InitialClosedNumericFrameCount,
             SavedHandlerCount,
-            Frame, Template, PrevCovLine, ProfileEntryTimestamp);
+            Frame, Template, PrevCovLine, ProfileEntryTimestamp, E.Suggestion);
       end;
     end;
     Result := RegisterUndefined;
     finally
       Dec(FNativeExecutionDepth);
+      FActiveTemplateProbe := SavedActiveTemplateProbe;
+      FActiveInstructionIPProbe := SavedActiveInstructionIPProbe;
       try
       UnwindClosedNumericFrames(InitialClosedNumericFrameCount, Frame,
         Template, PrevCovLine, ProfileEntryTimestamp);

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -5812,10 +5812,9 @@ begin
   begin
     if TGocciaNativeFunctionValue(AConstructor).NotConstructable then
       ThrowTypeError(
-        Format(SErrorNotConstructor,
+        Format(SErrorValueNotConstructor,
           [TGocciaNativeFunctionValue(AConstructor).Name]),
-        Format('''%s'' is not a constructor',
-          [TGocciaNativeFunctionValue(AConstructor).Name]));
+        SSuggestNotConstructorType);
     SuperResult := TGocciaNativeFunctionValue(AConstructor).Construct(
       AArguments, EffectiveNewTarget);
   end
@@ -9810,10 +9809,9 @@ begin
   begin
     if TGocciaNativeFunctionValue(AConstructor).NotConstructable then
       ThrowTypeError(
-        Format(SErrorNotConstructor,
+        Format(SErrorValueNotConstructor,
           [TGocciaNativeFunctionValue(AConstructor).Name]),
-        Format('''%s'' is not a constructor',
-          [TGocciaNativeFunctionValue(AConstructor).Name]));
+        SSuggestNotConstructorType);
     ConstructorName := TGocciaNativeFunctionValue(AConstructor).Name;
     if (TGocciaCallStack.Instance <> nil) then
       TGocciaCallStack.Instance.Push(ConstructorName, '', 0, 0);
@@ -9835,7 +9833,7 @@ begin
        (BytecodeFunction.FClosure.Template.IsGenerator or
         BytecodeFunction.FClosure.Template.IsAsync or
         BytecodeFunction.FClosure.Template.IsArrow) then
-      ThrowTypeError(Format(SErrorNotConstructor,
+      ThrowTypeError(Format(SErrorValueNotConstructor,
         [BytecodeFunction.GetProperty(PROP_NAME).ToStringLiteral.Value]),
         SSuggestNotConstructorType);
     if (BytecodeFunction.FConstructClassValue is TGocciaVMClassValue) and
@@ -9858,7 +9856,7 @@ begin
     ConstructorName := TGocciaFunctionBase(AConstructor).GetProperty(PROP_NAME)
       .ToStringLiteral.Value;
     if not TGocciaFunctionBase(AConstructor).IsConstructable then
-      ThrowTypeError(Format(SErrorNotConstructor, [ConstructorName]),
+      ThrowTypeError(Format(SErrorValueNotConstructor, [ConstructorName]),
         SSuggestNotConstructorType);
     // ES2026 §10.2.2 [[Construct]] for ordinary function objects:
     // OrdinaryCreateFromConstructor allocates a fresh object whose
@@ -14342,6 +14340,8 @@ var
   OperandRoots: TGocciaActiveRootFrame;
   SavedActiveTemplateProbe: PPointer;
   SavedActiveInstructionIPProbe: PInteger;
+  SavedConstructFrame: TGocciaCallFrame;
+  SavedConstructFrameOk: Boolean;
 
   procedure CurrentInstructionDebugLocation(out ALine, AColumn: Integer);
   begin
@@ -14366,12 +14366,14 @@ var
     EnterGocciaCallSite(SourcePath, DebugLine, DebugColumn, APrevious);
   end;
 
-  { Throw path only. Stamps the executing frame with this instruction's source
-    position so the error object's stack trace — and therefore the runner's
+  { Stamps the executing frame with this instruction's source position so the
+    error object's stack trace — and therefore the runner's
     `--> file:line:column` header and code frame — matches what the tree-walk
     evaluator reports for the same fault. Deferred frames carry no position of
-    their own (ADR 0074); paying the debug-map lookup here costs nothing on the
-    hot path. }
+    their own (ADR 0074). Called on failure paths and once per `new` reaching
+    ConstructValue (see StampCallSiteLocation) — never from an ordinary
+    call/property/index instruction, so the dispatch loop's throughput is
+    unaffected; the per-`new` debug-map lookup is the only steady-state cost. }
   procedure StampCurrentInstructionLocation;
   var
     SourcePath: string;
@@ -14464,14 +14466,23 @@ var
       NotConstructorSuggestion(CallSite.Callee, CalleeTypeName));
   end;
 
-  { ES2026 §7.2.5 IsConstructor, restricted to the shapes this VM can build:
-    everything else reaches the same "is not a constructor" rejection the
-    ConstructValue tail performs, only with the call site's own wording. }
+  { ES2026 §7.2.5 IsConstructor. False routes the construct site to
+    ThrowNotConstructorHere so the callee is named from the call-site
+    descriptor; True lets ConstructValue proceed. A callable that is not a
+    constructor (AArrow, AMethod, AGenerator, AAsync, or a native marked
+    NotConstructable) must return False here — otherwise it slips past to
+    ConstructValue's own generic rejection, which cannot name the callee. }
   function MayBeConstructor(const AValue: TGocciaValue): Boolean;
   begin
-    Result := Assigned(AValue) and (AValue is TGocciaObjectValue) and
-      (AValue.IsCallable or (AValue is TGocciaClassValue) or
-       (AValue is TGocciaProxyValue));
+    if not Assigned(AValue) then
+      Exit(False);
+    if AValue is TGocciaProxyValue then
+      Exit(True);
+    if AValue is TGocciaClassValue then
+      Exit(True);
+    if AValue is TGocciaFunctionBase then
+      Exit(TGocciaFunctionBase(AValue).IsConstructable);
+    Result := False;
   end;
 
 begin
@@ -14513,6 +14524,13 @@ begin
       SetCurrentRealm(ExecutionRealm);
     try
       Inc(FNativeExecutionDepth);
+      // Give the probed locals safe values before arming the probe: a throw in
+      // SetupNewFrame or the generator-resume preamble (before the dispatch
+      // loop assigns them) would otherwise make StampThrowLocation read an
+      // uninitialised Template pointer / garbage InstructionStartIP. A nil
+      // Template makes the stamp a no-op until the loop sets a real one.
+      Template := nil;
+      InstructionStartIP := 0;
       SavedActiveTemplateProbe := FActiveTemplateProbe;
       SavedActiveInstructionIPProbe := FActiveInstructionIPProbe;
       FActiveTemplateProbe := PPointer(@Template);
@@ -16966,13 +16984,26 @@ begin
              (GetRegister(A) is TGocciaBoundFunctionValue) or
              (GetRegister(A) is TGocciaProxyValue) then
           begin
+            if TGocciaCallStack.Instance <> nil then
+              SavedConstructFrameOk :=
+                TGocciaCallStack.Instance.TryGetTopFrame(SavedConstructFrame)
+            else
+              SavedConstructFrameOk := False;
             EnterCurrentInstructionCallSite(PreviousCallSite);
+            // Stamp the executing frame with this call's position so an error a
+            // native callee creates captures the call site (deferred frames are
+            // 0:0). Use the recorded call-site column, matching the tree-walk
+            // evaluator's per-call frame (the instruction line map resolves only
+            // to the enclosing statement). Snapshotted above and restored below.
+            StampCallSiteLocation(CurrentCallSite);
             try
               SetRegister(A, InvokeFunctionValue(GetRegister(A), CallArgs,
                 TGocciaUndefinedLiteralValue.UndefinedValue));
             finally
               LeaveGocciaCallSite(PreviousCallSite);
             end;
+            if SavedConstructFrameOk and (TGocciaCallStack.Instance <> nil) then
+              TGocciaCallStack.Instance.SetTopFrame(SavedConstructFrame);
           end
           else
             SetRegister(A, InvokeFunctionValue(GetRegister(A), CallArgs,
@@ -17265,13 +17296,23 @@ begin
              (GetRegister(A) is TGocciaBoundFunctionValue) or
              (GetRegister(A) is TGocciaProxyValue) then
           begin
+            if TGocciaCallStack.Instance <> nil then
+              SavedConstructFrameOk :=
+                TGocciaCallStack.Instance.TryGetTopFrame(SavedConstructFrame)
+            else
+              SavedConstructFrameOk := False;
             EnterCurrentInstructionCallSite(PreviousCallSite);
+            // See OP_CALL: stamp the recorded call-site position for a native
+            // callee's created error; snapshotted above, restored below.
+            StampCallSiteLocation(CurrentCallSite);
             try
               SetRegister(A, InvokeFunctionValue(GetRegister(A), CallArgs,
                 GetRegister(A - 1)));
             finally
               LeaveGocciaCallSite(PreviousCallSite);
             end;
+            if SavedConstructFrameOk and (TGocciaCallStack.Instance <> nil) then
+              TGocciaCallStack.Instance.SetTopFrame(SavedConstructFrame);
           end
           else
             SetRegister(A, InvokeFunctionValue(GetRegister(A), CallArgs,
@@ -17297,9 +17338,16 @@ begin
           if not MayBeConstructor(GetRegister(B)) then
             ThrowNotConstructorHere(GetRegister(B));
           { A native constructor can capture a stack trace (`new Error(...)`),
-            and this frame carries no position of its own. Stamp the construct
-            site first so the captured trace — and the diagnostic rendered from
-            it — locates the `new` expression. }
+            and this frame carries no position of its own. Snapshot the top
+            frame, stamp it at the construct site so a trace captured during
+            construction locates the `new`, then restore it on success so the
+            stamp does not leak onto a later throw in the same function
+            (`new Map(); JSON.parse('{')`). On a throw the frame unwinds. }
+          if TGocciaCallStack.Instance <> nil then
+            SavedConstructFrameOk :=
+              TGocciaCallStack.Instance.TryGetTopFrame(SavedConstructFrame)
+          else
+            SavedConstructFrameOk := False;
           StampCallSiteLocation(CurrentCallSite);
           CallArgs := AcquireArguments(C);
           try
@@ -17314,6 +17362,8 @@ begin
           finally
             ReleaseArguments(CallArgs);
           end;
+          if SavedConstructFrameOk and (TGocciaCallStack.Instance <> nil) then
+            TGocciaCallStack.Instance.SetTopFrame(SavedConstructFrame);
         end;
       end;
 
@@ -17334,6 +17384,13 @@ begin
         begin
           if not MayBeConstructor(GetRegister(B)) then
             ThrowNotConstructorHere(GetRegister(B));
+          // Snapshot/stamp/restore as in OP_CONSTRUCT, so a successful spread
+          // construct does not leave the caller frame stamped for a later throw.
+          if TGocciaCallStack.Instance <> nil then
+            SavedConstructFrameOk :=
+              TGocciaCallStack.Instance.TryGetTopFrame(SavedConstructFrame)
+          else
+            SavedConstructFrameOk := False;
           StampCallSiteLocation(CurrentCallSite);
           CallArgs := AcquireArguments(SpreadArray.Elements.Count);
           try
@@ -17348,6 +17405,8 @@ begin
           finally
             ReleaseArguments(CallArgs);
           end;
+          if SavedConstructFrameOk and (TGocciaCallStack.Instance <> nil) then
+            TGocciaCallStack.Instance.SetTopFrame(SavedConstructFrame);
         end;
       end;
 
@@ -18095,6 +18154,18 @@ begin
       // On error, wraps with SuppressedError in A.
       OP_USING_DISPOSE:
       begin
+        // Stamp the disposal site onto the top frame so an auto-SuppressedError
+        // created below (a double fault: dispose throws while an error is
+        // pending) records this location instead of the deferred frame's 0:0,
+        // matching the tree-walk interpreter. Snapshot/restore so it does not
+        // perturb the location seen by later instructions.
+        if TGocciaCallStack.Instance <> nil then
+          SavedConstructFrameOk :=
+            TGocciaCallStack.Instance.TryGetTopFrame(SavedConstructFrame)
+        else
+          SavedConstructFrameOk := False;
+        StampCurrentInstructionLocation;
+        try
         LeftValue := RegisterToValue(FRegisters[B]); // dispose method
         if Assigned(LeftValue) and not (LeftValue is TGocciaNullLiteralValue) and
            not (LeftValue is TGocciaUndefinedLiteralValue) and
@@ -18157,6 +18228,10 @@ begin
                 SetRegister(A, LeftValue);
             end;
           end;
+        end;
+        finally
+          if SavedConstructFrameOk and (TGocciaCallStack.Instance <> nil) then
+            TGocciaCallStack.Instance.SetTopFrame(SavedConstructFrame);
         end;
       end;
 
@@ -18505,7 +18580,7 @@ begin
             CreateErrorObject(SYNTAX_ERROR_NAME, E.Message),
             InitialFrameStackCount, InitialClosedNumericFrameCount,
             SavedHandlerCount,
-            Frame, Template, PrevCovLine, ProfileEntryTimestamp);
+            Frame, Template, PrevCovLine, ProfileEntryTimestamp, E.Suggestion);
         on E: TGocciaRuntimeError do
           HandleExceptionUnwind(
             CreateErrorObject(ERROR_NAME, E.Message),

--- a/source/units/Goccia.Values.ErrorHelper.pas
+++ b/source/units/Goccia.Values.ErrorHelper.pas
@@ -245,22 +245,36 @@ end;
 function CreateErrorObject(const AName, AMessage: string; const ASkipTop: Integer = 0): TGocciaObjectValue;
 var
   Proto: TGocciaObjectValue;
+  ResultRoot: TGocciaTempRoot;
 begin
   Proto := GetErrorPrototype(AName);
   // An error subclass instance so provenance can be attached below without
   // enlarging every plain object (see TGocciaErrorObjectValue).
-  if Assigned(Proto) then
-    Result := TGocciaErrorObjectValue.Create(Proto)
-  else
-    Result := TGocciaErrorObjectValue.Create;
-  Result.HasErrorData := True;
-  Result.AssignProperty(PROP_NAME, TGocciaStringLiteralValue.Create(AName));
-  Result.AssignProperty(PROP_MESSAGE, TGocciaStringLiteralValue.Create(AMessage));
+  { The error under construction must be a temp root: the property stores below
+    grow the shaped map at its collecting growth gate, CaptureStackTrace and the
+    diagnostic-excerpt reservation are GC safe points, and nothing else roots
+    this value yet — without the root a collection taken at any of them frees the
+    half-built error and the next field access dereferences freed memory (an
+    Access violation under -O3/-O4, where the collection lands mid-build). Mirror
+    the same guard the Error() constructor path already uses in Builtins.Globals. }
+  InitializeTempRoot(ResultRoot);
+  try
+    if Assigned(Proto) then
+      Result := TGocciaErrorObjectValue.Create(Proto)
+    else
+      Result := TGocciaErrorObjectValue.Create;
+    AddTempRootIfNeeded(ResultRoot, Result);
+    Result.HasErrorData := True;
+    Result.AssignProperty(PROP_NAME, TGocciaStringLiteralValue.Create(AName));
+    Result.AssignProperty(PROP_MESSAGE, TGocciaStringLiteralValue.Create(AMessage));
 
-  if (TGocciaCallStack.Instance <> nil) then
-    Result.ErrorStack :=
-      TGocciaCallStack.Instance.CaptureStackTrace(AName, AMessage, ASkipTop);
-  AttachErrorSourceProvenance(Result, ASkipTop);
+    if (TGocciaCallStack.Instance <> nil) then
+      Result.ErrorStack :=
+        TGocciaCallStack.Instance.CaptureStackTrace(AName, AMessage, ASkipTop);
+    AttachErrorSourceProvenance(Result, ASkipTop);
+  finally
+    RemoveTempRootIfNeeded(ResultRoot);
+  end;
 end;
 
 function CreateErrorObjectInRealm(const AName, AMessage: string;

--- a/source/units/Goccia.Values.ErrorHelper.pas
+++ b/source/units/Goccia.Values.ErrorHelper.pas
@@ -9,6 +9,17 @@ uses
   Goccia.Values.ObjectValue,
   Goccia.Values.Primitives;
 
+{ Records engine-trusted throw provenance on an error object for its runtime
+  code frame: the top call frame's source location (skipping ASkipTop frames)
+  and, when that module is in the engine's own source scope, the ±context
+  window of its source. Bound to real frames, never to the guest-writable
+  `.stack` string, so a guest-forged error object gets neither and renders no
+  code frame. Every error factory must call this so the two executors and every
+  host agree on what a genuine error's frame shows. Safe to call with no active
+  call stack (records nothing). }
+procedure AttachErrorSourceProvenance(const AError: TGocciaObjectValue;
+  const ASkipTop: Integer);
+
 { Creates a JavaScript error object with the given name and message.
   ASkipTop controls how many frames to skip from the top of the call stack. }
 function CreateErrorObject(const AName, AMessage: string; const ASkipTop: Integer = 0): TGocciaObjectValue;
@@ -67,12 +78,106 @@ procedure ThrowError(const AMessage, ASuggestion: string); overload;
 implementation
 
 uses
+  Classes,
+
   Goccia.Builtins.Globals,
   Goccia.CallStack,
   Goccia.Constants.ErrorNames,
   Goccia.Constants.PropertyNames,
+  Goccia.Diagnostics.SourceRegistry,
+  Goccia.GarbageCollector,
   Goccia.Values.Error,
   Goccia.Values.ObjectPropertyDescriptor;
+
+const
+  // Match FormatErrorWithSourceContext's context window so a captured excerpt
+  // and the entry-file fallback render the same number of lines.
+  ERROR_SOURCE_CONTEXT_BEFORE = 2;
+  ERROR_SOURCE_CONTEXT_AFTER = 2;
+  { TryGetGuestWindow bounds each retained line to 512 actual bytes. The joined
+    excerpt replaces the per-line headers with one header plus LF separators,
+    so five line caps are a conservative exact-representation ceiling. }
+  ERROR_SOURCE_EXCERPT_CAP_BYTES =
+    (ERROR_SOURCE_CONTEXT_BEFORE + 1 + ERROR_SOURCE_CONTEXT_AFTER) *
+    GOCCIA_DIAGNOSTIC_EXCERPT_MAX_LINE_BYTES;
+
+procedure AttachErrorSourceProvenance(const AError: TGocciaObjectValue;
+  const ASkipTop: Integer);
+var
+  ErrorObject: TGocciaErrorObjectValue;
+  Path, ExcerptText: string;
+  Line, Col, FirstLine: Integer;
+  Scope: TGocciaDiagnosticSourceScope;
+  Window: TStringList;
+  GC: TGarbageCollector;
+  ExcerptBytes: Int64;
+  Reserved: Boolean;
+begin
+  // Provenance lives only on the error subclass; a factory that builds a plain
+  // object simply carries none (and renders no frame).
+  if not (AError is TGocciaErrorObjectValue) then
+    Exit;
+  ErrorObject := TGocciaErrorObjectValue(AError);
+  if TGocciaCallStack.Instance = nil then
+    Exit;
+  if not TGocciaCallStack.Instance.TryGetTopThrowLocation(ASkipTop, Path,
+    Line, Col) then
+    Exit;
+  ErrorObject.HasErrorSourceLocation := True;
+  ErrorObject.ErrorSourcePath := Path;
+  ErrorObject.ErrorSourceLine := Line;
+  ErrorObject.ErrorSourceColumn := Col;
+  ErrorObject.ErrorSourceExcerpt := '';
+  ErrorObject.ErrorSourceExcerptFirstLine := 0;
+  ErrorObject.ErrorSourcePrincipal := 0;
+  // Capture the module's own ±context window from the ACTIVE scope — the engine
+  // actually executing — and only for GUEST-owned source (TryGetGuestWindow
+  // withholds transitively host-owned and cross-principal source). The excerpt travels
+  // on the error so the frame renders later, even after the engine is freed;
+  // its principal is stamped so a foreign renderer can refuse it.
+  Scope := TGocciaDiagnosticSourceRegistry.Current;
+  if not Assigned(Scope) then
+    Exit;
+  { Stamp the provenance principal even when no excerpt can be captured. The
+    entry-file fallback is authorized against this same explicit identity, and
+    a renderer supplied no/mismatched identity therefore gets location only. }
+  ErrorObject.ErrorSourcePrincipal := Scope.Principal;
+  Window := TStringList.Create;
+  try
+    if Scope.TryGetGuestWindow(Path, Line, ERROR_SOURCE_CONTEXT_BEFORE,
+      ERROR_SOURCE_CONTEXT_AFTER, Window, FirstLine) then
+    begin
+      ExcerptText := Window.Text;
+      ExcerptBytes := DiagnosticStringRetainedBytes(ExcerptText);
+      if ExcerptBytes > ERROR_SOURCE_EXCERPT_CAP_BYTES then
+        Exit;
+      // Charge exactly the retained UTF-16 allocation against --max-memory;
+      // the error object's destructor releases the same figure. The reservation
+      // may collect before refusing, so pass the not-yet-published error as an
+      // extra root. Refusal safely degrades to location-only.
+      GC := TGarbageCollector.Instance;
+      Reserved := False;
+      if Assigned(GC) then
+      begin
+        if not GC.TryReserveExternalBytes(ExcerptBytes, ErrorObject) then
+          Exit;
+        Reserved := True;
+      end;
+      try
+        ErrorObject.ErrorSourceExcerpt := ExcerptText;
+        ErrorObject.ErrorSourceExcerptFirstLine := FirstLine;
+        if Reserved then
+          ErrorObject.ErrorSourceExcerptCharged := ExcerptBytes;
+      except
+        if Reserved then
+          GC.ReleaseExternalBytes(ExcerptBytes);
+        raise;
+      end;
+    end;
+  finally
+    Window.Free;
+  end;
+end;
 
 function DOMExceptionLegacyCode(const AName: string): Integer;
 begin
@@ -142,10 +247,12 @@ var
   Proto: TGocciaObjectValue;
 begin
   Proto := GetErrorPrototype(AName);
+  // An error subclass instance so provenance can be attached below without
+  // enlarging every plain object (see TGocciaErrorObjectValue).
   if Assigned(Proto) then
-    Result := TGocciaObjectValue.Create(Proto)
+    Result := TGocciaErrorObjectValue.Create(Proto)
   else
-    Result := TGocciaObjectValue.Create;
+    Result := TGocciaErrorObjectValue.Create;
   Result.HasErrorData := True;
   Result.AssignProperty(PROP_NAME, TGocciaStringLiteralValue.Create(AName));
   Result.AssignProperty(PROP_MESSAGE, TGocciaStringLiteralValue.Create(AMessage));
@@ -153,6 +260,7 @@ begin
   if (TGocciaCallStack.Instance <> nil) then
     Result.ErrorStack :=
       TGocciaCallStack.Instance.CaptureStackTrace(AName, AMessage, ASkipTop);
+  AttachErrorSourceProvenance(Result, ASkipTop);
 end;
 
 function CreateErrorObjectInRealm(const AName, AMessage: string;

--- a/source/units/Goccia.Values.ObjectValue.pas
+++ b/source/units/Goccia.Values.ObjectValue.pas
@@ -147,6 +147,60 @@ type
     function ObjectPrototypeValueOf(const AArgs: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue;
   end;
 
+  { An error object that also carries engine-recorded throw provenance for its
+    runtime code frame. Kept as a subclass so these fields exist ONLY on error
+    objects — adding them to the base TGocciaObjectValue would enlarge every
+    object's InstanceSize and inflate the GC's per-object byte accounting (which
+    charges InstanceSize), shifting --max-memory behaviour for all programs.
+
+    The provenance is set from the real top call frame when the engine creates
+    the error (Goccia.Values.ErrorHelper.AttachErrorSourceProvenance), NEVER
+    from the guest-writable `.stack` property. HasErrorSourceLocation is False
+    on a guest-forged plain object (which is not this class at all), so it
+    renders no code frame. }
+  TGocciaErrorObjectValue = class(TGocciaObjectValue)
+  private
+    FHasErrorSourceLocation: Boolean;
+    FErrorSourcePath: string;
+    FErrorSourceLine: Integer;
+    FErrorSourceColumn: Integer;
+    // The ±context window of the throwing module's source, captured at creation
+    // (LF-joined), with the absolute line number of its first line. Empty when
+    // the module was not in the engine's own source scope (e.g. the entry file,
+    // whose lines the host still holds); the header location is shown regardless.
+    FErrorSourceExcerpt: string;
+    FErrorSourceExcerptFirstLine: Integer;
+    // Durable identity of the source scope (principal) the excerpt was captured
+    // from — compared, never dereferenced. A renderer must explicitly supply
+    // that same principal; a mismatch or no supplied principal refuses source.
+    // A process-monotonic Int64 (not a scope
+    // pointer) so a freed-then-reallocated scope can never be mistaken for the
+    // one that stamped the excerpt. See Goccia.Diagnostics.SourceRegistry.
+    FErrorSourcePrincipal: Int64;
+    // Bytes of FErrorSourceExcerpt charged against the GC --max-memory budget,
+    // released in Destroy so held errors cannot retain diagnostic copies past
+    // the ceiling.
+    FErrorSourceExcerptCharged: Int64;
+  public
+    destructor Destroy; override;
+    property HasErrorSourceLocation: Boolean read FHasErrorSourceLocation
+      write FHasErrorSourceLocation;
+    property ErrorSourcePath: string read FErrorSourcePath
+      write FErrorSourcePath;
+    property ErrorSourceLine: Integer read FErrorSourceLine
+      write FErrorSourceLine;
+    property ErrorSourceColumn: Integer read FErrorSourceColumn
+      write FErrorSourceColumn;
+    property ErrorSourceExcerpt: string read FErrorSourceExcerpt
+      write FErrorSourceExcerpt;
+    property ErrorSourceExcerptFirstLine: Integer
+      read FErrorSourceExcerptFirstLine write FErrorSourceExcerptFirstLine;
+    property ErrorSourcePrincipal: Int64 read FErrorSourcePrincipal
+      write FErrorSourcePrincipal;
+    property ErrorSourceExcerptCharged: Int64 read FErrorSourceExcerptCharged
+      write FErrorSourceExcerptCharged;
+  end;
+
 
 implementation
 
@@ -890,6 +944,21 @@ begin
 
   FSymbolInsertionOrder.Free;
   FRegExpData.Free;
+  inherited;
+end;
+
+destructor TGocciaErrorObjectValue.Destroy;
+var
+  GC: TGarbageCollector;
+begin
+  // Return the excerpt's charged bytes to the --max-memory budget.
+  if FErrorSourceExcerptCharged > 0 then
+  begin
+    GC := TGarbageCollector.Instance;
+    if Assigned(GC) then
+      GC.ReleaseExternalBytes(FErrorSourceExcerptCharged);
+    FErrorSourceExcerptCharged := 0;
+  end;
   inherited;
 end;
 

--- a/tests/language/expressions/call/non-callable-message-text.js
+++ b/tests/language/expressions/call/non-callable-message-text.js
@@ -73,6 +73,29 @@ describe("non-callable callee messages", () => {
   test("falls back to the value type when the callee is an expression", () => {
     expect(messageOf(() => (3)())).toBe("3 is not a function");
   });
+
+  test("names a non-callable tag in a tagged template", () => {
+    const t = 1;
+    expect(messageOf(() => t`x`)).toBe("t is not a function");
+  });
+});
+
+describe("non-constructor callable messages", () => {
+  test("an arrow used with new is reported by name, unquoted", () => {
+    const f = () => {};
+    expect(messageOf(() => new f())).toBe("f is not a constructor");
+  });
+
+  test("a method used with new is reported by name", () => {
+    const o = {
+      m() {},
+    };
+    expect(messageOf(() => new o.m())).toBe("o.m is not a constructor");
+  });
+
+  test("a non-constructable builtin used with new is reported by name", () => {
+    expect(messageOf(() => new Symbol())).toBe("Symbol is not a constructor");
+  });
 });
 
 describe("non-constructor callee messages", () => {

--- a/tests/language/expressions/call/non-callable-message-text.js
+++ b/tests/language/expressions/call/non-callable-message-text.js
@@ -1,0 +1,129 @@
+/*---
+description: A non-callable callee and a nullish property base are reported with the same message text in both execution modes
+esid: sec-function-calls-runtime-semantics-evaluation
+---*/
+
+// ES2026 §13.3.6.1 step 6 (throw a TypeError when the callee is not callable)
+// and §6.2.5.5 GetValue step 3.a (ToObject on a nullish base) say only *that*
+// a TypeError is thrown, not what it says. The message is therefore an engine
+// choice — and it used to be a different choice per execution mode: the
+// tree-walk evaluator named the callee off the AST while the bytecode VM only
+// had the runtime value, so `obj.missingMethod()` read
+// "obj.missingMethod is not a function" interpreted and
+// "undefined is not a function" compiled. Nullish property reads diverged the
+// same way ("Cannot read property 'x' of undefined" vs Node's
+// "Cannot read properties of undefined (reading 'x')").
+//
+// Both modes now build these strings from one shared formatter, so this file
+// pins the text itself: it fails in whichever mode drifts.
+
+const messageOf = (fn) => {
+  try {
+    fn();
+  } catch (e) {
+    return e.message;
+  }
+  return "<did not throw>";
+};
+
+describe("non-callable callee messages", () => {
+  test("names a member callee as written", () => {
+    const obj = {};
+    expect(messageOf(() => obj.missingMethod())).toBe(
+      "obj.missingMethod is not a function",
+    );
+  });
+
+  test("names a computed member callee as written", () => {
+    const obj = {};
+    const key = "missing";
+    expect(messageOf(() => obj[key]())).toBe("obj[key] is not a function");
+  });
+
+  test("names a member callee on a primitive receiver", () => {
+    const num = 5;
+    expect(messageOf(() => num.foo())).toBe("num.foo is not a function");
+  });
+
+  test("names a chained member callee in full", () => {
+    const o = { a: {} };
+    expect(messageOf(() => o.a.b())).toBe("o.a.b is not a function");
+  });
+
+  test("names an identifier callee without quoting it", () => {
+    const notFn = 3;
+    expect(messageOf(() => notFn())).toBe("notFn is not a function");
+  });
+
+  test("names an optional member callee including the ?. token", () => {
+    const obj = {};
+    expect(messageOf(() => obj?.missing())).toBe(
+      "obj?.missing is not a function",
+    );
+  });
+
+  test("names a spread call's callee", () => {
+    const obj = {};
+    const args = [1, 2];
+    expect(messageOf(() => obj.missingMethod(...args))).toBe(
+      "obj.missingMethod is not a function",
+    );
+  });
+
+  test("falls back to the value type when the callee is an expression", () => {
+    expect(messageOf(() => (3)())).toBe("3 is not a function");
+  });
+});
+
+describe("non-constructor callee messages", () => {
+  test("names an identifier constructor as written", () => {
+    const und = undefined;
+    expect(messageOf(() => new und())).toBe("und is not a constructor");
+  });
+
+  test("names a member constructor as written", () => {
+    const obj = {};
+    expect(messageOf(() => new obj.Missing())).toBe(
+      "obj.Missing is not a constructor",
+    );
+  });
+});
+
+describe("nullish property access messages", () => {
+  test("uses the 'Cannot read properties of undefined' form", () => {
+    const und = undefined;
+    expect(messageOf(() => und.x)).toBe(
+      "Cannot read properties of undefined (reading 'x')",
+    );
+  });
+
+  test("uses the 'Cannot read properties of null' form", () => {
+    const nul = null;
+    expect(messageOf(() => nul.x)).toBe(
+      "Cannot read properties of null (reading 'x')",
+    );
+  });
+
+  test("reports the missing property of an intermediate undefined", () => {
+    const obj = {};
+    expect(messageOf(() => obj.missing.deeper)).toBe(
+      "Cannot read properties of undefined (reading 'deeper')",
+    );
+  });
+
+  test("reports a computed key on a nullish base", () => {
+    const nul = null;
+    const key = "missing";
+    expect(messageOf(() => nul[key])).toBe(
+      "Cannot read properties of null (reading 'missing')",
+    );
+  });
+});
+
+describe("unresolved identifier messages", () => {
+  test("uses the 'is not defined' form", () => {
+    expect(messageOf(() => missingGlobalBinding)).toBe(
+      "missingGlobalBinding is not defined",
+    );
+  });
+});


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Renders identical runtime-error diagnostics (callee name, location, wording, and code frame) across the interpreter and bytecode VM — previously bytecode printed a bare `Fatal error: TypeError: …` where the interpreter printed a named callee, suggestion, `--> file:line:column` header, and a source frame.
- The code-frame source is bound to secure per-load provenance: an excerpt renders **only** from guest-owned module source, keyed on canonical file identity (POSIX device+inode / Windows volume+file-index), enforced at render by an explicit expected principal that fails closed when absent; host ownership propagates transitively through import chains. Source is byte-accurately charged against `--max-memory` with a transactional registry commit.
- Impact: closes the original script-controlled arbitrary host-file read (a thrown value's `stack` could name any path) **and** the cross-principal source disclosures (host-preloaded modules, nested-sandbox parent source, cross-engine stale source) surfaced across five cross-model security review rounds — four defeated, the fifth verified to hold.

## Testing

- [x] Full suite both modes; every disclosure repro re-run as a negative test with zero leaks across all host binaries
- [x] Cross-model security verification (independent implementer and reviewer); mutation-checked (reverting the principal exclusion re-discloses)
- [x] Differential zero divergence under bun 1.4.0 and CI-pinned 1.3.14; 69/69 Pascal unit tests; `./format.pas --check`, markdownlint, and doc checks clean
