### PR TITLE
fix(runtime): complete EGocciaBytecodeThrow boundary handling

### DIFF
--- a/source/units/Goccia.AST.Expressions.pas
+++ b/source/units/Goccia.AST.Expressions.pas
@@ -929,7 +929,8 @@ uses
   Goccia.Values.ObjectValue,
   Goccia.Values.PromiseValue,
   Goccia.Values.SymbolValue,
-  Goccia.Values.ToPrimitive;
+  Goccia.Values.ToPrimitive,
+  Goccia.VM.Exception;
 
 var
   GTemplateSiteIdLock: TGocciaCriticalSection;
@@ -2665,6 +2666,13 @@ begin
         Promise.Resolve(Module.GetNamespaceObject);
       end;
     except
+      { A module whose top-level compiled code throws surfaces here as
+        EGocciaBytecodeThrow; its ThrownValue is the guest completion, so
+        reject import() with that identity to match the VM twin
+        (TGocciaVMDynamicImportStartValue.Call) rather than a synthesized
+        Error. }
+      on E: EGocciaBytecodeThrow do
+        Promise.Reject(E.ThrownValue);
       on E: TGocciaThrowValue do
         Promise.Reject(E.Value);
       on E: TGocciaSyntaxError do

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -7331,6 +7331,7 @@ var
   CallArgs: TGocciaArgumentsCollection;
   CurrentError: TGocciaValue;
   HasError: Boolean;
+  ThrownVal: TGocciaValue;
 begin
   CurrentError := AExistingError;
   HasError := Assigned(AExistingError);
@@ -7349,12 +7350,23 @@ begin
           CallArgs.Free;
         end;
       except
-        on E: TGocciaThrowValue do
+        { A compiled [Symbol.dispose] throwing crosses the boundary as
+          EGocciaBytecodeThrow, a tree-walk dispose as TGocciaThrowValue;
+          UnwrapThrownValue yields the thrown value for either so disposal
+          records the guest's identity, not a synthesized Error. (The
+          SuppressedError-chaining behavior below is preserved verbatim from
+          the TGocciaThrowValue-only handler; its pre-existing chaining
+          semantics are out of scope here.) Anything that is not a boundary
+          throw re-raises unchanged, exactly as the narrower handler let it
+          propagate. }
+        on E: Exception do
         begin
+          if not UnwrapThrownValue(E, ThrownVal) then
+            raise;
           if HasError then
-            CurrentError := CreateSuppressedErrorObject(E.Value, CurrentError)
+            CurrentError := CreateSuppressedErrorObject(ThrownVal, CurrentError)
           else
-            CurrentError := E.Value;
+            CurrentError := ThrownVal;
           HasError := True;
         end;
       end;
@@ -7377,6 +7389,7 @@ var
   CurrentError: TGocciaValue;
   HasError: Boolean;
   CallResult: TGocciaValue;
+  ThrownVal: TGocciaValue;
 begin
   CurrentError := AExistingError;
   HasError := Assigned(AExistingError);
@@ -7402,12 +7415,19 @@ begin
             AwaitValue(CallResult);
         end;
       except
-        on E: TGocciaThrowValue do
+        { A compiled [Symbol.asyncDispose] throwing crosses the boundary as
+          EGocciaBytecodeThrow, a tree-walk dispose as TGocciaThrowValue;
+          UnwrapThrownValue yields the thrown value for either. Chaining and
+          re-raise semantics mirror the sync DisposeTrackedResources verbatim;
+          the pre-existing SuppressedError-chaining gap is out of scope. }
+        on E: Exception do
         begin
+          if not UnwrapThrownValue(E, ThrownVal) then
+            raise;
           if HasError then
-            CurrentError := CreateSuppressedErrorObject(E.Value, CurrentError)
+            CurrentError := CreateSuppressedErrorObject(ThrownVal, CurrentError)
           else
-            CurrentError := E.Value;
+            CurrentError := ThrownVal;
           HasError := True;
         end;
       end;
@@ -7779,12 +7799,16 @@ end;
 
 function PascalExceptionToErrorObject(const E: Exception): TGocciaValue;
 begin
