### PR TITLE
fix(modules): close class-body strictness leaks and enforce symlink containment

### DIFF
--- a/docs/module-resolution.md
+++ b/docs/module-resolution.md
@@ -132,7 +132,31 @@ checks enforce it, and a failure of any is an ordinary `Module not found:
 - **Containment.** The final expanded candidate is checked against the package
   directory before the extension probe and again after it. Segment validation
   rejects what is invalid on its face; this catches whatever any combination
-  still normalized into.
+  still normalized into. The pre-probe check compares normalized spellings,
+  because the candidate is a name that need not exist yet. The post-probe check
+  is **physical**: by then a real file has been found, and both it and the
+  package directory are canonicalized — every symbolic link on either path
+  resolved — before the comparison. A package that ships
+  `linked/out.js -> ../../../outside.js` normalizes to a path inside itself
+  while naming a file outside it, and only the physical check refuses that. It
+  follows the same principle as [ADR 0071](adr/0071-reject-symlinks-in-sandbox-seed-imports.md),
+  where the sandbox refuses a symlinked seed import rather than trusting where
+  its name appears to sit.
+
+  Canonicalizing the package directory as well as the candidate is what keeps
+  pnpm-style layouts working. There `node_modules/<pkg>` is itself a link into
+  a content-addressed store, so resolving only the candidate would place every
+  file in every pnpm package outside its own root; resolving both moves the
+  comparison into the store, where a store-internal file passes and a link that
+  leaves the store still does not.
+
+  **Platform support.** Canonicalization uses `realpath(3)` on Linux, macOS and
+  the BSDs, and `GetFinalPathNameByHandleW` on Windows, which follows both
+  symbolic links and directory junctions. Where a host cannot canonicalize a
+  path — the Lakon/WASI lane, whose in-memory filesystem has no links at all,
+  or a Windows file the process cannot open even for metadata — the normalized
+  spelling comparison stands on its own and the boundary is lexical for that
+  resolution.
 
 The legacy no-`exports` path is stricter here than Node, which would let
 `new URL(subpath, packageURL)` walk upward. A subpath containing `..` is never

--- a/source/shared/FileUtils.Test.pas
+++ b/source/shared/FileUtils.Test.pas
@@ -3,6 +3,7 @@ program FileUtils.Test;
 {$I Shared.inc}
 
 uses
+  {$IFDEF UNIX}BaseUnix,{$ENDIF}
   Classes,
   SysUtils,
 
@@ -32,6 +33,9 @@ type
     procedure TestMixedExtensionsAcrossDepths;
     procedure TestIsAbsoluteHostPathRootedForms;
     procedure TestIsAbsoluteHostPathRelativeForms;
+    procedure TestCanonicalHostPathIsUnknownForAMissingPath;
+    procedure TestCanonicalHostPathIsStableForARealFile;
+    procedure TestCanonicalHostPathFollowsASymlink;
   public
     procedure SetupTests; override;
     procedure BeforeEach; override;
@@ -58,6 +62,19 @@ begin
     TestIsAbsoluteHostPathRootedForms);
   Test('IsAbsoluteHostPath rejects paths read against a working directory',
     TestIsAbsoluteHostPathRelativeForms);
+  Test('CanonicalHostPath reports unknown for a path that does not exist',
+    TestCanonicalHostPathIsUnknownForAMissingPath);
+  Test('CanonicalHostPath is stable for a file that does exist',
+    TestCanonicalHostPathIsStableForARealFile);
+  { Creating a symlink needs an API this build only has on UNIX. }
+  {$IFDEF UNIX}
+  Test('CanonicalHostPath resolves a symlink to its target',
+    TestCanonicalHostPathFollowsASymlink);
+  {$ELSE}
+  Skip('CanonicalHostPath resolves a symlink to its target',
+    TestCanonicalHostPathFollowsASymlink,
+    'creating a symlink is not available on this platform');
+  {$ENDIF}
 end;
 
 procedure TFileUtilsTests.BeforeEach;
@@ -378,6 +395,51 @@ begin
   Expect<Boolean>(IsAbsoluteHostPath('\packages')).ToBe(False);
   Expect<Boolean>(IsAbsoluteHostPath('C:\packages')).ToBe(False);
   {$ENDIF}
+end;
+
+procedure TFileUtilsTests.TestCanonicalHostPathIsUnknownForAMissingPath;
+begin
+  { '' is the "cannot answer" signal, not a path. Callers branch on it, so a
+    name with nothing behind it must never come back as something. }
+  Expect<string>(CanonicalHostPath('')).ToBe('');
+  Expect<string>(CanonicalHostPath(FTempDir + PathDelim + 'absent.txt'))
+    .ToBe('');
+end;
+
+procedure TFileUtilsTests.TestCanonicalHostPathIsStableForARealFile;
+var
+  Canonical: string;
+begin
+  CreateTempFile('present.txt');
+
+  Canonical := CanonicalHostPath(FTempDir + PathDelim + 'present.txt');
+
+  Expect<Boolean>(Canonical <> '').ToBe(True);
+  { Canonicalizing an already-canonical path is the identity — the property the
+    containment comparison relies on when neither side carries a link. }
+  Expect<string>(CanonicalHostPath(Canonical)).ToBe(Canonical);
+  Expect<string>(ExtractFileName(Canonical)).ToBe('present.txt');
+end;
+
+procedure TFileUtilsTests.TestCanonicalHostPathFollowsASymlink;
+var
+  LinkPath, TargetCanonical: string;
+begin
+  CreateTempDir('inner');
+  CreateTempFile('inner' + PathDelim + 'target.txt');
+  LinkPath := FTempDir + PathDelim + 'link.txt';
+  TargetCanonical := CanonicalHostPath(
+    FTempDir + PathDelim + 'inner' + PathDelim + 'target.txt');
+
+  {$IFDEF UNIX}
+  Expect<Boolean>(fpSymlink(PAnsiChar(AnsiString('inner' + PathDelim +
+    'target.txt')), PAnsiChar(AnsiString(LinkPath))) = 0).ToBe(True);
+  {$ENDIF}
+
+  { The link and its target are two names for one file, and canonicalization is
+    what collapses them — the whole reason a containment check can be phrased
+    physically. }
+  Expect<string>(CanonicalHostPath(LinkPath)).ToBe(TargetCanonical);
 end;
 
 begin

--- a/source/shared/FileUtils.pas
+++ b/source/shared/FileUtils.pas
@@ -6,6 +6,7 @@ interface
 
 uses
   {$IFDEF UNIX}BaseUnix,{$ENDIF}
+  {$IFDEF MSWINDOWS}Windows,{$ENDIF}
   Classes,
   SysUtils;
 
@@ -35,6 +36,23 @@ function HostFileExists(const APath: string): Boolean;
 { True when APath itself is a symbolic link (UNIX) or a reparse
   point / junction (Windows). Does not follow the link. }
 function HostPathIsSymlink(const APath: string): Boolean;
+
+{ APath with every symbolic link along it resolved to the file it physically
+  names, or '' when the host cannot answer.
+
+  ExpandHostFileName only normalizes a *spelling*: it collapses `.` and `..`
+  and makes the path absolute, but it never touches the filesystem, so a path
+  that normalizes inside a directory can still resolve outside it through a
+  symlinked component. This resolves the links, which is what a containment
+  guarantee has to be phrased in.
+
+  '' means "unknown", never "root", and a caller must decide for itself what an
+  unknown means. It is returned when the path does not exist (POSIX
+  `realpath` and the Windows handle open both require it to), when the name
+  cannot be encoded for the host, and on builds with no canonicalization
+  available — currently the Lakon/WASI lane, whose filesystem is the virtual
+  one in SandboxVirtualFileSystem and has no symbolic links at all. }
+function CanonicalHostPath(const APath: string): string;
 
 { Read an entire file as strict UTF-8 source text. No BOM stripping or
   newline normalization is performed. Invalid UTF-8 raises EConvertError. }
@@ -112,6 +130,107 @@ begin
   Attr := FileGetAttr(APath);
   Result := (Attr <> -1) and ((Attr and faSymLink) <> 0);
 end;
+{$ENDIF}
+
+{$IF DEFINED(UNIX) AND NOT DEFINED(LAKON)}
+{ POSIX.1-2008 realpath(3). The two-argument form is used rather than the
+  malloc'ing one so no libc `free` has to be bound as well; POSIX requires the
+  caller's buffer to hold PATH_MAX bytes, which HOST_PATH_MAX_BYTES is (Linux's
+  value — macOS and the BSDs cap lower). }
+function HostRealPath(APath: PAnsiChar; AResolved: PAnsiChar): PAnsiChar;
+  cdecl; external 'c' name 'realpath';
+{$ENDIF}
+
+{$IFDEF MSWINDOWS}
+{ FPC 3.2.2's Windows unit stops at the pre-Vista path API, so the one call
+  that follows reparse points has to be declared here. FILE_NAME_NORMALIZED
+  ($0) plus VOLUME_NAME_DOS ($0) is the drive-letter spelling; the result still
+  carries a `\\?\` (or `\\?\UNC\`) prefix, which the caller strips. }
+function GetFinalPathNameByHandleW(AFile: THandle; APath: PWideChar;
+  APathLength, AFlags: DWORD): DWORD;
+  stdcall; external 'kernel32.dll' name 'GetFinalPathNameByHandleW';
+{$ENDIF}
+
+function CanonicalHostPath(const APath: string): string;
+{$IF DEFINED(UNIX) AND NOT DEFINED(LAKON)}
+const
+  HOST_PATH_MAX_BYTES = 4096;
+var
+  Buffer: array[0..HOST_PATH_MAX_BYTES - 1] of AnsiChar;
+  PathBytes, ResolvedBytes: TBytes;
+  ErrorOffset, Length_: Integer;
+begin
+  Result := '';
+  if APath = '' then
+    Exit;
+  if not TryEncodeUTF8NullTerminated(APath, PathBytes, ErrorOffset) then
+    Exit;
+  FillChar(Buffer[0], SizeOf(Buffer), 0);
+  if HostRealPath(PAnsiChar(@PathBytes[0]), @Buffer[0]) = nil then
+    Exit;
+  Length_ := 0;
+  while (Length_ < SizeOf(Buffer)) and (Buffer[Length_] <> #0) do
+    Inc(Length_);
+  SetLength(ResolvedBytes, Length_);
+  if Length_ > 0 then
+    Move(Buffer[0], ResolvedBytes[0], Length_);
+  { A path the host handed back is bytes, and the host does not promise they
+    are UTF-8. A name this process cannot represent is one it cannot compare
+    either, so it stays "unknown" rather than becoming a lossy string. }
+  if not TryDecodeUTF8(ResolvedBytes, Result, ErrorOffset) then
+    Result := '';
+end;
+{$ELSE}
+{$IFDEF MSWINDOWS}
+const
+  DEVICE_PATH_PREFIX = '\\?\';
+  DEVICE_UNC_PATH_PREFIX = '\\?\UNC\';
+var
+  Handle: THandle;
+  Buffer: array of WideChar;
+  Needed: DWORD;
+begin
+  Result := '';
+  if APath = '' then
+    Exit;
+  { FILE_FLAG_BACKUP_SEMANTICS is what lets a *directory* be opened at all, and
+    zero desired access asks only for the metadata this needs — no read rights,
+    so an unreadable file still canonicalizes. Every share mode is granted so
+    the probe never blocks whoever else has the file open. }
+  Handle := CreateFileW(PWideChar(APath), 0,
+    FILE_SHARE_READ or FILE_SHARE_WRITE or FILE_SHARE_DELETE, nil,
+    OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, 0);
+  if Handle = INVALID_HANDLE_VALUE then
+    Exit;
+  try
+    Needed := GetFinalPathNameByHandleW(Handle, nil, 0, 0);
+    if Needed = 0 then
+      Exit;
+    { The probing call reports the length *including* the terminator and the
+      filling one reports it without, so a buffer of that size always holds the
+      answer. A second call that asks for more than it fits means the file was
+      renamed between the two, and an unknown beats a truncated path. }
+    SetLength(Buffer, Needed + 1);
+    Needed := GetFinalPathNameByHandleW(Handle, @Buffer[0], Needed, 0);
+    if (Needed = 0) or (Needed > DWORD(Length(Buffer) - 1)) then
+      Exit;
+    SetString(Result, PWideChar(@Buffer[0]), Integer(Needed));
+  finally
+    CloseHandle(Handle);
+  end;
+  if Copy(Result, 1, Length(DEVICE_UNC_PATH_PREFIX)) =
+     DEVICE_UNC_PATH_PREFIX then
+    Result := '\\' + Copy(Result, Length(DEVICE_UNC_PATH_PREFIX) + 1, MaxInt)
+  else if Copy(Result, 1, Length(DEVICE_PATH_PREFIX)) = DEVICE_PATH_PREFIX then
+    Result := Copy(Result, Length(DEVICE_PATH_PREFIX) + 1, MaxInt);
+end;
+{$ELSE}
+begin
+  { No canonicalization on this lane. Callers fall back to their lexical check;
+    see the interface comment. }
+  Result := '';
+end;
+{$ENDIF}
 {$ENDIF}
 
 function MatchesExtension(const AName: string; const AExtensions: array of string): Boolean;

--- a/source/units/Goccia.Compiler.Statements.pas
+++ b/source/units/Goccia.Compiler.Statements.pas
@@ -5927,20 +5927,36 @@ var
   ClosedCount, I: Integer;
   ThisReg: UInt16;
   OldRejectArgumentsInDirectEval: Boolean;
+  StrictCtx: TGocciaCompilationContext;
 begin
   OldRejectArgumentsInDirectEval := ACtx.Template.RejectArgumentsInDirectEval;
   ACtx.Template.RejectArgumentsInDirectEval := True;
   ACtx.Scope.BeginScope;
+  { ES2026 §15.7.1: a ClassBody is strict-mode code whatever the enclosing
+    script's mode is. An instance field initializer gets that for free — it is
+    compiled into the `<fields>` child template, whose StrictCode defaults to
+    True — but a static one is emitted straight into the enclosing template, so
+    under the non-strict compatibility profile it inherited the script's sloppy
+    flags and an assignment to an undeclared name compiled to a global create
+    instead of a throw. Both the compiler-wide flag and the context copy are
+    cleared, the same pair the computed-element-key path above clears. }
+  StrictCtx := ACtx;
+  StrictCtx.NonStrictMode := False;
+  StrictCtx.CompatibilityNonStrictMode := False;
+  if Assigned(ACtx.SetNonStrictMode) then
+    ACtx.SetNonStrictMode(False);
   try
     ThisReg := ACtx.Scope.DeclareLocal(KEYWORD_THIS, False);
     EmitInstruction(ACtx, EncodeABC(OP_MOVE, ThisReg, AClassReg, 0));
-    CompileFieldValueWithInferredName(ACtx, AExpression, ADest,
+    CompileFieldValueWithInferredName(StrictCtx, AExpression, ADest,
       AInferredName);
     ACtx.Scope.EndScope(ClosedLocals, ClosedCount);
     for I := 0 to ClosedCount - 1 do
       EmitInstruction(ACtx,
         EncodeABx(OP_CLOSE_UPVALUE, 0, UInt16(ClosedLocals[I])));
   finally
+    if Assigned(ACtx.SetNonStrictMode) then
+      ACtx.SetNonStrictMode(ACtx.CompatibilityNonStrictMode);
     ACtx.Template.RejectArgumentsInDirectEval :=
       OldRejectArgumentsInDirectEval;
   end;

--- a/source/units/Goccia.Engine.Realm.Test.pas
+++ b/source/units/Goccia.Engine.Realm.Test.pas
@@ -16,6 +16,7 @@ uses
   Goccia.Executor,
   Goccia.Executor.Bytecode,
   Goccia.Executor.Interpreter,
+  Goccia.GarbageCollector,
   Goccia.Realm,
   Goccia.Runtime,
   Goccia.RuntimeExtensions.URL,
@@ -499,8 +500,19 @@ begin
     try
       Key := TGocciaStringLiteralValue.Create('storage-key');
       Store := TGocciaStringLiteralValue.Create('outer-store');
-      OuterContext := DeriveAsyncContext(nil, Key, Store);
-      SetCurrentAsyncContext(OuterContext);
+      // Key and Store live only in Pascal locals until the snapshot is
+      // installed as the current context; the derive itself allocates, so
+      // they need temp roots across it or a collection makes this test
+      // nondeterministic.
+      TGarbageCollector.Instance.AddTempRoot(Key);
+      TGarbageCollector.Instance.AddTempRoot(Store);
+      try
+        OuterContext := DeriveAsyncContext(nil, Key, Store);
+        SetCurrentAsyncContext(OuterContext);
+      finally
+        TGarbageCollector.Instance.RemoveTempRoot(Store);
+        TGarbageCollector.Instance.RemoveTempRoot(Key);
+      end;
       Expect<Boolean>(CurrentAsyncContext = OuterContext).ToBe(True);
 
       InnerEngine := TGocciaEngine.Create('<inner-async>', InnerSource,

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -8124,6 +8124,25 @@ begin
     Result := AFallbackScope;
 end;
 
+// ES2026 §15.7.1: a ClassBody is always strict-mode code — "All parts of a
+// ClassDeclaration or a ClassExpression are strict mode code" — regardless of
+// how the enclosing script was configured. Strictness is therefore another
+// thing a class body takes from its own text rather than from wherever it is
+// evaluated: the construction routes hand an initializer the *caller's*
+// context, which under the non-strict compatibility profile still carries the
+// script's sloppy flags, and an initializer assigning to an undeclared name
+// then created a global instead of raising ReferenceError.
+//
+// Both flags are cleared, not only NonStrictMode: every behavioral gate ANDs
+// the pair (VarBindingNameCollectionMode, the identifier-assignment paths in
+// Goccia.AST.Expressions), so leaving the compatibility half set keeps part of
+// the sloppy semantics alive inside the class body.
+procedure ApplyClassBodyStrictness(var AContext: TGocciaEvaluationContext); {$IFDEF FPC}inline;{$ENDIF}
+begin
+  AContext.NonStrictMode := False;
+  AContext.CompatibilityNonStrictMode := False;
+end;
+
 // The scope is not the only thing a field initializer inherits from the class
 // definition rather than from the construction site. `import()` resolves its
 // specifier against, and `import.meta.url` reports, the module the code was
@@ -8165,6 +8184,7 @@ begin
     ClassInitializerScopeParent(AClassValue, AContext.Scope), AClassValue);
   LocalScope.ThisValue := AInstance;
   LocalContext.Scope := LocalScope;
+  ApplyClassBodyStrictness(LocalContext);
   ApplyClassDefinitionSourceContext(AClassValue, LocalContext);
 
   { ES2026 §7.3.33 InitializeInstanceElements only ever defines the fields of
@@ -8241,7 +8261,11 @@ var
   I: Integer;
   FOEntry: TGocciaClassFieldOrderEntry;
   Expr: TGocciaExpression;
+  LocalContext: TGocciaEvaluationContext;
 begin
+  LocalContext := AContext;
+  ApplyClassBodyStrictness(LocalContext);
+
   { §7.3.33 InitializeInstanceElements defines this class's fields only — each
     superclass initializes its own inside its own [[Construct]]. Walking the
     chain here re-ran an ancestor's private field initializers on a receiver
@@ -8260,7 +8284,7 @@ begin
       if FOEntry.IsComputed then
       begin
         if Assigned(FOEntry.Initializer) then
-          PropertyValue := EvaluateExpression(FOEntry.Initializer, AContext)
+          PropertyValue := EvaluateExpression(FOEntry.Initializer, LocalContext)
         else
           PropertyValue := TGocciaUndefinedLiteralValue.UndefinedValue;
         if FOEntry.ComputedKey is TGocciaSymbolValue then
@@ -8279,7 +8303,7 @@ begin
           FOEntry.Name, Expr) then
         begin
           if Assigned(Expr) then
-            PropertyValue := EvaluateExpression(Expr, AContext)
+            PropertyValue := EvaluateExpression(Expr, LocalContext)
           else
             PropertyValue := TGocciaUndefinedLiteralValue.UndefinedValue;
           InitializeRawPrivateInstanceProperty(AInstance, FOEntry.Name,
@@ -8290,7 +8314,7 @@ begin
       begin
         if AClassValue.InstancePropertyDefs.TryGetValue(FOEntry.Name, Expr) and Assigned(Expr) then
         begin
-          PropertyValue := EvaluateExpression(Expr, AContext);
+          PropertyValue := EvaluateExpression(Expr, LocalContext);
           AInstance.AssignProperty(FOEntry.Name, PropertyValue);
         end;
       end;
@@ -8300,10 +8324,10 @@ begin
   begin
     for Entry in AClassValue.InstancePropertyDefs do
     begin
-      PropertyValue := EvaluateExpression(Entry.Value, AContext);
+      PropertyValue := EvaluateExpression(Entry.Value, LocalContext);
       AInstance.AssignProperty(Entry.Key, PropertyValue);
     end;
-    InitializePrivateInstanceProperties(AInstance, AClassValue, AContext);
+    InitializePrivateInstanceProperties(AInstance, AClassValue, LocalContext);
   end;
 end;
 
@@ -9491,14 +9515,14 @@ var
 begin
   Continuation := CurrentGeneratorContinuation;
   ClassStrictContext := AContext;
-  ClassStrictContext.NonStrictMode := False;
+  ApplyClassBodyStrictness(ClassStrictContext);
   SuperClass := nil;
   SuperClassValue := nil;
   MethodSuperClass := nil;
   if Assigned(AClassDef.SuperClassExpression) then
   begin
     HeritageContext := AContext;
-    HeritageContext.NonStrictMode := False;
+    ApplyClassBodyStrictness(HeritageContext);
     SuperClassValue := EvaluateExpression(AClassDef.SuperClassExpression,
       HeritageContext);
     if SuperClassValue is TGocciaClassValue then
@@ -9746,14 +9770,14 @@ begin
   begin
     Elem := AClassDef.FElements[I];
     if Elem.Kind = cekStaticBlock then
-      ExecuteStaticBlock(Elem.StaticBlockBody, AContext, ClassValue)
+      ExecuteStaticBlock(Elem.StaticBlockBody, ClassStrictContext, ClassValue)
     else if ((Elem.Kind = cekField) or
              ((Elem.Kind = cekAccessor) and Elem.IsPrivate)) and
             Elem.IsStatic then
     begin
       if Assigned(Elem.FieldInitializer) then
       begin
-        StaticFieldContext := AContext;
+        StaticFieldContext := ClassStrictContext;
         StaticFieldScope := TGocciaClassInitScope.Create(AContext.Scope,
           ClassValue);
         StaticFieldScope.ThisValue := ClassValue;
@@ -11229,11 +11253,14 @@ procedure InitializePrivateInstanceProperties(const AInstance: TGocciaObjectValu
 var
   PropertyValue: TGocciaValue;
   Entry: TGocciaExpressionMap.TKeyValuePair;
+  LocalContext: TGocciaEvaluationContext;
 begin
+  LocalContext := AContext;
+  ApplyClassBodyStrictness(LocalContext);
   for Entry in AClassValue.PrivateInstancePropertyDefs do
   begin
     if Assigned(Entry.Value) then
-      PropertyValue := EvaluateExpression(Entry.Value, AContext)
+      PropertyValue := EvaluateExpression(Entry.Value, LocalContext)
     else
       PropertyValue := TGocciaUndefinedLiteralValue.UndefinedValue;
     if AInstance is TGocciaInstanceValue then
@@ -11648,8 +11675,10 @@ begin
   Result.CoverageEnabled := (TGocciaCoverageTracker.Instance <> nil) and
     TGocciaCoverageTracker.Instance.Enabled;
   Result.StrictTypes := ADefinitionScope.EffectiveStrictTypes;
-  Result.NonStrictMode := ADefinitionScope.EffectiveNonStrictMode;
-  Result.CompatibilityNonStrictMode := Result.NonStrictMode;
+  // The synthesized context stands in for the class's own definition context,
+  // so it is subject to the same rule as every other piece of class-body code:
+  // strict, whatever the defining scope's mode was.
+  ApplyClassBodyStrictness(Result);
 end;
 
 // ES2026 §7.3.14 Construct(F, argumentsList, newTarget) for a class the

--- a/source/units/Goccia.ModuleResolver.pas
+++ b/source/units/Goccia.ModuleResolver.pas
@@ -412,7 +412,11 @@ begin
   if not TryResolveWithExtensions(TargetCandidate, AResolvedPath) then
     raise EModuleNotFound.CreateNotFound(AModulePath, TargetCandidate);
 
-  if not IsPathInsideDirectory(AResolvedPath, PackageDirectory) then
+  { The post-probe gate is the physical one. The candidate above is a name that
+    may not exist yet, so only its spelling can be judged; by here a real file
+    has been found, and a real file is what a symlinked child of the package
+    would have escaped through. }
+  if not IsPathPhysicallyInsideDirectory(AResolvedPath, PackageDirectory) then
     raise EModuleNotFound.CreateNotFound(AModulePath, AResolvedPath);
 
   if IsCommonJSModuleFile(Manifest, AResolvedPath) then

--- a/source/units/Goccia.Modules.NodeResolution.Test.pas
+++ b/source/units/Goccia.Modules.NodeResolution.Test.pas
@@ -3,8 +3,11 @@ program Goccia.Modules.NodeResolution.Test;
 {$I Goccia.inc}
 
 uses
+  {$IFDEF UNIX}BaseUnix,{$ENDIF}
+  Classes,
   SysUtils,
 
+  FileUtils,
   TestingPascalLibrary,
 
   Goccia.Modules.NodeResolution,
@@ -13,6 +16,12 @@ uses
 type
   TNodeResolutionTests = class(TTestSuite)
   private
+    FTempDirectories: TStringList;
+
+    function CreateTempDirectory: string;
+    procedure DeleteDirectoryTree(const APath: string);
+    procedure WriteFixtureFile(const APath, AText: string);
+    function TryCreateSymlink(const ATarget, ALinkPath: string): Boolean;
     procedure TestSplitsPlainPackageName;
     procedure TestSplitsPackageSubpath;
     procedure TestSplitsScopedPackageName;
@@ -42,6 +51,10 @@ type
     procedure TestNodeModulesSegmentIsRejected;
     procedure TestContainmentAcceptsPathsInsideTheDirectory;
     procedure TestContainmentRejectsSiblingAndEscapedPaths;
+    procedure TestPhysicalContainmentRejectsAnEscapingChildLink;
+    procedure TestPhysicalContainmentAllowsAnInPackageLink;
+    procedure TestPhysicalContainmentAllowsAStoreLinkedPackageRoot;
+    procedure TestPhysicalContainmentRejectsAnEscapeFromALinkedRoot;
 
     procedure TestModuleFieldIsPreferredOverMain;
     procedure TestMainIsUsedWhenNoModuleField;
@@ -72,8 +85,90 @@ type
     procedure TestNestedTemplateLiteralsAreTracked;
     procedure TestUnterminatedTemplateFallsBackToTheRawScan;
   public
+    procedure BeforeAll; override;
+    procedure AfterAll; override;
     procedure SetupTests; override;
   end;
+
+procedure TNodeResolutionTests.BeforeAll;
+begin
+  inherited BeforeAll;
+  FTempDirectories := TStringList.Create;
+end;
+
+procedure TNodeResolutionTests.AfterAll;
+var
+  I: Integer;
+begin
+  for I := 0 to FTempDirectories.Count - 1 do
+    DeleteDirectoryTree(FTempDirectories[I]);
+  FTempDirectories.Free;
+  inherited AfterAll;
+end;
+
+function TNodeResolutionTests.CreateTempDirectory: string;
+begin
+  Result := IncludeTrailingPathDelimiter(GetTempDir(False)) +
+    'goccia-node-containment-' + IntToStr(Random(MaxInt));
+  { The name is deterministic — nothing seeds the generator — so a run that
+    died before its teardown would otherwise poison every run after it: a
+    symlink fixture cannot be created over one that is already there, and the
+    test would fail on the leftover rather than on the code. }
+  DeleteDirectoryTree(Result);
+  ForceDirectories(Result);
+  FTempDirectories.Add(Result);
+end;
+
+procedure TNodeResolutionTests.DeleteDirectoryTree(const APath: string);
+var
+  EntryPath: string;
+  SearchRec: TSearchRec;
+begin
+  if not DirectoryExists(APath) then
+    Exit;
+
+  { faSymLink has to be asked for: without it FindFirst stats through a link
+    and silently drops any that no longer resolves, which is exactly what the
+    escape fixtures leave behind once their target is gone. }
+  if FindFirst(IncludeTrailingPathDelimiter(APath) + '*',
+    faAnyFile or faSymLink, SearchRec) = 0 then
+  begin
+    repeat
+      if (SearchRec.Name = '.') or (SearchRec.Name = '..') then
+        Continue;
+
+      EntryPath := IncludeTrailingPathDelimiter(APath) + SearchRec.Name;
+      { A symlink to a directory must be unlinked, not descended into and
+        emptied — otherwise the teardown deletes whatever it points at. }
+      if ((SearchRec.Attr and faDirectory) = faDirectory) and
+         (not FileUtils.HostPathIsSymlink(EntryPath)) then
+        DeleteDirectoryTree(EntryPath)
+      else
+        DeleteFile(EntryPath);
+    until FindNext(SearchRec) <> 0;
+    FindClose(SearchRec);
+  end;
+
+  RemoveDir(APath);
+end;
+
+procedure TNodeResolutionTests.WriteFixtureFile(const APath, AText: string);
+begin
+  ForceDirectories(ExtractFileDir(APath));
+  FileUtils.WriteUTF8FileText(APath, AText);
+end;
+
+function TNodeResolutionTests.TryCreateSymlink(const ATarget,
+  ALinkPath: string): Boolean;
+begin
+  {$IFDEF UNIX}
+  Result := fpSymlink(PAnsiChar(AnsiString(ATarget)),
+    PAnsiChar(AnsiString(ALinkPath))) = 0;
+  {$ELSE}
+  { Only the UNIX cases are registered; see SetupTests. }
+  Result := False;
+  {$ENDIF}
+end;
 
 procedure TNodeResolutionTests.SetupTests;
 begin
@@ -125,6 +220,33 @@ begin
     TestContainmentAcceptsPathsInsideTheDirectory);
   Test('Containment rejects sibling and escaped paths',
     TestContainmentRejectsSiblingAndEscapedPaths);
+  { Real symlinks on disk. Creating one needs an API this build only has on
+    UNIX, and on Windows it also needs a privilege an unelevated CI job does
+    not hold, so the cases are registered as skipped there rather than
+    reporting a pass they never ran. }
+  {$IFDEF UNIX}
+  Test('Physical containment rejects a package child linked outside it',
+    TestPhysicalContainmentRejectsAnEscapingChildLink);
+  Test('Physical containment allows a link inside the package',
+    TestPhysicalContainmentAllowsAnInPackageLink);
+  Test('Physical containment allows a store-linked package root',
+    TestPhysicalContainmentAllowsAStoreLinkedPackageRoot);
+  Test('Physical containment rejects an escape from a store-linked root',
+    TestPhysicalContainmentRejectsAnEscapeFromALinkedRoot);
+  {$ELSE}
+  Skip('Physical containment rejects a package child linked outside it',
+    TestPhysicalContainmentRejectsAnEscapingChildLink,
+    'creating a symlink is not available on this platform');
+  Skip('Physical containment allows a link inside the package',
+    TestPhysicalContainmentAllowsAnInPackageLink,
+    'creating a symlink is not available on this platform');
+  Skip('Physical containment allows a store-linked package root',
+    TestPhysicalContainmentAllowsAStoreLinkedPackageRoot,
+    'creating a symlink is not available on this platform');
+  Skip('Physical containment rejects an escape from a store-linked root',
+    TestPhysicalContainmentRejectsAnEscapeFromALinkedRoot,
+    'creating a symlink is not available on this platform');
+  {$ENDIF}
 
   Test('module field is preferred over main', TestModuleFieldIsPreferredOverMain);
   Test('main is used when there is no module field',
@@ -565,6 +687,106 @@ begin
   Expect<Boolean>(IsPathInsideDirectory(ParentDirectory + 'pkg-evil' +
     PathDelim + 'x.js', PackageDirectory)).ToBe(False);
   Expect<Boolean>(IsPathInsideDirectory('', PackageDirectory)).ToBe(False);
+end;
+
+{ ── Physical containment ───────────────────────────────────── }
+
+procedure TNodeResolutionTests.TestPhysicalContainmentRejectsAnEscapingChildLink;
+var
+  Candidate, PackageDirectory, Root: string;
+begin
+  { The shape a package would ship to escape itself: a link whose name sits
+    inside the package and whose target does not. The lexical check passes it,
+    which is exactly why the physical one exists. }
+  Root := IncludeTrailingPathDelimiter(CreateTempDirectory);
+  PackageDirectory := Root + 'pkg';
+  WriteFixtureFile(Root + 'outside.js', 'export const secret = 1;');
+  ForceDirectories(PackageDirectory + PathDelim + 'linked');
+  Candidate := PackageDirectory + PathDelim + 'linked' + PathDelim + 'out.js';
+
+  Expect<Boolean>(TryCreateSymlink('..' + PathDelim + '..' + PathDelim +
+    'outside.js', Candidate)).ToBe(True);
+
+  Expect<Boolean>(IsPathInsideDirectory(Candidate,
+    PackageDirectory)).ToBe(True);
+  Expect<Boolean>(IsPathPhysicallyInsideDirectory(Candidate,
+    PackageDirectory)).ToBe(False);
+end;
+
+procedure TNodeResolutionTests.TestPhysicalContainmentAllowsAnInPackageLink;
+var
+  Candidate, PackageDirectory, Root: string;
+begin
+  { A package is free to link to its own files, and plenty do. Only leaving the
+    package is refused. }
+  Root := IncludeTrailingPathDelimiter(CreateTempDirectory);
+  PackageDirectory := Root + 'pkg';
+  WriteFixtureFile(PackageDirectory + PathDelim + 'src' + PathDelim +
+    'real.js', 'export const value = 1;');
+  Candidate := PackageDirectory + PathDelim + 'alias.js';
+
+  Expect<Boolean>(TryCreateSymlink('src' + PathDelim + 'real.js',
+    Candidate)).ToBe(True);
+
+  Expect<Boolean>(IsPathPhysicallyInsideDirectory(Candidate,
+    PackageDirectory)).ToBe(True);
+end;
+
+procedure TNodeResolutionTests.TestPhysicalContainmentAllowsAStoreLinkedPackageRoot;
+var
+  Candidate, PackageDirectory, Root, StorePackage: string;
+begin
+  { pnpm's layout: node_modules/<pkg> is itself a link into a
+    content-addressed store, and the package's real files live there.
+    Canonicalizing the candidate alone would put every one of them outside
+    their own package; canonicalizing the root too moves the comparison into
+    the store, where they belong. }
+  Root := IncludeTrailingPathDelimiter(CreateTempDirectory);
+  StorePackage := Root + 'store' + PathDelim + 'pkg@1.0.0' + PathDelim +
+    'node_modules' + PathDelim + 'pkg';
+  WriteFixtureFile(StorePackage + PathDelim + 'index.js',
+    'export const value = 1;');
+  WriteFixtureFile(StorePackage + PathDelim + 'lib' + PathDelim + 'deep.js',
+    'export const deep = 1;');
+  ForceDirectories(Root + 'node_modules');
+  PackageDirectory := Root + 'node_modules' + PathDelim + 'pkg';
+
+  Expect<Boolean>(TryCreateSymlink(StorePackage, PackageDirectory)).ToBe(True);
+
+  Candidate := PackageDirectory + PathDelim + 'index.js';
+  Expect<Boolean>(IsPathPhysicallyInsideDirectory(Candidate,
+    PackageDirectory)).ToBe(True);
+
+  Candidate := PackageDirectory + PathDelim + 'lib' + PathDelim + 'deep.js';
+  Expect<Boolean>(IsPathPhysicallyInsideDirectory(Candidate,
+    PackageDirectory)).ToBe(True);
+end;
+
+procedure TNodeResolutionTests.TestPhysicalContainmentRejectsAnEscapeFromALinkedRoot;
+var
+  Candidate, PackageDirectory, Root, StorePackage: string;
+begin
+  { The two links composed: a store-linked package root whose store copy ships
+    an escaping child. Following only one of them would let this through. }
+  Root := IncludeTrailingPathDelimiter(CreateTempDirectory);
+  StorePackage := Root + 'store' + PathDelim + 'pkg@1.0.0' + PathDelim +
+    'node_modules' + PathDelim + 'pkg';
+  WriteFixtureFile(StorePackage + PathDelim + 'index.js',
+    'export const value = 1;');
+  WriteFixtureFile(Root + 'store' + PathDelim + 'other.js',
+    'export const secret = 1;');
+  ForceDirectories(Root + 'node_modules');
+  PackageDirectory := Root + 'node_modules' + PathDelim + 'pkg';
+
+  Expect<Boolean>(TryCreateSymlink(StorePackage, PackageDirectory)).ToBe(True);
+  Expect<Boolean>(TryCreateSymlink('..' + PathDelim + '..' + PathDelim + '..' +
+    PathDelim + 'other.js', StorePackage + PathDelim + 'escape.js')).ToBe(True);
+
+  Candidate := PackageDirectory + PathDelim + 'escape.js';
+  Expect<Boolean>(IsPathInsideDirectory(Candidate,
+    PackageDirectory)).ToBe(True);
+  Expect<Boolean>(IsPathPhysicallyInsideDirectory(Candidate,
+    PackageDirectory)).ToBe(False);
 end;
 
 { ── Target selection ───────────────────────────────────────── }

--- a/source/units/Goccia.Modules.NodeResolution.pas
+++ b/source/units/Goccia.Modules.NodeResolution.pas
@@ -148,6 +148,33 @@ function IsValidExportsTarget(const ATarget: string): Boolean;
   first, so it compares real host paths rather than spellings. }
 function IsPathInsideDirectory(const APath, ADirectory: string): Boolean;
 
+{ True when APath lives strictly beneath ADirectory *on disk*, not merely in
+  spelling.
+
+  IsPathInsideDirectory compares normalized path strings, and a string
+  comparison cannot see a symbolic link: a package that ships
+  `linked/out.js -> ../../../outside.js` normalizes to a path inside the
+  package while naming a file outside it. The documented guarantee is that
+  nothing outside the package can satisfy an import of it, so the final gate
+  has to be phrased physically. This follows ADR 0071's precedent, where the
+  sandbox refuses a symlinked seed import rather than trusting where its name
+  appears to sit.
+
+  Both sides are canonicalized — the package root as well as the candidate —
+  which is what keeps pnpm-style layouts working. There `node_modules/<pkg>` is
+  itself a link into a content-addressed store, so canonicalizing only the
+  candidate would put every file in every pnpm package outside its own root.
+  Resolving the root too moves the whole comparison into the store, where a
+  store-internal file passes and a link that leaves the store still does not.
+
+  When either side cannot be canonicalized the lexical verdict stands alone.
+  That is the state of things on a host with no canonicalization (see
+  CanonicalHostPath) — never a weaker answer than before this check existed,
+  but the physical guarantee is only as good as the host's ability to resolve
+  links. docs/module-resolution.md records which hosts those are. }
+function IsPathPhysicallyInsideDirectory(const APath,
+  ADirectory: string): Boolean;
+
 { Heuristic CommonJS detection over module source text.
 
   True when the source carries CommonJS markers (`require(...)`,
@@ -640,6 +667,26 @@ begin
   Path := ExpandHostFileName(APath);
   Directory := IncludeTrailingPathDelimiter(ExpandHostFileName(ADirectory));
   Result := Copy(Path, 1, Length(Directory)) = Directory;
+end;
+
+function IsPathPhysicallyInsideDirectory(const APath,
+  ADirectory: string): Boolean;
+var
+  CanonicalDirectory, CanonicalPath: string;
+begin
+  { The lexical check still runs, and first: it is the cheaper refusal, and it
+    is the only one that can speak about a path the host cannot resolve. }
+  if not IsPathInsideDirectory(APath, ADirectory) then
+    Exit(False);
+
+  CanonicalDirectory := CanonicalHostPath(ADirectory);
+  CanonicalPath := CanonicalHostPath(APath);
+  if (CanonicalDirectory = '') or (CanonicalPath = '') then
+    Exit(True);
+
+  Result := Copy(CanonicalPath, 1,
+    Length(IncludeTrailingPathDelimiter(CanonicalDirectory))) =
+    IncludeTrailingPathDelimiter(CanonicalDirectory);
 end;
 
 { Walks a condition value — a string, a nested condition object, or an array of

--- a/tests/language/classes/nonstrict-compat/field-initializers-strict.js
+++ b/tests/language/classes/nonstrict-compat/field-initializers-strict.js
@@ -1,0 +1,235 @@
+/*---
+description: >
+  A ClassBody is strict-mode code (ES2026 §15.7.1) even when the surrounding
+  script runs with the non-strict compatibility profile, so an assignment to an
+  undeclared name inside one raises ReferenceError instead of creating a global.
+features: [compat-function, compat-non-strict-mode, compat-var]
+---*/
+
+// The regression was in how class-body code inherited strictness: the
+// construction routes handed a field initializer the *caller's* evaluation
+// context, which under this profile still carries the script's sloppy flags,
+// so an initializer's assignment to an undeclared identifier created a global
+// instead of throwing. Node throws ReferenceError for every case below in both
+// a sloppy script and a module.
+describe("class bodies stay strict under the non-strict compatibility profile", () => {
+  test("an instance field initializer throws for an undeclared assignment", () => {
+    class Leaky {
+      f = (undeclaredFieldTarget_q9 = 41);
+    }
+
+    expect(() => new Leaky()).toThrow(ReferenceError);
+    expect("undeclaredFieldTarget_q9" in globalThis).toBe(false);
+  });
+
+  test("Reflect.construct throws the same ReferenceError", () => {
+    class Leaky {
+      f = (undeclaredReflectTarget_q9 = 41);
+    }
+
+    expect(() => Reflect.construct(Leaky, [])).toThrow(ReferenceError);
+    expect("undeclaredReflectTarget_q9" in globalThis).toBe(false);
+  });
+
+  test("a proxy without a construct trap throws it too", () => {
+    class Leaky {
+      f = (undeclaredProxyTarget_q9 = 41);
+    }
+
+    const P = new Proxy(Leaky, {});
+
+    expect(() => new P()).toThrow(ReferenceError);
+    expect("undeclaredProxyTarget_q9" in globalThis).toBe(false);
+  });
+
+  test("a subclass running the base class fields throws", () => {
+    class Base {
+      f = (undeclaredSubclassTarget_q9 = 41);
+    }
+    class Derived extends Base {}
+
+    expect(() => new Derived()).toThrow(ReferenceError);
+    expect("undeclaredSubclassTarget_q9" in globalThis).toBe(false);
+  });
+
+  test("a derived class with its own field initializer throws", () => {
+    class Derived extends Object {
+      f = (undeclaredDerivedTarget_q9 = 41);
+    }
+
+    expect(() => new Derived()).toThrow(ReferenceError);
+    expect("undeclaredDerivedTarget_q9" in globalThis).toBe(false);
+  });
+
+  test("a private field initializer throws", () => {
+    class Leaky {
+      #p = (undeclaredPrivateTarget_q9 = 41);
+
+      read() {
+        return this.#p;
+      }
+    }
+
+    expect(() => new Leaky()).toThrow(ReferenceError);
+    expect("undeclaredPrivateTarget_q9" in globalThis).toBe(false);
+  });
+
+  test("a computed-key field's initializer throws", () => {
+    const key = "computed";
+
+    class Leaky {
+      [key] = (undeclaredComputedInitTarget_q9 = 41);
+    }
+
+    expect(() => new Leaky()).toThrow(ReferenceError);
+    expect("undeclaredComputedInitTarget_q9" in globalThis).toBe(false);
+  });
+
+  test("a computed key expression throws at class-definition time", () => {
+    expect(() => {
+      class Leaky {
+        [(undeclaredComputedKeyTarget_q9 = 41)] = 1;
+      }
+
+      return Leaky;
+    }).toThrow(ReferenceError);
+    expect("undeclaredComputedKeyTarget_q9" in globalThis).toBe(false);
+  });
+
+  test("a static field initializer throws at class-definition time", () => {
+    expect(() => {
+      class Leaky {
+        static s = (undeclaredStaticFieldTarget_q9 = 41);
+      }
+
+      return Leaky;
+    }).toThrow(ReferenceError);
+    expect("undeclaredStaticFieldTarget_q9" in globalThis).toBe(false);
+  });
+
+  test("a static initialization block throws at class-definition time", () => {
+    expect(() => {
+      class Leaky {
+        static {
+          undeclaredStaticBlockTarget_q9 = 41;
+        }
+      }
+
+      return Leaky;
+    }).toThrow(ReferenceError);
+    expect("undeclaredStaticBlockTarget_q9" in globalThis).toBe(false);
+  });
+
+  test("method, constructor, getter and setter bodies throw", () => {
+    class Methods {
+      constructor(run) {
+        if (run) {
+          undeclaredCtorTarget_q9 = 41;
+        }
+      }
+
+      m() {
+        undeclaredMethodTarget_q9 = 41;
+      }
+
+      get g() {
+        undeclaredGetterTarget_q9 = 41;
+        return 1;
+      }
+
+      set s(value) {
+        undeclaredSetterTarget_q9 = value;
+      }
+    }
+
+    const instance = new Methods(false);
+
+    expect(() => new Methods(true)).toThrow(ReferenceError);
+    expect(() => instance.m()).toThrow(ReferenceError);
+    expect(() => instance.g).toThrow(ReferenceError);
+    expect(() => {
+      instance.s = 1;
+    }).toThrow(ReferenceError);
+  });
+
+  test("nested function bodies inside a field initializer are strict too", () => {
+    class Nested {
+      fromFunction = (function () {
+        return this;
+      })();
+
+      fromArrow = (() => this)();
+    }
+
+    const instance = new Nested();
+
+    // Strict code leaves a nullish `this` alone instead of coercing it to the
+    // global object, and an arrow still sees the instance under construction.
+    expect(instance.fromFunction).toBeUndefined();
+    expect(instance.fromArrow).toBe(instance);
+  });
+
+  test("an unqualified method call still gets a strict undefined this", () => {
+    class Detached {
+      m() {
+        return this;
+      }
+    }
+
+    const detached = new Detached().m;
+
+    expect(detached()).toBeUndefined();
+  });
+});
+
+// Guards the other direction: the fix must confine itself to class bodies and
+// leave the profile's sloppy semantics outside one exactly as they were.
+describe("non-class code keeps the compatibility profile's sloppy semantics", () => {
+  test("an undeclared assignment outside a class body still creates a global", () => {
+    delete globalThis.sloppyOutsideClassTarget_q9;
+
+    try {
+      const result = (sloppyOutsideClassTarget_q9 = 3);
+
+      expect(result).toBe(3);
+      expect(globalThis.sloppyOutsideClassTarget_q9).toBe(3);
+    } finally {
+      delete globalThis.sloppyOutsideClassTarget_q9;
+    }
+  });
+
+  test("an undeclared assignment inside a plain function still creates a global", () => {
+    delete globalThis.sloppyFunctionTarget_q9;
+
+    const create = function () {
+      sloppyFunctionTarget_q9 = 5;
+    };
+
+    try {
+      create();
+
+      expect(globalThis.sloppyFunctionTarget_q9).toBe(5);
+    } finally {
+      delete globalThis.sloppyFunctionTarget_q9;
+    }
+  });
+
+  test("a plain function still binds a nullish this to globalThis", () => {
+    const readThis = function () {
+      return this;
+    };
+
+    expect(readThis()).toBe(globalThis);
+  });
+
+  test("with statements are still available outside a class body", () => {
+    const scope = { value: 7 };
+    let seen = 0;
+
+    with (scope) {
+      seen = value;
+    }
+
+    expect(seen).toBe(7);
+  });
+});

--- a/tests/language/classes/nonstrict-compat/goccia.json
+++ b/tests/language/classes/nonstrict-compat/goccia.json
@@ -1,0 +1,5 @@
+{
+  "compat-function": true,
+  "compat-non-strict-mode": true,
+  "compat-var": true
+}

--- a/tests/language/modules/node-modules/package-boundary.js
+++ b/tests/language/modules/node-modules/package-boundary.js
@@ -3,6 +3,16 @@
 // node_modules — so a passing test means the resolver refused, not that it
 // missed a file. The positive control at the end proves the wildcard the
 // escapes ride on actually works, which is what keeps the refusals meaningful.
+//
+// These are the *lexical* escapes. The physical one — a package shipping a
+// symlinked child that resolves outside itself — is covered in
+// source/units/Goccia.Modules.NodeResolution.Test.pas instead, because the
+// fixture has to be a real symlink: this suite's fixtures are committed files,
+// and a committed symlink materializes as an ordinary text file wherever git
+// checks out without symlink support (Windows without developer mode), which
+// would turn the escape into a file that legitimately lives inside the package
+// and silently invert the assertion. The Pascal tests create the link at run
+// time and are registered as skipped where that is not possible.
 import { wildcardLabel } from "pkg-escape-wildcard";
 import { insideLabel } from "pkg-escape-wildcard/sub/inside";
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Resolves the CodeRabbit round-2 findings raised against the round-1 fix layer (#1200), per the freeze discipline: green layers take no further pushes; the fixes land here.
- **Class-body strictness (Major):** strict-mode semantics were applied inconsistently across class-body evaluation sites; every leak site now enforces strict mode, so a method or field initializer can no longer observe sloppy-mode behavior.
- **Symlink containment (Major):** module resolution is now contained to physical paths inside the allowed root, with a real Windows implementation (`GetFinalPathNameByHandleW`) — a symlink pointing outside the root no longer escapes the sandbox filesystem boundary.
- Plus the minor test-rooting finding.

## Testing

- [x] 17/17 acceptance in both modes; full suite both modes
- [x] Differential zero divergence under bun 1.4.0 and CI-pinned 1.3.14
- [x] Windows path canonicalization exercised; `./format.pas --check`, markdownlint, and doc checks clean
