### PR TITLE
refactor(runtime): remove unused ASCII memo cleanup

### DIFF
--- a/source/shared/TextSemantics.pas
+++ b/source/shared/TextSemantics.pas
@@ -73,15 +73,6 @@ function NormalizeNewlinesToLF(const AText: string): string;
 function StringListToSourceText(const ALines: TStrings): string;
 function StringListToLFText(const ALines: TStrings): string;
 
-{ Release the per-thread is-ASCII memo. FPC does not auto-finalize managed
-  threadvars at thread exit. This unit's own finalization clears the main
-  thread's slots on process shutdown; because the unit stays free of engine
-  dependencies, that path works in every binary that links it (including the
-  shared JSON/numeric/config tools that never link the engine). Worker threads
-  are covered separately: the engine's Goccia.RegExp.VM registers this proc with
-  Goccia.ThreadCleanupRegistry, whose drain releases each worker's slots on exit. }
-procedure ClearAsciiMemo;
-
 implementation
 
 uses
@@ -384,10 +375,6 @@ function UTF16CodeUnitPairToString(const AFirst, ASecond: Cardinal): string;
 begin
   Result := Char(AFirst and $FFFF) + Char(ASecond and $FFFF);
 end;
-
-threadvar
-  GAsciiMemoStr0: string;
-  GAsciiMemoStr1: string;
 
 function UTF16StringsEqual(const ALeft, ARight: string): Boolean;
 begin
@@ -867,25 +854,5 @@ begin
 
   Result := Buffer.ToString;
 end;
-
-// Release the is-ASCII memo strings; FPC does not finalize managed threadvars at
-// thread exit. Run from this unit's own finalization on the main thread, and —
-// for worker threads — via Goccia.ThreadCleanupRegistry, where Goccia.RegExp.VM
-// registers it (see the declaration comment above).
-procedure ClearAsciiMemo;
-begin
-  GAsciiMemoStr0 := '';
-  GAsciiMemoStr1 := '';
-end;
-
-initialization
-
-finalization
-  // Main-thread cleanup, kept here because this generic unit has no engine
-  // dependency and so cannot self-register with Goccia.ThreadCleanupRegistry;
-  // it runs in every binary that links TextSemantics, including ones that never
-  // link the engine (Goccia.RegExp.VM registers the worker-thread path). FPC
-  // does not auto-finalize managed threadvars at thread exit.
-  ClearAsciiMemo;
 
 end.

--- a/source/units/Goccia.RegExp.VM.pas
+++ b/source/units/Goccia.RegExp.VM.pas
@@ -1420,15 +1420,6 @@ begin
 end;
 
 initialization
-  // FPC does not auto-finalize managed threadvars at thread exit. Register this
-  // unit's regex-input memo, and also the is-ASCII memo owned by the shared
-  // TextSemantics unit: TextSemantics is generic infrastructure that stays free
-  // of engine dependencies, so its per-thread memo is registered here instead
-  // (every engine binary links the regex VM). See ClearAsciiMemo in
-  // source/shared/TextSemantics.pas. The registry drain releases both memos on
-  // worker exit (ShutdownThreadRuntime) and on the main thread
-  // (Goccia.ThreadCleanupRegistry's finalization).
   RegisterThreadvarCleanup(@ClearRegExpInputMemo);
-  RegisterThreadvarCleanup(@ClearAsciiMemo);
 
 end.

--- a/source/units/Goccia.ThreadCleanupLeak.Test.pas
+++ b/source/units/Goccia.ThreadCleanupLeak.Test.pas
@@ -25,8 +25,6 @@ uses
   {$IFDEF UNIX}cthreads,{$ENDIF}
   SysUtils,
 
-  TextSemantics,
-
   Goccia.Builtins.Atomics,
   Goccia.Builtins.DisposableStack,
   Goccia.Builtins.Semver,
@@ -169,7 +167,6 @@ begin
   Expect<Boolean>(IsThreadvarCleanupRegistered(@ClearSemverHosts)).ToBe(True);
   Expect<Boolean>(IsThreadvarCleanupRegistered(@ClearTimeZoneCache)).ToBe(True);
   Expect<Boolean>(IsThreadvarCleanupRegistered(@ClearRegExpInputMemo)).ToBe(True);
-  Expect<Boolean>(IsThreadvarCleanupRegistered(@ClearAsciiMemo)).ToBe(True);
 end;
 
 begin


### PR DESCRIPTION
## Summary

- Remove the two unused ASCII memo threadvars, their empty cleanup routine, and its registry assertion (45 lines deleted). Source inspection found no writer or reader of the memo.
- Keep the live RegExp input memo and all remaining thread cleanup coverage. Historical ADRs retain their original decision records.
- This implements the obsolete ASCII memo recommendation from the September 4 codebase audit.

## Testing

- [x] Verified no regressions: clean test runner build; all 12,818 JavaScript tests / 28,573 assertions passed in each executor. The initial bytecode run timed out in WeakMap GC under concurrent builds; that file and the complete suite passed on rerun with fewer workers.
- [x] Documentation assessed: no public behavior or contributor workflow changes; historical ADRs are immutable.
- [x] Native Pascal: TextSemantics 12/12 and ThreadCleanupLeak 3/3 passed, including the unchanged reclamation threshold.
- [x] Format gate: 463 files checked; separate manual diff review and `git diff --check` passed.
- Benchmark comparison is not applicable to deleting never-used state.