-  { A JS throw that left the bytecode VM already carries the guest's completion
-    value. Synthesizing a fresh Error from the Pascal message would hand `catch`
-    a different object whose `message` is EGocciaBytecodeThrow's "Name: message"
-    rendering; the thrown value itself is what ES2026 §14.15.3 binds. }
-  if E is EGocciaBytecodeThrow then
-    Result := EGocciaBytecodeThrow(E).ThrownValue
+  { A JS throw that left an executor boundary already carries the guest's
+    completion value. Synthesizing a fresh Error from the Pascal message would
+    hand `catch` a different object whose `message` is the "Name: message"
+    rendering; the thrown value itself is what ES2026 §14.15.3 binds.
+    UnwrapThrownValue centralizes the boundary-exception class list; callers
+    here only ever reach this with a non-TGocciaThrowValue (their `catch` arms
+    handle TGocciaThrowValue first), so its TGocciaThrowValue branch is inert
+    at this site. }
+  if UnwrapThrownValue(E, Result) then
+    Exit
   else if E is TGocciaTypeError then
     Result := CreateErrorObject(TYPE_ERROR_NAME, E.Message)
   else if E is TGocciaReferenceError then

--- a/source/units/Goccia.Generator.Continuation.pas
+++ b/source/units/Goccia.Generator.Continuation.pas
@@ -223,7 +223,8 @@ uses
   Goccia.Values.IteratorSupport,
   Goccia.Values.NativeFunction,
   Goccia.Values.ObjectValue,
-  Goccia.Values.SymbolValue;
+  Goccia.Values.SymbolValue,
+  Goccia.VM.Exception;
 
 threadvar
   // Non-owning "current continuation" pointer: GC-managed and save/restored
@@ -403,6 +404,12 @@ begin
       end;
       Promise.Resolve(CreateIteratorResult(UnwrappedValue, Done));
     except
