### PR TITLE
fix(shadowrealm): unpin ShadowRealm.prototype at host teardown

### DIFF
--- a/source/units/Goccia.Builtins.GlobalShadowRealm.pas
+++ b/source/units/Goccia.Builtins.GlobalShadowRealm.pas
@@ -391,6 +391,16 @@ end;
 
 destructor TGocciaShadowRealmHost.Destroy;
 begin
+  // Install pinned FPrototype so ShadowRealm.prototype survives collection for
+  // the engine's whole life; the pin has to be released at teardown, or it
+  // outlives the engine as a dangling GC root. On a worker thread that runs
+  // several engines in sequence, the next collection after this engine is torn
+  // down would mark the freed prototype and walk into its torn-down realm
+  // graph (e.g. a module import binding left pointing at a released runtime
+  // module), faulting during MarkRoots. This mirrors FRealm.Free unpinning the
+  // intrinsic prototype graph at engine teardown.
+  if Assigned(FPrototype) and (TGarbageCollector.Instance <> nil) then
+    TGarbageCollector.Instance.UnpinObject(FPrototype);
   FChildRealms.Free;
   FWrappedHosts.Free;
   inherited;

--- a/tests/built-ins/ShadowRealm/runtime-module-warmup/async-hooks-import.js
+++ b/tests/built-ins/ShadowRealm/runtime-module-warmup/async-hooks-import.js
@@ -1,0 +1,26 @@
+// Regression: importing a runtime module (node:async_hooks) from a directory
+// that enables --unsafe-shadowrealm used to segfault during a multi-file run on
+// one worker thread. EnableShadowRealm pins ShadowRealm.prototype for the
+// engine's lifetime but never released the pin at teardown, so the next
+// garbage collection after this engine was torn down walked the freed prototype
+// into its released realm graph (a module import binding still pointing at the
+// released node:async_hooks module) and faulted in MarkRoots. This file plus a
+// sibling under the same unsafe-shadowrealm config reproduces the two-file,
+// one-worker warm-up that triggered it; both must run clean in both modes.
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
+describe("ShadowRealm + node:async_hooks warm-up", () => {
+  test("imports the runtime module without faulting", () => {
+    expect(typeof AsyncLocalStorage).toBe("function");
+    const als = new AsyncLocalStorage();
+    expect(als.getStore()).toBeUndefined();
+    expect(als.run("bound", () => als.getStore())).toBe("bound");
+  });
+
+  test("ShadowRealm is still available alongside the runtime module", () => {
+    expect(typeof ShadowRealm).toBe("function");
+    const realm = new ShadowRealm();
+    expect(realm.evaluate("1 + 1")).toBe(2);
+  });
+});

--- a/tests/built-ins/ShadowRealm/runtime-module-warmup/csv-import.js
+++ b/tests/built-ins/ShadowRealm/runtime-module-warmup/csv-import.js
@@ -1,0 +1,22 @@
+// Second file of the ShadowRealm runtime-module warm-up regression (see
+// async-hooks-import.js). A different runtime module (goccia:csv) confirms the
+// fault was general to host-module warm-up under --unsafe-shadowrealm, not
+// specific to node:async_hooks. Two files under one unsafe-shadowrealm config
+// are what forced the crashing collection between engines on a single worker.
+
+import { parse } from "goccia:csv";
+
+describe("ShadowRealm + goccia:csv warm-up", () => {
+  test("imports the runtime module without faulting", () => {
+    expect(typeof parse).toBe("function");
+    const rows = parse("name,age\nAlice,30", { headers: false });
+    expect(rows.length).toBe(2);
+    expect(rows[0][0]).toBe("name");
+    expect(rows[1][1]).toBe("30");
+  });
+
+  test("ShadowRealm still constructs a child realm", () => {
+    const realm = new ShadowRealm();
+    expect(realm.evaluate("'x' + 'y'")).toBe("xy");
+  });
+});


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Fixes a segfault: importing any runtime module (`node:async_hooks`, `goccia:csv`, `goccia:timers`) from a directory with `unsafe-shadowrealm: true` in a multi-file run crashed during warm-up.
- Root cause was a leaked GC pin — the ShadowRealm host pinned `ShadowRealm.prototype` for the engine's lifetime but never released it at teardown, so the next per-file `GC.Collect` marked a surviving-but-dangling prototype and walked into a freed realm graph (`EXC_BAD_ACCESS` in `MarkRoots`). The host destructor now unpins the prototype before freeing child realms; a pure lifetime fix that grants the child no capability and preserves realm isolation.

## Testing

- [x] Full suite both modes; committed multi-file `unsafe-shadowrealm` warm-up regression test that faults before the fix
- [x] lldb backtrace + mutation confirming the pin as the cause; heaptrc clean
- [x] Differential zero divergence under bun 1.4.0 and CI-pinned 1.3.14; `./format.pas --check` and doc checks clean
