### PR TITLE
perf(website): throttle rate-limit bucket cleanup

### DIFF
--- a/website/src/__tests__/rate-limit.test.ts
+++ b/website/src/__tests__/rate-limit.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { clientIp, rateLimit } from "@/lib/rate-limit";
 
 // The rate limiter reads `Date.now()` on each call, so we can drive its
@@ -95,6 +95,49 @@ describe("rateLimit — token-bucket window", () => {
     const fresh = rateLimit(b);
     expect(fresh.ok).toBe(true);
     expect(fresh.remaining).toBe(fresh.limit - 1);
+  });
+
+  test("large live populations do not rescan on every request and still expire", () => {
+    let now = 1_000_000;
+    Date.now = () => now;
+    const prefix = uniqueKey("population");
+    const initial = rateLimit(`${prefix}:0`);
+    for (let i = 1; i < 5_000; i++) rateLimit(`${prefix}:${i}`);
+
+    const store = (
+      globalThis as typeof globalThis & {
+        __GOCCIA_RL_BUCKETS__: Map<string, { count: number; resetAt: number }>;
+      }
+    ).__GOCCIA_RL_BUCKETS__;
+    const scan = spyOn(store, Symbol.iterator);
+    try {
+      now += 2_000;
+      const activeKey = `${prefix}:active`;
+      const active = rateLimit(activeKey);
+      let last = active;
+      for (let i = 0; i < 2_000; i++) last = rateLimit(activeKey);
+      expect(last.ok).toBe(false);
+      expect(last.resetAt).toBe(active.resetAt);
+      expect(scan).toHaveBeenCalledTimes(1);
+
+      now = initial.resetAt;
+      rateLimit(uniqueKey("after-expiry"));
+      expect(scan).toHaveBeenCalledTimes(2);
+      expect(store.has(`${prefix}:0`)).toBe(false);
+      expect(store.has(`${prefix}:4999`)).toBe(false);
+      expect(store.has(activeKey)).toBe(true);
+      expect(rateLimit(activeKey).ok).toBe(false);
+
+      now = active.resetAt;
+      const renewed = rateLimit(activeKey);
+      expect(renewed.ok).toBe(true);
+      expect(renewed.remaining).toBe(renewed.limit - 1);
+    } finally {
+      scan.mockRestore();
+      for (const key of store.keys()) {
+        if (key.startsWith(prefix)) store.delete(key);
+      }
+    }
   });
 });
 

--- a/website/src/__tests__/rate-limit.test.ts
+++ b/website/src/__tests__/rate-limit.test.ts
@@ -121,7 +121,7 @@ describe("rateLimit — token-bucket window", () => {
       expect(scan).toHaveBeenCalledTimes(1);
 
       now = initial.resetAt;
-      rateLimit(uniqueKey("after-expiry"));
+      rateLimit(`${prefix}:after-expiry`);
       expect(scan).toHaveBeenCalledTimes(2);
       expect(store.has(`${prefix}:0`)).toBe(false);
       expect(store.has(`${prefix}:4999`)).toBe(false);

--- a/website/src/lib/rate-limit.ts
+++ b/website/src/lib/rate-limit.ts
@@ -25,6 +25,8 @@ function getBucketStore(): Map<string, Bucket> {
   return g.__GOCCIA_RL_BUCKETS__;
 }
 const buckets = getBucketStore();
+const CLEANUP_INTERVAL_MS = 1_000;
+let nextCleanupAt = 0;
 
 export type RateLimitResult = {
   ok: boolean;
@@ -41,11 +43,12 @@ export function rateLimit(key: string): RateLimitResult {
     buckets.set(key, b);
   }
   b.count += 1;
-  // Opportunistic GC: drop a few stale entries every so often so the map
-  // doesn't grow unbounded under traffic.
-  if (buckets.size > 4096) {
+  // A large active map rarely contains expired entries. Sweep at most once
+  // per second instead of scanning it again for every request in the window.
+  if (buckets.size > 4096 && now >= nextCleanupAt) {
+    nextCleanupAt = now + CLEANUP_INTERVAL_MS;
     for (const [k, v] of buckets) {
-      if (v.resetAt < now) buckets.delete(k);
+      if (v.resetAt <= now) buckets.delete(k);
     }
   }
   return {


### PR DESCRIPTION
## Summary

- Sweep expired rate-limit buckets at most once per second when the map exceeds 4,096 clients. Previously every request scanned the entire map, including denied requests while all entries were live.
- Preserve fixed-window quotas and reclaim expired entries at the reset boundary. A high-cardinality regression exercises 5,000 clients, repeated denied requests, expiry, and active-client preservation.
- Local in-process A/B: 2,000 checks with 20,000 live buckets took a median 549.27 ms before and 0.385 ms after (7 alternating measured samples after warmup, including one candidate sweep). These are synthetic map costs, not endpoint throughput.

## Testing

- [x] Website: 205 tests / 530 assertions passed; focused rate-limit tests 12/12; changed-file Biome check passed.
- [x] Documentation assessed: public quota behavior and configuration are unchanged; the change is internal expiration maintenance.
- [x] Native test runner build and Pascal format check passed; separate manual diff review passed.
- [x] All 49 CI checks are green at `5ecbe936f502bdd2bcfaaa49a7ae5902928726ea`, including both JavaScript executors, CLI, test262 and benchmark lanes. The local development suite stalled in unchanged baseline native code under workstation contention; clean CI validation passed.
- [x] Local synthetic performance comparison verifies the same quota decisions; per-sample baseline spread 436–847 ms and candidate spread 0.166–0.618 ms.