+      { A compiled callee (e.g. a sync iterable's bytecode `next`) throwing
+        inside this async-from-sync step leaves the VM as EGocciaBytecodeThrow;
+        it carries the thrown value, so reject with that identity rather than
+        synthesizing a fresh Error from the Pascal message. }
+      on E: EGocciaBytecodeThrow do
+        Promise.Reject(E.ThrownValue);
       on E: TGocciaThrowValue do
         Promise.Reject(E.Value);
       on E: TGocciaTypeError do
@@ -469,6 +476,11 @@ begin
       Result := ResolveIteratorResult(CreateIteratorResult(
         TGocciaUndefinedLiteralValue.UndefinedValue, True), True);
   except
+    { A compiled callee's throw crosses the boundary as EGocciaBytecodeThrow
+      carrying the thrown value; reject with that identity rather than a fresh
+      Error synthesized from the Pascal message. }
+    on E: EGocciaBytecodeThrow do
+      Result := PromiseReject(E.ThrownValue);
     on E: TGocciaThrowValue do
       Result := PromiseReject(E.Value);
     on E: TGocciaTypeError do
@@ -518,6 +530,11 @@ begin
     end;
     Result := ResolveIteratorResult(CreateIteratorResult(Value, True), False);
   except
+    { A compiled callee's throw crosses the boundary as EGocciaBytecodeThrow
+      carrying the thrown value; reject with that identity rather than a fresh
+      Error synthesized from the Pascal message. }
+    on E: EGocciaBytecodeThrow do
+      Result := PromiseReject(E.ThrownValue);
     on E: TGocciaThrowValue do
       Result := PromiseReject(E.Value);
     on E: TGocciaTypeError do
@@ -564,6 +581,11 @@ begin
     end;
     Result := PromiseReject(Value);
   except
+    { A compiled callee's throw crosses the boundary as EGocciaBytecodeThrow
+      carrying the thrown value; reject with that identity rather than a fresh
+      Error synthesized from the Pascal message. }
+    on E: EGocciaBytecodeThrow do
+      Result := PromiseReject(E.ThrownValue);
     on E: TGocciaThrowValue do
       Result := PromiseReject(E.Value);
     on E: TGocciaTypeError do

--- a/source/units/Goccia.VM.Exception.pas
+++ b/source/units/Goccia.VM.Exception.pas
@@ -61,6 +61,19 @@ type
 // TGocciaThrowValue and does nothing for any other exception.
 procedure ReraiseBytecodeThrow(const AException: Exception);
 
+// A JS throw that crosses an executor boundary arrives as a Pascal exception
+// carrying the guest's completion value: EGocciaBytecodeThrow (a compiled
+// callee's throw leaving the VM) or TGocciaThrowValue (the tree-walk
+// evaluator's throw). Both bind the thrown value itself — ES2026 §14.15.3 —
+// not a fresh Error synthesized from the Pascal message. This is the single
+// place that knows the boundary-exception class list, so every
+// exception→value/rejection/mark site can route through it: a new boundary
+// class is then covered everywhere by extending this one function instead of
+// every ladder by hand. Returns True and sets AValue to the identity-preserved
+// thrown value for such an exception; returns False (AValue := nil) otherwise.
+function UnwrapThrownValue(const AException: Exception;
+  out AValue: TGocciaValue): Boolean;
+
 implementation
 
 uses
@@ -73,6 +86,21 @@ begin
   if AException is EGocciaBytecodeThrow then
     raise TGocciaThrowValue.Create(EGocciaBytecodeThrow(AException).ThrownValue,
       EGocciaBytecodeThrow(AException).Suggestion);
+end;
+
+function UnwrapThrownValue(const AException: Exception;
+  out AValue: TGocciaValue): Boolean;
+begin
+  if AException is EGocciaBytecodeThrow then
+    AValue := EGocciaBytecodeThrow(AException).ThrownValue
+  else if AException is TGocciaThrowValue then
+    AValue := TGocciaThrowValue(AException).Value
+  else
+  begin
+    AValue := nil;
+    Exit(False);
+  end;
+  Result := True;
 end;
 
 procedure TGocciaBytecodeHandlerStack.Push(const ACatchIP: Integer;

--- a/source/units/Goccia.Values.FFICallback.Test.pas
+++ b/source/units/Goccia.Values.FFICallback.Test.pas
@@ -1,0 +1,108 @@
+program Goccia.Values.FFICallback.Test;
+
+{$I Goccia.inc}
+
+uses
+  SysUtils,
+
+  TestingPascalLibrary,
+
+  Goccia.Arguments.Collection,
+  Goccia.FFI.Types,
+  Goccia.GarbageCollector,
+  Goccia.TestSetup,
+  Goccia.Values.FFICallback,
+  Goccia.Values.NativeFunction,
+  Goccia.Values.NativeFunctionCallback,
+  Goccia.Values.ObjectValue,
+  Goccia.Values.Primitives,
+  Goccia.VM.Exception;
+
+type
+  // Matches the trampoline generated for a callback taking no arguments and
+  // returning void.
+  TVoidCallbackTrampoline = procedure; cdecl;
+
+  TFFICallbackGCTests = class(TTestSuite)
+  private
+    FThrownValue: TGocciaValue;
+    function ThrowingCallbackBody(const AArgs: TGocciaArgumentsCollection;
+      const AThisValue: TGocciaValue): TGocciaValue;
+  public
+    procedure SetupTests; override;
+    procedure BeforeEach; override;
+    procedure TestMarkReferencesKeepsBytecodeThrowPayloadReachable;
+  end;
+
+{ TFFICallbackGCTests }
+
+function TFFICallbackGCTests.ThrowingCallbackBody(
+  const AArgs: TGocciaArgumentsCollection;
+  const AThisValue: TGocciaValue): TGocciaValue;
+begin
+  { A compiled callback body's JS throw leaves the VM as EGocciaBytecodeThrow.
+    Raising it here reproduces exactly what InvokeFromNative parks. }
+  raise EGocciaBytecodeThrow.Create(FThrownValue);
+end;
+
+procedure TFFICallbackGCTests.SetupTests;
+begin
+  Test('MarkReferences keeps a parked EGocciaBytecodeThrow payload reachable ' +
+    'across a collection',
+    TestMarkReferencesKeepsBytecodeThrowPayloadReachable);
+end;
+
+procedure TFFICallbackGCTests.BeforeEach;
+begin
+  FThrownValue := nil;
+end;
+
+procedure TFFICallbackGCTests.TestMarkReferencesKeepsBytecodeThrowPayloadReachable;
+var
+  Descriptor: TGocciaFFITypeDescriptor;
+  Callable: TGocciaNativeFunctionValue;
+  Callback: TGocciaFFICallbackValue;
+  Trampoline: TVoidCallbackTrampoline;
+begin
+  { The thrown value is an ordinary managed object reachable from nothing but
+    the exception the callback body raises. }
+  FThrownValue := TGocciaObjectValue.Create;
+
+  Descriptor := TGocciaFFITypeDescriptor.CreateCallback([],
+    TGocciaFFITypeDescriptor.CreateScalar(fftVoid));
+  Callable := TGocciaNativeFunctionValue.CreateWithoutPrototype(
+    ThrowingCallbackBody, '<throwing-callback>', 0);
+  Callback := TGocciaFFICallbackValue.Create(Descriptor, Callable);
+  try
+    Expect<Boolean>(Assigned(Callback.Pointer)).ToBe(True);
+
+    { Invoke the native trampoline directly. No FFI call context is active on
+      this thread, so InvokeFromNative parks the throw into the callback's
+      FPendingException field — the exact path MarkReferences must scan — rather
+      than the transient per-call context. }
+    Trampoline := TVoidCallbackTrampoline(Callback.Pointer);
+    Trampoline();
+
+    { Simulate the start of a mark phase: advancing the generation makes every
+      object read as unmarked. The only live reference to FThrownValue now is
+      the parked EGocciaBytecodeThrow, so it survives the sweep iff
+      Callback.MarkReferences marks it. }
+    TGCManagedObject.AdvanceMark;
+    Expect<Boolean>(FThrownValue.GCMarked).ToBe(False);
+
+    Callback.MarkReferences;
+
+    Expect<Boolean>(FThrownValue.GCMarked).ToBe(True);
+  finally
+    { Release the native slot and free the parked exception without re-raising
+      it (Close would re-raise). }
+    Callback.CloseForFFICallCleanup;
+  end;
+end;
+
+begin
+  TestRunnerProgram.AddSuite(
+    TFFICallbackGCTests.Create('FFI callback GC'));
+  RunGocciaTests;
+  ExitCode := TestResultToExitCode;
+end.

--- a/source/units/Goccia.Values.FFICallback.pas
+++ b/source/units/Goccia.Values.FFICallback.pas
@@ -77,7 +77,8 @@ uses
   Goccia.Values.ErrorHelper,
   Goccia.Values.FFIPointer,
   Goccia.Values.FFIType,
-  Goccia.Values.NativeFunction;
+  Goccia.Values.NativeFunction,
+  Goccia.VM.Exception;
 
 const
   FFI_CALLBACK_TAG = 'FFICallback';
@@ -718,13 +719,22 @@ begin
 end;
 
 procedure TGocciaFFICallbackValue.MarkReferences;
+var
+  PendingThrown: TGocciaValue;
 begin
   if GCMarked then Exit;
   inherited;
   if Assigned(FCallable) then FCallable.MarkReferences;
   if Assigned(FCloseFunction) then FCloseFunction.MarkReferences;
-  if FPendingException is TGocciaThrowValue then
-    TGocciaThrowValue(FPendingException).Value.MarkReferences;
+  { FPendingException is parked from Exception(AcquireExceptionObject) for ANY
+    exception a compiled callback body raises, including EGocciaBytecodeThrow.
+    Its ThrownValue is reachable from nothing else the collector scans, so an
+    allocation-triggered GC between the park and the re-raise (RaisePendingFailure
+    / Close) would sweep it and hand the guest a freed object. UnwrapThrownValue
+    covers every boundary exception class that carries a live TGocciaValue. }
+  if UnwrapThrownValue(FPendingException, PendingThrown) and
+     Assigned(PendingThrown) then
+    PendingThrown.MarkReferences;
 end;
 
 procedure DispatchCallbackHook(const AContext: Pointer;

--- a/source/units/Goccia.Values.FunctionValue.pas
+++ b/source/units/Goccia.Values.FunctionValue.pas
@@ -185,19 +185,20 @@ type
 function TryRejectAsyncPromiseWithException(
   const APromise: TGocciaPromiseValue;
   const AException: Exception): Boolean;
+var
+  ThrownVal: TGocciaValue;
 begin
   Result := True;
   { A hoisted module-level `async function` is an interpreter closure even
     under the bytecode executor (the module loader creates it during linking),
     so its body can call a compiled function whose JS throw leaves the VM as
     EGocciaBytecodeThrow. That is a guest completion carrying the thrown value,
-    exactly like TGocciaThrowValue; without this branch the resume path treated
-    it as an engine fault, re-raised it into the microtask queue, and left the
-    async function's promise forever pending. }
-  if AException is EGocciaBytecodeThrow then
-    APromise.Reject(EGocciaBytecodeThrow(AException).ThrownValue)
-  else if AException is TGocciaThrowValue then
-    APromise.Reject(TGocciaThrowValue(AException).Value)
+    exactly like TGocciaThrowValue; without this the resume path treated it as
+    an engine fault, re-raised it into the microtask queue, and left the async
+    function's promise forever pending. UnwrapThrownValue handles both boundary
+    classes, identity preserved. }
+  if UnwrapThrownValue(AException, ThrownVal) then
+    APromise.Reject(ThrownVal)
   else if AException is TGocciaTypeError then
     APromise.Reject(CreateErrorObject(TYPE_ERROR_NAME, AException.Message))
   else if AException is TGocciaReferenceError then

--- a/tests/language/async-generators/compiled-callee-throw/goccia.json
+++ b/tests/language/async-generators/compiled-callee-throw/goccia.json
@@ -1,0 +1,4 @@
+{
+  "source-type": "module",
+  "compat-function": true
+}

--- a/tests/language/async-generators/compiled-callee-throw/helpers/delegating-async-generator.js
+++ b/tests/language/async-generators/compiled-callee-throw/helpers/delegating-async-generator.js
@@ -1,0 +1,9 @@
+// A module-level exported async generator. With compat-function enabled the
+// module loader creates it as an interpreter closure even under the bytecode
+// executor, so its yield* delegation runs through the interpreter's
+// async-from-sync iterator (Goccia.Generator.Continuation). The sync iterable
+// it delegates to is created by the VM-compiled caller, so that iterable's
+// `next` throw crosses the boundary as the engine's bytecode-throw exception.
+export async function* delegate(iterable) {
+  yield* iterable;
+}

--- a/tests/language/async-generators/compiled-callee-throw/yield-star-throw.js
+++ b/tests/language/async-generators/compiled-callee-throw/yield-star-throw.js
@@ -1,0 +1,67 @@
+/*---
+description: interpreter-run async generator yield* over a compiled throwing sync next rejects with the thrown value itself
+features: [async-generators, modules, compat-function]
+---*/
+
+// `delegate` is an imported module-level async generator, so under the bytecode
+// executor it runs on the interpreter and its yield* uses the interpreter's
+// async-from-sync iterator. The throwing sync iterable is created here, so its
+// `next` is VM-compiled and its throw crosses that boundary as the engine's
+// bytecode-throw exception. The rejection must carry the thrown value's
+// identity, not a fresh Error synthesized from "Name: message".
+import { delegate } from "./helpers/delegating-async-generator.js";
+
+class Boom extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "Boom";
+  }
+}
+
+describe("interpreter async generator yield* over a compiled throwing sync iterator", () => {
+  test("rejects next() with the thrown error's identity", async () => {
+    const boom = new Boom("boom");
+    const throwingIterable = {
+      [Symbol.iterator]() {
+        return {
+          next() {
+            throw boom;
+          },
+        };
+      },
+    };
+
+    let caught = null;
+    try {
+      await delegate(throwingIterable).next();
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBe(boom);
+    expect(caught.name).toBe("Boom");
+    expect(caught.message).toBe("boom");
+  });
+
+  test("rejects next() with a thrown non-error value's identity", async () => {
+    const sentinel = { marker: "sentinel" };
+    const throwingIterable = {
+      [Symbol.iterator]() {
+        return {
+          next() {
+            throw sentinel;
+          },
+        };
+      },
+    };
+
+    let caught = "unset";
+    try {
+      await delegate(throwingIterable).next();
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBe(sentinel);
+  });
+});

--- a/tests/language/explicit-resource-management/compiled-dispose-throw/dispose-throw.js
+++ b/tests/language/explicit-resource-management/compiled-dispose-throw/dispose-throw.js
@@ -1,0 +1,82 @@
+/*---
+description: interpreter-run disposal catches a compiled dispose throw, keeps disposing, and surfaces the thrown value
+features: [explicit-resource-management, modules, compat-function]
+---*/
+
+// disposeSync/disposeAsync are imported module-level async functions, so under
+// the bytecode executor they run on the interpreter and their disposal uses the
+// interpreter's DisposeTrackedResources / DisposeTrackedResourcesAsync ladders.
+// The resources are created here, so their dispose methods are VM-compiled and a
+// throw crosses that boundary as the engine's bytecode-throw exception. The
+// ladder must CATCH that exception (so a later resource is still disposed) and
+// surface the thrown value's identity — not let it escape uncaught.
+import { disposeSync, disposeAsync } from "./helpers/disposer.js";
+
+class Boom extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "Boom";
+  }
+}
+
+describe("interpreter disposal of a compiled throwing resource", () => {
+  test("using [Symbol.dispose] throw is caught; later resource still disposed", async () => {
+    const boom = new Boom("boom");
+    let trackerDisposed = false;
+    const tracker = {
+      [Symbol.dispose]() {
+        trackerDisposed = true;
+      },
+    };
+    const thrower = {
+      [Symbol.dispose]() {
+        throw boom;
+      },
+    };
+
+    let caught = null;
+    try {
+      await disposeSync(tracker, thrower);
+    } catch (error) {
+      caught = error;
+    }
+
+    // If the bytecode throw escaped uncaught, disposal would stop before the
+    // tracker (declared first, disposed last) ran.
+    expect(trackerDisposed).toBe(true);
+    expect(caught).toBe(boom);
+    expect(caught.name).toBe("Boom");
+    expect(caught.message).toBe("boom");
+  });
+
+  test("await using synchronous dispose throw is caught; later resource still disposed", async () => {
+    const boom = new Boom("boom");
+    let trackerDisposed = false;
+    const tracker = {
+      async [Symbol.asyncDispose]() {
+        trackerDisposed = true;
+      },
+    };
+    // A synchronous [Symbol.dispose] under await using throws before the await
+    // point, so its bytecode throw reaches the async disposal ladder as the
+    // engine's bytecode-throw exception (an async dispose would instead reject a
+    // promise, surfacing as a plain interpreter throw).
+    const thrower = {
+      [Symbol.dispose]() {
+        throw boom;
+      },
+    };
+
+    let caught = null;
+    try {
+      await disposeAsync(tracker, thrower);
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(trackerDisposed).toBe(true);
+    expect(caught).toBe(boom);
+    expect(caught.name).toBe("Boom");
+    expect(caught.message).toBe("boom");
+  });
+});

--- a/tests/language/explicit-resource-management/compiled-dispose-throw/goccia.json
+++ b/tests/language/explicit-resource-management/compiled-dispose-throw/goccia.json
@@ -1,0 +1,4 @@
+{
+  "source-type": "module",
+  "compat-function": true
+}

--- a/tests/language/explicit-resource-management/compiled-dispose-throw/helpers/disposer.js
+++ b/tests/language/explicit-resource-management/compiled-dispose-throw/helpers/disposer.js
@@ -1,0 +1,20 @@
+// Interpreter-run (compat-function) functions that perform the disposal, so the
+// interpreter's DisposeTrackedResources / DisposeTrackedResourcesAsync ladders
+// handle a throw from the (VM-compiled) resource's dispose method. Two
+// resources are tracked so the test can observe that disposal CONTINUES past a
+// thrown boundary exception (the throwing resource is declared last, so LIFO
+// disposal runs it first). If the ladder failed to catch the bytecode throw it
+// would escape immediately and the tracker would never be disposed.
+export async function disposeSync(tracker, thrower) {
+  {
+    using t = tracker;
+    using x = thrower;
+  }
+}
+
+export async function disposeAsync(tracker, thrower) {
+  {
+    await using t = tracker;
+    await using x = thrower;
+  }
+}

--- a/tests/language/modules/dynamic-import-compiled-throw/dynamic-import-throw.js
+++ b/tests/language/modules/dynamic-import-compiled-throw/dynamic-import-throw.js
@@ -1,0 +1,35 @@
+/*---
+description: dynamic import() evaluated by the interpreter of a module whose compiled top-level throws rejects with the thrown value itself
+features: [modules, compat-function]
+---*/
+
+// importThrowing is an imported module-level async function, so under the
+// bytecode executor it runs on the interpreter and evaluates import() through
+// the interpreter's TGocciaImportExpression ladder. The imported module's
+// top-level code is VM-compiled, so its throw crosses that boundary as the
+// engine's bytecode-throw exception. The rejection must carry the thrown
+// value's identity, not a fresh Error synthesized from "Name: message".
+import { importThrowing } from "./helpers/importer.js";
+
+describe("interpreter dynamic import() of a module with a compiled top-level throw", () => {
+  test("rejects with the thrown value, identity preserved", async () => {
+    // Arm the imported module's top-level throw for this evaluation only.
+    globalThis.__gocciaArmTopLevelThrow = true;
+
+    let caught = null;
+    try {
+      await importThrowing();
+    } catch (error) {
+      caught = error;
+    } finally {
+      globalThis.__gocciaArmTopLevelThrow = false;
+    }
+
+    // A mangled rejection would be a plain Error named "Error" with message
+    // "Boom: boom"; the identity-preserving path keeps the module's own Boom.
+    expect(caught).not.toBe(null);
+    expect(caught instanceof Error).toBe(true);
+    expect(caught.name).toBe("Boom");
+    expect(caught.message).toBe("boom");
+  });
+});

--- a/tests/language/modules/dynamic-import-compiled-throw/goccia.json
+++ b/tests/language/modules/dynamic-import-compiled-throw/goccia.json
@@ -1,0 +1,4 @@
+{
+  "source-type": "module",
+  "compat-function": true
+}

--- a/tests/language/modules/dynamic-import-compiled-throw/helpers/importer.js
+++ b/tests/language/modules/dynamic-import-compiled-throw/helpers/importer.js
@@ -1,0 +1,5 @@
+// Interpreter-run (compat-function) async function that evaluates import() so
+// the interpreter's TGocciaImportExpression ladder handles the rejection.
+export async function importThrowing() {
+  return import("./top-level-throw.js");
+}

--- a/tests/language/modules/dynamic-import-compiled-throw/helpers/top-level-throw.js
+++ b/tests/language/modules/dynamic-import-compiled-throw/helpers/top-level-throw.js
@@ -1,0 +1,18 @@
+// Top-level code that throws during module evaluation, but only when the
+// importing test has armed the flag. The test runner also evaluates this file
+// standalone (it discovers every .js); leaving the flag unset there lets that
+// run complete cleanly instead of reporting a spurious failure. Under the
+// bytecode executor the armed throw is VM-compiled, so it crosses the
+// dynamic-import boundary as the engine's bytecode-throw exception.
+class Boom extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "Boom";
+  }
+}
+
+if (globalThis.__gocciaArmTopLevelThrow) {
+  throw new Boom("boom");
+}
+
+export const unreached = true;


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Completes `EGocciaBytecodeThrow` handling at every executor boundary that converts a Pascal exception to a JS value or rejection. A shared `UnwrapThrownValue` helper now centralizes the boundary-exception class list, so a compiled callee's `throw` preserves the thrown value's identity across the interpreter/bytecode boundary everywhere — previously it was mangled into a synthesized `Error("Name: message")` at four sites: async-generator `yield*` over a compiled sync iterator, dynamic `import()`, `using`/`await using` disposal, and (a GC-correctness hole) the FFI-callback parked-exception mark, where an `EGocciaBytecodeThrow` payload went unmarked and could be swept before re-raise.
- Follows the round-2 fix (#1203) that first unwrapped this exception on the async-reject path; this generalizes it and adds the shared helper so a future boundary exception class is covered in one place.

## Testing

- [x] Full suite both modes; per-site cross-boundary regression tests (mutation-verified: reverting fails bytecode-only or GC-faults)
- [x] Pascal FFI-callback GC unit test for the parked-exception mark
- [x] Differential zero divergence under bun 1.4.0 and CI-pinned 1.3.14; `./format.pas --check` and doc checks clean
