### PR TITLE
refactor(website): centralize report storage and publication

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -68,6 +68,23 @@ Two settings live outside this repo:
   logs that it skipped, and the release reaches the site on its next
   deployment instead.
 
+## Report publication
+
+CI publisher commands under `scripts/publish-*.ts` normalize report files and
+compute report-specific summaries before uploading them. `scripts/lib/report-publishing.ts` supplies the
+shared GitHub run metadata, timestamp parsing, and profile file arguments.
+`src/lib/report-blob.ts` owns byte reads, compression, upload options, and
+profile attachments; each `*-blob-store.ts` adapter owns its schema, environment
+settings, and storage paths. Requests continue reading published Blob data;
+publisher metadata and file processing remain in CI scripts.
+
+AWFY and Web Tooling overwrite one pointer per UTC day. JetStream retains a
+pointer per run within each day. Test262 keeps its distinct report path and
+profile namespace, with profile access controlled by `TEST262_BLOB_ACCESS`;
+benchmark profiles use `BENCHMARK_PROFILE_BLOB_ACCESS`. See the
+[benchmark guide](../docs/benchmarks.md) and [test262 guide](../docs/test262.md)
+for the report and publication contracts.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/website/scripts/lib/report-publishing.ts
+++ b/website/scripts/lib/report-publishing.ts
@@ -1,0 +1,105 @@
+import { readFile } from "node:fs/promises";
+import { GITHUB_REPO_URL } from "../../src/lib/github";
+
+function numberFromEnv(name: string): number | null {
+  const value = process.env[name];
+  if (!value) return null;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+export function timestampFromEnv(
+  name: string,
+  unixSeconds = true,
+): string | null {
+  const value = process.env[name]?.trim();
+  if (!value) return null;
+  if (unixSeconds && /^\d+$/.test(value)) {
+    const seconds = Number(value);
+    if (Number.isSafeInteger(seconds) && seconds > 0) {
+      return new Date(seconds * 1000).toISOString();
+    }
+  }
+  const time = Date.parse(value);
+  return Number.isNaN(time) ? null : new Date(time).toISOString();
+}
+
+export function currentRunMetadata(
+  artifactIdEnv: string,
+  createdAt: string | null,
+) {
+  const runId = numberFromEnv("GITHUB_RUN_ID");
+  const artifactId = numberFromEnv(artifactIdEnv) ?? runId ?? Date.now();
+  const repository = process.env.GITHUB_REPOSITORY ?? "frostney/GocciaScript";
+  const server = process.env.GITHUB_SERVER_URL ?? "https://github.com";
+  const headSha = process.env.GITHUB_SHA ?? "unknown";
+  const now = new Date().toISOString();
+  return {
+    runId: runId ?? artifactId,
+    runNumber: numberFromEnv("GITHUB_RUN_NUMBER") ?? 0,
+    artifactId,
+    title: process.env.GITHUB_WORKFLOW ?? "CI",
+    headSha,
+    shortSha: headSha.slice(0, 8),
+    runUrl: runId
+      ? `${server}/${repository}/actions/runs/${runId}`
+      : GITHUB_REPO_URL,
+    createdAt: createdAt ?? now,
+    updatedAt: now,
+    artifactCreatedAt: now,
+  };
+}
+
+export function parseProfileArgs(
+  args: string[],
+  usage: () => never,
+): {
+  aggregate: string;
+  markdown: string | null;
+  detailsArchive: string | null;
+} {
+  let aggregate: string | null = null;
+  let markdown: string | null = null;
+  let detailsArchive: string | null = null;
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--aggregate") aggregate = args[++i] ?? null;
+    else if (arg.startsWith("--aggregate=")) {
+      aggregate = arg.slice("--aggregate=".length);
+    } else if (arg === "--markdown") markdown = args[++i] ?? null;
+    else if (arg.startsWith("--markdown=")) {
+      markdown = arg.slice("--markdown=".length);
+    } else if (arg === "--details-archive") detailsArchive = args[++i] ?? null;
+    else if (arg.startsWith("--details-archive=")) {
+      detailsArchive = arg.slice("--details-archive=".length);
+    } else if (arg === "--help" || arg === "-h") {
+      usage();
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!aggregate) usage();
+  return { aggregate, markdown, detailsArchive };
+}
+
+async function readJsonFile(filePath: string): Promise<string> {
+  const raw = await readFile(filePath, "utf8");
+  const parsed = JSON.parse(raw) as unknown;
+  return `${JSON.stringify(parsed, null, 2)}\n`;
+}
+
+export async function readProfileFiles(
+  aggregatePath: string,
+  markdownPath: string | null,
+  detailsArchivePath: string | null,
+) {
+  return {
+    aggregateJson: await readJsonFile(aggregatePath),
+    markdown: markdownPath ? await readFile(markdownPath) : undefined,
+    detailsArchive: detailsArchivePath
+      ? await readFile(detailsArchivePath)
+      : undefined,
+  };
+}

--- a/website/scripts/lib/report-publishing.ts
+++ b/website/scripts/lib/report-publishing.ts
@@ -17,7 +17,8 @@ export function timestampFromEnv(
   if (unixSeconds && /^\d+$/.test(value)) {
     const seconds = Number(value);
     if (Number.isSafeInteger(seconds) && seconds > 0) {
-      return new Date(seconds * 1000).toISOString();
+      const date = new Date(seconds * 1000);
+      return Number.isNaN(date.getTime()) ? null : date.toISOString();
     }
   }
   const time = Date.parse(value);

--- a/website/scripts/publish-awfy-report.ts
+++ b/website/scripts/publish-awfy-report.ts
@@ -7,7 +7,7 @@ import {
   awfyBlobReportPathForArtifactId,
   publishAwfyReportsToBlob,
 } from "../src/lib/awfy-blob-store";
-import { GITHUB_REPO_URL } from "../src/lib/github";
+import { currentRunMetadata, timestampFromEnv } from "./lib/report-publishing";
 
 type AwfyReport = {
   metadata?: {
@@ -46,26 +46,6 @@ type AwfyReport = {
 
 function log(message: string) {
   console.log(`[publish-awfy] ${message}`);
-}
-
-function numberFromEnv(name: string): number | null {
-  const value = process.env[name];
-  if (!value) return null;
-  const parsed = Number(value);
-  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
-}
-
-function timestampFromEnv(name: string): string | null {
-  const value = process.env[name]?.trim();
-  if (!value) return null;
-  if (/^\d+$/.test(value)) {
-    const seconds = Number(value);
-    if (Number.isSafeInteger(seconds) && seconds > 0) {
-      return new Date(seconds * 1000).toISOString();
-    }
-  }
-  const time = Date.parse(value);
-  return Number.isNaN(time) ? null : new Date(time).toISOString();
 }
 
 function finiteRatio(value: unknown): number | null {
@@ -157,31 +137,11 @@ async function readEntryFromFile(
     throw new Error(`${filePath} is not a valid AWFY report`);
   }
 
-  const runId = numberFromEnv("GITHUB_RUN_ID");
-  const runNumber = numberFromEnv("GITHUB_RUN_NUMBER");
-  const artifactId =
-    numberFromEnv("AWFY_ARTIFACT_ID") ??
-    numberFromEnv("GITHUB_RUN_ID") ??
-    Date.now();
-  const repository = process.env.GITHUB_REPOSITORY ?? "frostney/GocciaScript";
-  const server = process.env.GITHUB_SERVER_URL ?? "https://github.com";
-  const headSha = process.env.GITHUB_SHA ?? "unknown";
-  const now = new Date().toISOString();
-  const createdAt = timestampFromEnv("AWFY_RUN_CREATED_AT") ?? now;
-
   return {
-    runId: runId ?? artifactId,
-    runNumber: runNumber ?? 0,
-    artifactId,
-    title: process.env.GITHUB_WORKFLOW ?? "CI",
-    headSha,
-    shortSha: headSha.slice(0, 8),
-    runUrl: runId
-      ? `${server}/${repository}/actions/runs/${runId}`
-      : GITHUB_REPO_URL,
-    createdAt,
-    updatedAt: now,
-    artifactCreatedAt: now,
+    ...currentRunMetadata(
+      "AWFY_ARTIFACT_ID",
+      timestampFromEnv("AWFY_RUN_CREATED_AT"),
+    ),
     summary: summaryFromReport(parsed),
     reportJson: `${JSON.stringify(parsed, null, 2)}\n`,
   };

--- a/website/scripts/publish-benchmark-profile-reports.ts
+++ b/website/scripts/publish-benchmark-profile-reports.ts
@@ -1,5 +1,4 @@
 #!/usr/bin/env bun
-import { readFile } from "node:fs/promises";
 import {
   type BenchmarkProfileBlobPublishEntry,
   benchmarkProfileBlobDailyPathForDay,
@@ -7,67 +6,15 @@ import {
   benchmarkProfileBlobReportPathForArtifactId,
   publishBenchmarkProfileReportsToBlob,
 } from "../src/lib/benchmark-profile-blob-store";
-import { GITHUB_REPO_URL } from "../src/lib/github";
+import {
+  currentRunMetadata,
+  parseProfileArgs,
+  readProfileFiles,
+  timestampFromEnv,
+} from "./lib/report-publishing";
 
 function log(message: string) {
   console.log(`[publish-benchmark-profile] ${message}`);
-}
-
-function numberFromEnv(name: string): number | null {
-  const value = process.env[name];
-  if (!value) return null;
-  const parsed = Number(value);
-  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
-}
-
-function timestampFromEnv(name: string): string | null {
-  const value = process.env[name]?.trim();
-  if (!value) return null;
-  if (/^\d+$/.test(value)) {
-    const seconds = Number(value);
-    if (Number.isSafeInteger(seconds) && seconds > 0) {
-      return new Date(seconds * 1000).toISOString();
-    }
-  }
-  const time = Date.parse(value);
-  return Number.isNaN(time) ? null : new Date(time).toISOString();
-}
-
-function parseArgs(args: string[]): {
-  aggregate: string;
-  markdown: string | null;
-  detailsArchive: string | null;
-} {
-  let aggregate: string | null = null;
-  let markdown: string | null = null;
-  let detailsArchive: string | null = null;
-
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
-    if (arg === "--aggregate") aggregate = args[++i] ?? null;
-    else if (arg.startsWith("--aggregate=")) {
-      aggregate = arg.slice("--aggregate=".length);
-    } else if (arg === "--markdown") markdown = args[++i] ?? null;
-    else if (arg.startsWith("--markdown=")) {
-      markdown = arg.slice("--markdown=".length);
-    } else if (arg === "--details-archive") detailsArchive = args[++i] ?? null;
-    else if (arg.startsWith("--details-archive=")) {
-      detailsArchive = arg.slice("--details-archive=".length);
-    } else if (arg === "--help" || arg === "-h") {
-      usage();
-    } else {
-      throw new Error(`Unknown argument: ${arg}`);
-    }
-  }
-
-  if (!aggregate) usage();
-  return { aggregate, markdown, detailsArchive };
-}
-
-async function readJsonFile(filePath: string): Promise<string> {
-  const raw = await readFile(filePath, "utf8");
-  const parsed = JSON.parse(raw) as unknown;
-  return `${JSON.stringify(parsed, null, 2)}\n`;
 }
 
 async function readEntryFromFiles(
@@ -75,36 +22,16 @@ async function readEntryFromFiles(
   markdownPath: string | null,
   detailsArchivePath: string | null,
 ): Promise<BenchmarkProfileBlobPublishEntry> {
-  const runId = numberFromEnv("GITHUB_RUN_ID");
-  const runNumber = numberFromEnv("GITHUB_RUN_NUMBER");
-  const artifactId =
-    numberFromEnv("BENCHMARK_PROFILE_ARTIFACT_ID") ??
-    numberFromEnv("GITHUB_RUN_ID") ??
-    Date.now();
-  const repository = process.env.GITHUB_REPOSITORY ?? "frostney/GocciaScript";
-  const server = process.env.GITHUB_SERVER_URL ?? "https://github.com";
-  const headSha = process.env.GITHUB_SHA ?? "unknown";
-  const now = new Date().toISOString();
-  const createdAt = timestampFromEnv("BENCHMARK_PROFILE_RUN_CREATED_AT") ?? now;
-
   return {
-    runId: runId ?? artifactId,
-    runNumber: runNumber ?? 0,
-    artifactId,
-    title: process.env.GITHUB_WORKFLOW ?? "CI",
-    headSha,
-    shortSha: headSha.slice(0, 8),
-    runUrl: runId
-      ? `${server}/${repository}/actions/runs/${runId}`
-      : GITHUB_REPO_URL,
-    createdAt,
-    updatedAt: now,
-    artifactCreatedAt: now,
-    aggregateJson: await readJsonFile(aggregatePath),
-    markdown: markdownPath ? await readFile(markdownPath) : undefined,
-    detailsArchive: detailsArchivePath
-      ? await readFile(detailsArchivePath)
-      : undefined,
+    ...currentRunMetadata(
+      "BENCHMARK_PROFILE_ARTIFACT_ID",
+      timestampFromEnv("BENCHMARK_PROFILE_RUN_CREATED_AT"),
+    ),
+    ...(await readProfileFiles(
+      aggregatePath,
+      markdownPath,
+      detailsArchivePath,
+    )),
   };
 }
 
@@ -121,7 +48,7 @@ Environment:
 }
 
 async function main() {
-  const args = parseArgs(process.argv.slice(2));
+  const args = parseProfileArgs(process.argv.slice(2), usage);
   if (!process.env.BLOB_READ_WRITE_TOKEN) {
     throw new Error(
       "Set BLOB_READ_WRITE_TOKEN to publish benchmark profile Blob data",

--- a/website/scripts/publish-jetstream-report.ts
+++ b/website/scripts/publish-jetstream-report.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env bun
 
 import { readFile } from "node:fs/promises";
-import { GITHUB_REPO_URL } from "../src/lib/github";
 import {
   type JetStreamBlobPublishEntry,
   jetStreamBlobDailyPathForRun,
@@ -9,6 +8,7 @@ import {
   jetStreamBlobReportPathForArtifactId,
   publishJetStreamReportsToBlob,
 } from "../src/lib/jetstream-blob-store";
+import { currentRunMetadata, timestampFromEnv } from "./lib/report-publishing";
 
 type EngineStats = {
   ok?: number;
@@ -40,18 +40,6 @@ export type JetStreamReport = {
   }>;
   geomeanRatios?: Record<string, unknown>;
 };
-
-function numberFromEnv(name: string): number | null {
-  const parsed = Number(process.env[name]);
-  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
-}
-
-function timestampFromEnv(name: string): string | null {
-  const value = process.env[name]?.trim();
-  if (!value) return null;
-  const time = Date.parse(value);
-  return Number.isNaN(time) ? null : new Date(time).toISOString();
-}
 
 function finiteRatio(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) && value > 0
@@ -135,27 +123,11 @@ async function readEntry(filePath: string): Promise<JetStreamBlobPublishEntry> {
   if (!Array.isArray(report.targets)) {
     throw new Error(`${filePath} is not a valid JetStream report`);
   }
-  const runId = numberFromEnv("GITHUB_RUN_ID");
-  const artifactId =
-    numberFromEnv("JETSTREAM_ARTIFACT_ID") ?? runId ?? Date.now();
-  const repository = process.env.GITHUB_REPOSITORY ?? "frostney/GocciaScript";
-  const server = process.env.GITHUB_SERVER_URL ?? "https://github.com";
-  const headSha = process.env.GITHUB_SHA ?? "unknown";
-  const now = new Date().toISOString();
-  const createdAt = timestampFromEnv("JETSTREAM_RUN_CREATED_AT") ?? now;
   return {
-    runId: runId ?? artifactId,
-    runNumber: numberFromEnv("GITHUB_RUN_NUMBER") ?? 0,
-    artifactId,
-    title: process.env.GITHUB_WORKFLOW ?? "CI",
-    headSha,
-    shortSha: headSha.slice(0, 8),
-    runUrl: runId
-      ? `${server}/${repository}/actions/runs/${runId}`
-      : GITHUB_REPO_URL,
-    createdAt,
-    updatedAt: now,
-    artifactCreatedAt: now,
+    ...currentRunMetadata(
+      "JETSTREAM_ARTIFACT_ID",
+      timestampFromEnv("JETSTREAM_RUN_CREATED_AT", false),
+    ),
     summary: summaryFromReport(report),
     reportJson: `${JSON.stringify(report, null, 2)}\n`,
   };

--- a/website/scripts/publish-test262-profile-reports.ts
+++ b/website/scripts/publish-test262-profile-reports.ts
@@ -1,6 +1,4 @@
 #!/usr/bin/env bun
-import { readFile } from "node:fs/promises";
-import { GITHUB_REPO_URL } from "../src/lib/github";
 import {
   publishTest262ProfileReportsToBlob,
   type Test262ProfileBlobPublishEntry,
@@ -8,66 +6,15 @@ import {
   test262ProfileBlobPrefix,
   test262ProfileBlobReportPathForArtifactId,
 } from "../src/lib/test262-blob-store";
+import {
+  currentRunMetadata,
+  parseProfileArgs,
+  readProfileFiles,
+  timestampFromEnv,
+} from "./lib/report-publishing";
 
 function log(message: string) {
   console.log(`[publish-test262-profile] ${message}`);
-}
-
-function numberFromEnv(name: string): number | null {
-  const value = process.env[name];
-  if (!value) return null;
-  const parsed = Number(value);
-  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
-}
-
-function timestampFromEnv(name: string): string | null {
-  const value = process.env[name]?.trim();
-  if (!value) return null;
-  if (/^\d+$/.test(value)) {
-    const seconds = Number(value);
-    if (Number.isSafeInteger(seconds) && seconds > 0) {
-      return new Date(seconds * 1000).toISOString();
-    }
-  }
-  const time = Date.parse(value);
-  return Number.isNaN(time) ? null : new Date(time).toISOString();
-}
-
-function parseArgs(args: string[]): {
-  aggregate: string;
-  markdown: string | null;
-  detailsArchive: string | null;
-} {
-  let aggregate: string | null = null;
-  let markdown: string | null = null;
-  let detailsArchive: string | null = null;
-
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
-    if (arg === "--aggregate") aggregate = args[++i] ?? null;
-    else if (arg.startsWith("--aggregate=")) {
-      aggregate = arg.slice("--aggregate=".length);
-    } else if (arg === "--markdown") markdown = args[++i] ?? null;
-    else if (arg.startsWith("--markdown=")) {
-      markdown = arg.slice("--markdown=".length);
-    } else if (arg === "--details-archive") detailsArchive = args[++i] ?? null;
-    else if (arg.startsWith("--details-archive=")) {
-      detailsArchive = arg.slice("--details-archive=".length);
-    } else if (arg === "--help" || arg === "-h") {
-      usage();
-    } else {
-      throw new Error(`Unknown argument: ${arg}`);
-    }
-  }
-
-  if (!aggregate) usage();
-  return { aggregate, markdown, detailsArchive };
-}
-
-async function readJsonFile(filePath: string): Promise<string> {
-  const raw = await readFile(filePath, "utf8");
-  const parsed = JSON.parse(raw) as unknown;
-  return `${JSON.stringify(parsed, null, 2)}\n`;
 }
 
 async function readEntryFromFiles(
@@ -75,39 +22,17 @@ async function readEntryFromFiles(
   markdownPath: string | null,
   detailsArchivePath: string | null,
 ): Promise<Test262ProfileBlobPublishEntry> {
-  const runId = numberFromEnv("GITHUB_RUN_ID");
-  const runNumber = numberFromEnv("GITHUB_RUN_NUMBER");
-  const artifactId =
-    numberFromEnv("TEST262_PROFILE_ARTIFACT_ID") ??
-    numberFromEnv("GITHUB_RUN_ID") ??
-    Date.now();
-  const repository = process.env.GITHUB_REPOSITORY ?? "frostney/GocciaScript";
-  const server = process.env.GITHUB_SERVER_URL ?? "https://github.com";
-  const headSha = process.env.GITHUB_SHA ?? "unknown";
-  const now = new Date().toISOString();
-  const createdAt =
-    timestampFromEnv("TEST262_PROFILE_RUN_CREATED_AT") ??
-    timestampFromEnv("TEST262_RUN_CREATED_AT") ??
-    now;
-
   return {
-    runId: runId ?? artifactId,
-    runNumber: runNumber ?? 0,
-    artifactId,
-    title: process.env.GITHUB_WORKFLOW ?? "CI",
-    headSha,
-    shortSha: headSha.slice(0, 8),
-    runUrl: runId
-      ? `${server}/${repository}/actions/runs/${runId}`
-      : GITHUB_REPO_URL,
-    createdAt,
-    updatedAt: now,
-    artifactCreatedAt: now,
-    aggregateJson: await readJsonFile(aggregatePath),
-    markdown: markdownPath ? await readFile(markdownPath) : undefined,
-    detailsArchive: detailsArchivePath
-      ? await readFile(detailsArchivePath)
-      : undefined,
+    ...currentRunMetadata(
+      "TEST262_PROFILE_ARTIFACT_ID",
+      timestampFromEnv("TEST262_PROFILE_RUN_CREATED_AT") ??
+        timestampFromEnv("TEST262_RUN_CREATED_AT"),
+    ),
+    ...(await readProfileFiles(
+      aggregatePath,
+      markdownPath,
+      detailsArchivePath,
+    )),
   };
 }
 
@@ -124,7 +49,7 @@ Environment:
 }
 
 async function main() {
-  const args = parseArgs(process.argv.slice(2));
+  const args = parseProfileArgs(process.argv.slice(2), usage);
   if (!process.env.BLOB_READ_WRITE_TOKEN) {
     throw new Error(
       "Set BLOB_READ_WRITE_TOKEN to publish test262 profile Blob data",

--- a/website/scripts/publish-test262-results.ts
+++ b/website/scripts/publish-test262-results.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env bun
 import { readFile } from "node:fs/promises";
-import { GITHUB_REPO_URL } from "../src/lib/github";
 import {
   publishTest262ReportsToBlob,
   type Test262BlobPublishEntry,
@@ -14,57 +13,20 @@ import {
   type Test262Report,
   type Test262TimelinePoint,
 } from "../src/lib/test262-dashboard";
+import { currentRunMetadata, timestampFromEnv } from "./lib/report-publishing";
 
 function log(message: string) {
   console.log(`[publish-test262] ${message}`);
 }
 
-function numberFromEnv(name: string): number | null {
-  const value = process.env[name];
-  if (!value) return null;
-  const parsed = Number(value);
-  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
-}
-
-function timestampFromEnv(name: string): string | null {
-  const value = process.env[name]?.trim();
-  if (!value) return null;
-  if (/^\d+$/.test(value)) {
-    const seconds = Number(value);
-    if (Number.isSafeInteger(seconds) && seconds > 0) {
-      return new Date(seconds * 1000).toISOString();
-    }
-  }
-  const time = Date.parse(value);
-  return Number.isNaN(time) ? null : new Date(time).toISOString();
-}
-
 function pointFromCurrentRun(report: Test262Report): Test262TimelinePoint {
-  const runId = numberFromEnv("GITHUB_RUN_ID");
-  const runNumber = numberFromEnv("GITHUB_RUN_NUMBER");
-  const artifactId =
-    numberFromEnv("TEST262_ARTIFACT_ID") ??
-    numberFromEnv("GITHUB_RUN_ID") ??
-    Date.now();
-  const repository = process.env.GITHUB_REPOSITORY ?? "frostney/GocciaScript";
-  const server = process.env.GITHUB_SERVER_URL ?? "https://github.com";
-  const headSha = process.env.GITHUB_SHA ?? "unknown";
-  const now = new Date().toISOString();
-  const createdAt = timestampFromEnv("TEST262_RUN_CREATED_AT") ?? now;
+  const metadata = currentRunMetadata(
+    "TEST262_ARTIFACT_ID",
+    timestampFromEnv("TEST262_RUN_CREATED_AT"),
+  );
   return {
-    runId: runId ?? artifactId,
-    runNumber: runNumber ?? 0,
-    title: process.env.GITHUB_WORKFLOW ?? "CI",
-    headSha,
-    shortSha: headSha.slice(0, 8),
-    runUrl: runId
-      ? `${server}/${repository}/actions/runs/${runId}`
-      : GITHUB_REPO_URL,
-    createdAt,
-    updatedAt: now,
-    artifactId,
-    artifactCreatedAt: now,
-    jsonUrl: jsonUrlForArtifact(artifactId),
+    ...metadata,
+    jsonUrl: jsonUrlForArtifact(metadata.artifactId),
     summary: report.summary,
   };
 }

--- a/website/scripts/publish-web-tooling-report.ts
+++ b/website/scripts/publish-web-tooling-report.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env bun
 import { readFile } from "node:fs/promises";
-import { GITHUB_REPO_URL } from "../src/lib/github";
 import {
   publishWebToolingReportsToBlob,
   type WebToolingBlobPublishEntry,
@@ -8,6 +7,7 @@ import {
   webToolingBlobPrefix,
   webToolingBlobReportPathForArtifactId,
 } from "../src/lib/web-tooling-blob-store";
+import { currentRunMetadata, timestampFromEnv } from "./lib/report-publishing";
 
 type WebToolingReport = {
   summary?: Partial<WebToolingBlobPublishEntry["summary"]>;
@@ -21,26 +21,6 @@ type WebToolingReport = {
 
 function log(message: string) {
   console.log(`[publish-web-tooling] ${message}`);
-}
-
-function numberFromEnv(name: string): number | null {
-  const value = process.env[name];
-  if (!value) return null;
-  const parsed = Number(value);
-  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
-}
-
-function timestampFromEnv(name: string): string | null {
-  const value = process.env[name]?.trim();
-  if (!value) return null;
-  if (/^\d+$/.test(value)) {
-    const seconds = Number(value);
-    if (Number.isSafeInteger(seconds) && seconds > 0) {
-      return new Date(seconds * 1000).toISOString();
-    }
-  }
-  const time = Date.parse(value);
-  return Number.isNaN(time) ? null : new Date(time).toISOString();
 }
 
 function safeCount(value: unknown): number {
@@ -79,31 +59,11 @@ async function readEntryFromFile(
     throw new Error(`${filePath} is not a valid Web Tooling report`);
   }
 
-  const runId = numberFromEnv("GITHUB_RUN_ID");
-  const runNumber = numberFromEnv("GITHUB_RUN_NUMBER");
-  const artifactId =
-    numberFromEnv("WEB_TOOLING_ARTIFACT_ID") ??
-    numberFromEnv("GITHUB_RUN_ID") ??
-    Date.now();
-  const repository = process.env.GITHUB_REPOSITORY ?? "frostney/GocciaScript";
-  const server = process.env.GITHUB_SERVER_URL ?? "https://github.com";
-  const headSha = process.env.GITHUB_SHA ?? "unknown";
-  const now = new Date().toISOString();
-  const createdAt = timestampFromEnv("WEB_TOOLING_RUN_CREATED_AT") ?? now;
-
   return {
-    runId: runId ?? artifactId,
-    runNumber: runNumber ?? 0,
-    artifactId,
-    title: process.env.GITHUB_WORKFLOW ?? "CI",
-    headSha,
-    shortSha: headSha.slice(0, 8),
-    runUrl: runId
-      ? `${server}/${repository}/actions/runs/${runId}`
-      : GITHUB_REPO_URL,
-    createdAt,
-    updatedAt: now,
-    artifactCreatedAt: now,
+    ...currentRunMetadata(
+      "WEB_TOOLING_ARTIFACT_ID",
+      timestampFromEnv("WEB_TOOLING_RUN_CREATED_AT"),
+    ),
     summary: summaryFromReport(parsed),
     reportJson: `${JSON.stringify(parsed, null, 2)}\n`,
   };

--- a/website/src/__tests__/report-publishing.test.ts
+++ b/website/src/__tests__/report-publishing.test.ts
@@ -2,6 +2,7 @@ import { afterAll, describe, expect, test } from "bun:test";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { timestampFromEnv } from "../../scripts/lib/report-publishing";
 
 const directory = mkdtempSync(join(tmpdir(), "report-publishing-"));
 const website = resolve(import.meta.dir, "../..");
@@ -71,6 +72,22 @@ function publish(
     .split("\n")
     .map((line) => JSON.parse(line));
 }
+
+test("Unix timestamps respect the inclusive Date range and return null beyond it", () => {
+  const name = "REPORT_PUBLISHING_TEST_TIMESTAMP";
+  const previous = process.env[name];
+  try {
+    process.env[name] = "8640000000000";
+    expect(timestampFromEnv(name)).toBe("+275760-09-13T00:00:00.000Z");
+    for (const value of ["8640000000001", String(Number.MAX_SAFE_INTEGER)]) {
+      process.env[name] = value;
+      expect(timestampFromEnv(name)).toBeNull();
+    }
+  } finally {
+    if (previous === undefined) delete process.env[name];
+    else process.env[name] = previous;
+  }
+});
 
 describe("report publisher commands", () => {
   test("preserves GitHub metadata, namespace overrides, and daily paths across publishers", () => {
@@ -142,7 +159,7 @@ describe("report publisher commands", () => {
       {
         TEST262_PROFILE_ARTIFACT_ID: "invalid",
         GITHUB_RUN_NUMBER: "1.5",
-        TEST262_PROFILE_RUN_CREATED_AT: "invalid",
+        TEST262_PROFILE_RUN_CREATED_AT: "8640000000001",
         TEST262_RUN_CREATED_AT: "1788483600",
         TEST262_PROFILE_BLOB_PREFIX: " /// ",
         TEST262_BLOB_ACCESS: "PRIVATE",

--- a/website/src/__tests__/report-publishing.test.ts
+++ b/website/src/__tests__/report-publishing.test.ts
@@ -1,0 +1,197 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const directory = mkdtempSync(join(tmpdir(), "report-publishing-"));
+const website = resolve(import.meta.dir, "../..");
+const report = join(directory, "report.json");
+const preload = join(directory, "blob-mock.ts");
+const uploads = join(directory, "uploads.jsonl");
+writeFileSync(
+  report,
+  JSON.stringify({ targets: [], results: [], summary: {} }),
+);
+writeFileSync(
+  preload,
+  `
+import { mock } from "bun:test";
+import { appendFileSync } from "node:fs";
+mock.module(${JSON.stringify(import.meta.resolve("@vercel/blob"))}, () => ({
+  BlobNotFoundError: class extends Error {},
+  get: async () => null,
+  list: async () => ({ blobs: [], hasMore: false }),
+  put: async (pathname, body, options) => {
+    appendFileSync(process.env.PUBLISH_TEST_OUTPUT, JSON.stringify({
+      pathname, options, body: typeof body === "string" ? JSON.parse(body) : null,
+    }) + "\\n");
+    return { url: "https://blob.test/" + pathname, downloadUrl: "https://blob.test/" + pathname };
+  },
+}));
+`,
+);
+afterAll(() => rmSync(directory, { recursive: true, force: true }));
+
+function publish(
+  script: string,
+  overrides: Record<string, string>,
+  args = [report],
+) {
+  const env = { ...process.env };
+  for (const key of Object.keys(env)) {
+    if (
+      /^(GITHUB_|AWFY_|JETSTREAM_|WEB_TOOLING_|BENCHMARK_PROFILE_|TEST262_)/.test(
+        key,
+      )
+    )
+      delete env[key];
+  }
+  writeFileSync(uploads, "");
+  const result = Bun.spawnSync(
+    [
+      process.execPath,
+      "--preload",
+      preload,
+      `scripts/publish-${script}.ts`,
+      ...args,
+    ],
+    {
+      cwd: website,
+      env: {
+        ...env,
+        BLOB_READ_WRITE_TOKEN: "test-only",
+        PUBLISH_TEST_OUTPUT: uploads,
+        ...overrides,
+      },
+    },
+  );
+  expect(result.exitCode, result.stderr.toString()).toBe(0);
+  return readFileSync(uploads, "utf8")
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line));
+}
+
+describe("report publisher commands", () => {
+  test("preserves GitHub metadata, namespace overrides, and daily paths across publishers", () => {
+    for (const [script, envPrefix, dailyPath] of [
+      ["awfy-report", "AWFY", "custom/daily/2026-09-04.json"],
+      ["jetstream-report", "JETSTREAM", "custom/daily/2026-09-04/101.json"],
+      ["web-tooling-report", "WEB_TOOLING", "custom/daily/2026-09-04.json"],
+      ["test262-results", "TEST262", "custom/daily/2026-09-04.json"],
+      [
+        "benchmark-profile-reports",
+        "BENCHMARK_PROFILE",
+        "custom/daily/2026-09-04.json",
+      ],
+      [
+        "test262-profile-reports",
+        "TEST262_PROFILE",
+        "custom/daily/2026-09-04.json",
+      ],
+    ]) {
+      const profile = script.includes("profile");
+      const calls = publish(
+        script,
+        {
+          GITHUB_RUN_ID: "101",
+          GITHUB_RUN_NUMBER: "7",
+          GITHUB_SHA: "abcdef123456",
+          GITHUB_WORKFLOW: "Publish",
+          GITHUB_SERVER_URL: "https://forge.test",
+          GITHUB_REPOSITORY: "owner/repo",
+          [`${envPrefix}_ARTIFACT_ID`]: "202",
+          [`${envPrefix}_RUN_CREATED_AT`]: "2026-09-04T01:00:00Z",
+          [`${envPrefix}_BLOB_PREFIX`]: " /custom/ ",
+          [`${envPrefix === "TEST262_PROFILE" ? "TEST262" : envPrefix}_BLOB_ACCESS`]:
+            "private",
+        },
+        profile ? ["--aggregate", report] : [report],
+      );
+      expect(calls.map((call) => call.pathname)).toEqual([
+        profile
+          ? "custom/runs/202/aggregate.json.gz"
+          : script === "test262-results"
+            ? "custom/runs/202.json.gz"
+            : "custom/runs/202/report.json.gz",
+        dailyPath,
+      ]);
+      expect(calls.every((call) => call.options.access === "private")).toBe(
+        true,
+      );
+      expect(calls[1].body).toMatchObject({
+        runId: 101,
+        runNumber: 7,
+        artifactId: 202,
+        title: "Publish",
+        headSha: "abcdef123456",
+        shortSha: "abcdef12",
+        runUrl: "https://forge.test/owner/repo/actions/runs/101",
+        createdAt: "2026-09-04T01:00:00.000Z",
+      });
+      if (profile)
+        expect(Object.keys(calls[1].body.profileReports)).toEqual([
+          "aggregate",
+        ]);
+    }
+  });
+
+  test("preserves local defaults and test262 profile timestamp fallback", () => {
+    const calls = publish(
+      "test262-profile-reports",
+      {
+        TEST262_PROFILE_ARTIFACT_ID: "invalid",
+        GITHUB_RUN_NUMBER: "1.5",
+        TEST262_PROFILE_RUN_CREATED_AT: "invalid",
+        TEST262_RUN_CREATED_AT: "1788483600",
+        TEST262_PROFILE_BLOB_PREFIX: " /// ",
+        TEST262_BLOB_ACCESS: "PRIVATE",
+      },
+      [`--aggregate=${report}`],
+    );
+    const pointer = calls[1].body;
+    expect(pointer.runId).toBe(pointer.artifactId);
+    expect(Number.isSafeInteger(pointer.artifactId)).toBe(true);
+    expect(pointer).toMatchObject({
+      runNumber: 0,
+      title: "CI",
+      headSha: "unknown",
+      runUrl: "https://github.com/frostney/GocciaScript",
+      createdAt: "2026-09-04T01:00:00.000Z",
+    });
+    expect(calls[1].pathname).toBe("test262-profiles/daily/2026-09-04.json");
+    expect(calls[0].options.access).toBe("public");
+  });
+
+  test("keeps JetStream's date-only timestamp parser and artifact fallback", () => {
+    const calls = publish("jetstream-report", {
+      GITHUB_RUN_ID: "101",
+      JETSTREAM_ARTIFACT_ID: "0",
+      JETSTREAM_RUN_CREATED_AT: "1788483600",
+    });
+    expect(calls[1].body.artifactId).toBe(101);
+    expect(calls[1].body.createdAt).toBe(calls[1].body.updatedAt);
+  });
+
+  test("reads optional profile attachments with both CLI argument forms", () => {
+    const markdown = join(directory, "summary.md");
+    const archive = join(directory, "details.tar.gz");
+    writeFileSync(markdown, "# profile\n");
+    writeFileSync(archive, Buffer.from([0, 255, 1]));
+    for (const script of [
+      "benchmark-profile-reports",
+      "test262-profile-reports",
+    ]) {
+      const calls = publish(script, {}, [
+        `--aggregate=${report}`,
+        "--markdown",
+        markdown,
+        `--details-archive=${archive}`,
+      ]);
+      expect(calls).toHaveLength(4);
+      expect(calls[3].body.profileReports.markdown.size).toBe(10);
+      expect(calls[3].body.profileReports.detailsArchive.size).toBe(3);
+      expect(calls[1].options.contentType).toBe("text/markdown; charset=utf-8");
+    }
+  });
+});

--- a/website/src/__tests__/test262-blob-store.test.ts
+++ b/website/src/__tests__/test262-blob-store.test.ts
@@ -25,6 +25,7 @@ type BlobListCall = {
 const getCalls: BlobGetCall[] = [];
 const putCalls: BlobPutCall[] = [];
 const listCalls: BlobListCall[] = [];
+let failedPutPath: string | null = null;
 
 class BlobNotFoundError extends Error {
   constructor() {
@@ -39,9 +40,14 @@ function textStream(text: string): ReadableStream<Uint8Array> {
 }
 
 function byteStream(bytes: Uint8Array): ReadableStream<Uint8Array> {
-  const stream = new Response(Buffer.from(bytes)).body;
-  if (!stream) throw new Error("expected response body stream");
-  return stream;
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(bytes.slice(0, 1));
+      controller.enqueue(bytes.slice(1, 7));
+      controller.enqueue(bytes.slice(7));
+      controller.close();
+    },
+  });
 }
 
 function summary(totalRun: number): Test262SuiteSummary {
@@ -86,6 +92,14 @@ mock.module("@vercel/blob", () => ({
   BlobNotFoundError,
   get: async (pathname: string, options: Record<string, unknown>) => {
     getCalls.push({ pathname, options });
+    if (pathname === "test262/runs/404.json.gz") throw new BlobNotFoundError();
+    if (pathname === "test262/runs/500.json.gz")
+      throw new Error("access denied");
+    if (pathname === "test262/runs/304.json.gz") return { statusCode: 304 };
+    if (pathname === "test262/runs/300.json.gz")
+      return { statusCode: 200, stream: null };
+    if (pathname === "test262/runs/400.json.gz")
+      return { statusCode: 200, stream: textStream("corrupt") };
     if (pathname === "test262/daily/2026-06-10.json") {
       return {
         statusCode: 200,
@@ -157,6 +171,7 @@ mock.module("@vercel/blob", () => ({
     options: Record<string, unknown>,
   ) => {
     putCalls.push({ pathname, body, options });
+    if (pathname === failedPutPath) throw new Error("upload failed");
     return {
       url: `https://blob.test/${pathname}`,
       downloadUrl: `https://blob.test/${pathname}?download=1`,
@@ -169,6 +184,7 @@ mock.module("@vercel/blob", () => ({
 }));
 
 function resetState() {
+  failedPutPath = null;
   getCalls.length = 0;
   putCalls.length = 0;
   listCalls.length = 0;
@@ -407,5 +423,28 @@ describe("test262 Blob store", () => {
         options: { access: "public" },
       },
     ]);
+  });
+
+  test("treats missing reports as absent and propagates transport and gzip failures", async () => {
+    resetState();
+    const { readTest262BlobReportJsonByArtifactId: read } =
+      await importBlobStore();
+    for (const id of [404, 304, 300, 999]) expect(await read(id)).toBeNull();
+    await expect(read(500)).rejects.toThrow("access denied");
+    await expect(read(400)).rejects.toThrow();
+    getCalls.length = 0;
+    for (const id of [0, -1, 1.5, Number.NaN])
+      expect(await read(id)).toBeNull();
+    expect(getCalls).toHaveLength(0);
+  });
+
+  test("does not publish a daily pointer when its report upload fails", async () => {
+    resetState();
+    const { publishTest262ReportsToBlob } = await importBlobStore();
+    failedPutPath = "test262/runs/1002.json.gz";
+    await expect(publishTest262ReportsToBlob([publishEntry()])).rejects.toThrow(
+      "upload failed",
+    );
+    expect(putCalls.map((call) => call.pathname)).toEqual([failedPutPath]);
   });
 });

--- a/website/src/lib/awfy-blob-store.ts
+++ b/website/src/lib/awfy-blob-store.ts
@@ -1,14 +1,19 @@
-import { gunzipSync, gzipSync } from "node:zlib";
-import { BlobNotFoundError, get, list, put } from "@vercel/blob";
+import { list } from "@vercel/blob";
+import {
+  type BlobAccess,
+  type BlobReport,
+  blobAccess,
+  byCreatedAtThenRunNumber,
+  cleanBlobPrefix,
+  putCompressedReportBlob,
+  putDailyBlobPointer,
+  readBlobText,
+  readCompressedBlobText,
+} from "./report-blob";
 
-export type AwfyBlobAccess = "public" | "private";
+export type AwfyBlobAccess = BlobAccess;
 
-export type AwfyBlobReport = {
-  path: string;
-  url: string;
-  downloadUrl: string;
-  size: number;
-};
+export type AwfyBlobReport = BlobReport;
 
 export type AwfyBlobRunSummary = {
   targetCount: number;
@@ -51,21 +56,13 @@ export type AwfyBlobPublishEntry = Omit<
 };
 
 const DEFAULT_PREFIX = "awfy";
-const DEFAULT_ACCESS: AwfyBlobAccess = "public";
-
-function cleanPrefix(value: string | undefined, fallback: string): string {
-  const trimmed = (value ?? fallback).trim().replace(/^\/+|\/+$/g, "");
-  return trimmed || fallback;
-}
 
 export function awfyBlobPrefix(): string {
-  return cleanPrefix(process.env.AWFY_BLOB_PREFIX, DEFAULT_PREFIX);
+  return cleanBlobPrefix(process.env.AWFY_BLOB_PREFIX, DEFAULT_PREFIX);
 }
 
 export function awfyBlobAccess(): AwfyBlobAccess {
-  return process.env.AWFY_BLOB_ACCESS === "private"
-    ? "private"
-    : DEFAULT_ACCESS;
+  return blobAccess(process.env.AWFY_BLOB_ACCESS);
 }
 
 export function awfyBlobRunsPrefix(prefix = awfyBlobPrefix()): string {
@@ -97,51 +94,6 @@ function dailyPathForRun(
   return awfyBlobDailyPathForDay(run.createdAt.slice(0, 10), prefix);
 }
 
-function byCreatedAtThenRunNumber(
-  a: Pick<AwfyBlobRun, "createdAt" | "runNumber">,
-  b: Pick<AwfyBlobRun, "createdAt" | "runNumber">,
-): number {
-  return (
-    Date.parse(a.createdAt) - Date.parse(b.createdAt) ||
-    a.runNumber - b.runNumber
-  );
-}
-
-async function streamToBytes(stream: ReadableStream<Uint8Array>) {
-  const reader = stream.getReader();
-  const chunks: Uint8Array[] = [];
-  let total = 0;
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    chunks.push(value);
-    total += value.byteLength;
-  }
-  const bytes = new Uint8Array(total);
-  let offset = 0;
-  for (const chunk of chunks) {
-    bytes.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  return bytes;
-}
-
-async function readBlobBytes(pathname: string): Promise<Uint8Array | null> {
-  try {
-    const result = await get(pathname, { access: awfyBlobAccess() });
-    if (!result || result.statusCode !== 200 || !result.stream) return null;
-    return await streamToBytes(result.stream);
-  } catch (error) {
-    if (error instanceof BlobNotFoundError) return null;
-    throw error;
-  }
-}
-
-async function readBlobText(pathname: string): Promise<string | null> {
-  const bytes = await readBlobBytes(pathname);
-  return bytes ? new TextDecoder().decode(bytes) : null;
-}
-
 function isAwfyBlobRun(value: unknown): value is AwfyBlobRun {
   if (!value || typeof value !== "object") return false;
   const run = value as Record<string, unknown>;
@@ -159,8 +111,7 @@ function isAwfyBlobRun(value: unknown): value is AwfyBlobRun {
 export async function readAwfyBlobReportJson(
   run: Pick<AwfyBlobRun, "report">,
 ): Promise<string | null> {
-  const bytes = await readBlobBytes(run.report.path);
-  return bytes ? gunzipSync(bytes).toString("utf8") : null;
+  return readCompressedBlobText(run.report.path, awfyBlobAccess());
 }
 
 export async function listAwfyBlobDailyRuns(
@@ -176,7 +127,7 @@ export async function listAwfyBlobDailyRuns(
     });
     cursor = page.cursor;
     for (const blob of page.blobs) {
-      const text = await readBlobText(blob.pathname);
+      const text = await readBlobText(blob.pathname, awfyBlobAccess());
       if (!text) continue;
       try {
         const parsed: unknown = JSON.parse(text);
@@ -202,13 +153,11 @@ export async function publishAwfyReportsToBlob(
       entry.artifactId,
       prefix,
     );
-    const compressed = gzipSync(`${entry.reportJson.trimEnd()}\n`);
-    const reportBlob = await put(reportPath, compressed, {
+    const reportBlob = await putCompressedReportBlob(
+      reportPath,
+      entry.reportJson,
       access,
-      allowOverwrite: true,
-      cacheControlMaxAge: 31_536_000,
-      contentType: "application/gzip",
-    });
+    );
 
     const published: AwfyBlobRun = {
       runId: entry.runId,
@@ -222,23 +171,13 @@ export async function publishAwfyReportsToBlob(
       updatedAt: entry.updatedAt,
       artifactCreatedAt: entry.artifactCreatedAt,
       summary: entry.summary,
-      report: {
-        path: reportPath,
-        url: reportBlob.url,
-        downloadUrl: reportBlob.downloadUrl,
-        size: compressed.byteLength,
-      },
+      report: reportBlob,
       publishedAt: new Date().toISOString(),
     };
-    await put(
+    await putDailyBlobPointer(
       dailyPathForRun(published, prefix),
-      JSON.stringify(published, null, 2),
-      {
-        access,
-        allowOverwrite: true,
-        cacheControlMaxAge: 900,
-        contentType: "application/json",
-      },
+      published,
+      access,
     );
     publishedRuns.push(published);
   }

--- a/website/src/lib/benchmark-profile-blob-store.ts
+++ b/website/src/lib/benchmark-profile-blob-store.ts
@@ -1,18 +1,18 @@
-import { gzipSync } from "node:zlib";
-import { put } from "@vercel/blob";
+import {
+  type BlobAccess,
+  type BlobReport,
+  blobAccess,
+  byCreatedAtThenRunNumber,
+  cleanBlobPrefix,
+  type ProfileReportKind,
+  publishProfileArtifacts,
+  putDailyBlobPointer,
+} from "./report-blob";
 
-export type BenchmarkProfileBlobAccess = "public" | "private";
-export type BenchmarkProfileBlobReportKind =
-  | "aggregate"
-  | "markdown"
-  | "detailsArchive";
+export type BenchmarkProfileBlobAccess = BlobAccess;
+export type BenchmarkProfileBlobReportKind = ProfileReportKind;
 
-export type BenchmarkProfileBlobReport = {
-  path: string;
-  url: string;
-  downloadUrl: string;
-  size: number;
-};
+export type BenchmarkProfileBlobReport = BlobReport;
 
 export type BenchmarkProfileBlobRun = {
   runId: number;
@@ -43,21 +43,16 @@ export type BenchmarkProfileBlobPublishEntry = Omit<
 };
 
 const DEFAULT_PREFIX = "benchmark-profiles";
-const DEFAULT_ACCESS: BenchmarkProfileBlobAccess = "public";
-
-function cleanPrefix(value: string | undefined, fallback: string): string {
-  const trimmed = (value ?? fallback).trim().replace(/^\/+|\/+$/g, "");
-  return trimmed || fallback;
-}
 
 export function benchmarkProfileBlobPrefix(): string {
-  return cleanPrefix(process.env.BENCHMARK_PROFILE_BLOB_PREFIX, DEFAULT_PREFIX);
+  return cleanBlobPrefix(
+    process.env.BENCHMARK_PROFILE_BLOB_PREFIX,
+    DEFAULT_PREFIX,
+  );
 }
 
 export function benchmarkProfileBlobAccess(): BenchmarkProfileBlobAccess {
-  return process.env.BENCHMARK_PROFILE_BLOB_ACCESS === "private"
-    ? "private"
-    : DEFAULT_ACCESS;
+  return blobAccess(process.env.BENCHMARK_PROFILE_BLOB_ACCESS);
 }
 
 export function benchmarkProfileBlobRunsPrefix(
@@ -100,16 +95,6 @@ function dailyPathForRun(
   );
 }
 
-function byCreatedAtThenRunNumber(
-  a: Pick<BenchmarkProfileBlobRun, "createdAt" | "runNumber">,
-  b: Pick<BenchmarkProfileBlobRun, "createdAt" | "runNumber">,
-): number {
-  return (
-    Date.parse(a.createdAt) - Date.parse(b.createdAt) ||
-    a.runNumber - b.runNumber
-  );
-}
-
 export async function publishBenchmarkProfileReportsToBlob(
   entries: BenchmarkProfileBlobPublishEntry[],
 ): Promise<BenchmarkProfileBlobRun[]> {
@@ -118,66 +103,16 @@ export async function publishBenchmarkProfileReportsToBlob(
   const publishedRuns: BenchmarkProfileBlobRun[] = [];
 
   for (const entry of entries) {
-    const aggregatePath = benchmarkProfileBlobReportPathForArtifactId(
-      entry.artifactId,
-      "aggregate",
-      prefix,
-    );
-    const aggregateCompressed = gzipSync(`${entry.aggregateJson.trimEnd()}\n`);
-    const aggregateBlob = await put(aggregatePath, aggregateCompressed, {
+    const profileReports = await publishProfileArtifacts(
+      entry,
+      (kind) =>
+        benchmarkProfileBlobReportPathForArtifactId(
+          entry.artifactId,
+          kind,
+          prefix,
+        ),
       access,
-      allowOverwrite: true,
-      cacheControlMaxAge: 31_536_000,
-      contentType: "application/gzip",
-    });
-    const profileReports: BenchmarkProfileBlobRun["profileReports"] = {
-      aggregate: {
-        path: aggregatePath,
-        url: aggregateBlob.url,
-        downloadUrl: aggregateBlob.downloadUrl,
-        size: aggregateCompressed.byteLength,
-      },
-    };
-
-    if (entry.markdown) {
-      const markdownPath = benchmarkProfileBlobReportPathForArtifactId(
-        entry.artifactId,
-        "markdown",
-        prefix,
-      );
-      const markdownBlob = await put(markdownPath, entry.markdown, {
-        access,
-        allowOverwrite: true,
-        cacheControlMaxAge: 31_536_000,
-        contentType: "text/markdown; charset=utf-8",
-      });
-      profileReports.markdown = {
-        path: markdownPath,
-        url: markdownBlob.url,
-        downloadUrl: markdownBlob.downloadUrl,
-        size: entry.markdown.byteLength,
-      };
-    }
-
-    if (entry.detailsArchive) {
-      const archivePath = benchmarkProfileBlobReportPathForArtifactId(
-        entry.artifactId,
-        "detailsArchive",
-        prefix,
-      );
-      const archiveBlob = await put(archivePath, entry.detailsArchive, {
-        access,
-        allowOverwrite: true,
-        cacheControlMaxAge: 31_536_000,
-        contentType: "application/gzip",
-      });
-      profileReports.detailsArchive = {
-        path: archivePath,
-        url: archiveBlob.url,
-        downloadUrl: archiveBlob.downloadUrl,
-        size: entry.detailsArchive.byteLength,
-      };
-    }
+    );
 
     const published: BenchmarkProfileBlobRun = {
       runId: entry.runId,
@@ -193,15 +128,10 @@ export async function publishBenchmarkProfileReportsToBlob(
       profileReports,
       publishedAt: new Date().toISOString(),
     };
-    await put(
+    await putDailyBlobPointer(
       dailyPathForRun(published, prefix),
-      JSON.stringify(published, null, 2),
-      {
-        access,
-        allowOverwrite: true,
-        cacheControlMaxAge: 900,
-        contentType: "application/json",
-      },
+      published,
+      access,
     );
     publishedRuns.push(published);
   }

--- a/website/src/lib/jetstream-blob-store.ts
+++ b/website/src/lib/jetstream-blob-store.ts
@@ -1,7 +1,17 @@
-import { gunzipSync, gzipSync } from "node:zlib";
-import { BlobNotFoundError, get, list, put } from "@vercel/blob";
+import { list } from "@vercel/blob";
+import {
+  type BlobAccess,
+  type BlobReport,
+  blobAccess,
+  byCreatedAtThenRunNumber,
+  cleanBlobPrefix,
+  putCompressedReportBlob,
+  putDailyBlobPointer,
+  readBlobBytes,
+  readCompressedBlobText,
+} from "./report-blob";
 
-export type JetStreamBlobAccess = "public" | "private";
+export type JetStreamBlobAccess = BlobAccess;
 
 export type JetStreamReferenceRatios = {
   quickjs: number | null;
@@ -19,12 +29,7 @@ export type JetStreamBlobRunSummary = {
   targetNames: string[];
 };
 
-export type JetStreamBlobReport = {
-  path: string;
-  url: string;
-  downloadUrl: string;
-  size: number;
-};
+export type JetStreamBlobReport = BlobReport;
 
 export type JetStreamBlobRun = {
   runId: number;
@@ -48,21 +53,13 @@ export type JetStreamBlobPublishEntry = Omit<
 > & { reportJson: string };
 
 const DEFAULT_PREFIX = "jetstream";
-const DEFAULT_ACCESS: JetStreamBlobAccess = "public";
-
-function cleanPrefix(value: string | undefined, fallback: string): string {
-  const trimmed = (value ?? fallback).trim().replace(/^\/+|\/+$/g, "");
-  return trimmed || fallback;
-}
 
 export function jetStreamBlobPrefix(): string {
-  return cleanPrefix(process.env.JETSTREAM_BLOB_PREFIX, DEFAULT_PREFIX);
+  return cleanBlobPrefix(process.env.JETSTREAM_BLOB_PREFIX, DEFAULT_PREFIX);
 }
 
 export function jetStreamBlobAccess(): JetStreamBlobAccess {
-  return process.env.JETSTREAM_BLOB_ACCESS === "private"
-    ? "private"
-    : DEFAULT_ACCESS;
+  return blobAccess(process.env.JETSTREAM_BLOB_ACCESS);
 }
 
 export function jetStreamBlobRunsPrefix(
@@ -92,46 +89,6 @@ export function jetStreamBlobDailyPathForRun(
   return `${jetStreamBlobDailyPrefix(prefix)}/${day}/${runId}.json`;
 }
 
-function byCreatedAtThenRunNumber(
-  left: Pick<JetStreamBlobRun, "createdAt" | "runNumber">,
-  right: Pick<JetStreamBlobRun, "createdAt" | "runNumber">,
-): number {
-  return (
-    Date.parse(left.createdAt) - Date.parse(right.createdAt) ||
-    left.runNumber - right.runNumber
-  );
-}
-
-async function streamToBytes(stream: ReadableStream<Uint8Array>) {
-  const reader = stream.getReader();
-  const chunks: Uint8Array[] = [];
-  let total = 0;
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    chunks.push(value);
-    total += value.byteLength;
-  }
-  const bytes = new Uint8Array(total);
-  let offset = 0;
-  for (const chunk of chunks) {
-    bytes.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  return bytes;
-}
-
-async function readBlobBytes(pathname: string): Promise<Uint8Array | null> {
-  try {
-    const result = await get(pathname, { access: jetStreamBlobAccess() });
-    if (!result || result.statusCode !== 200 || !result.stream) return null;
-    return await streamToBytes(result.stream);
-  } catch (error) {
-    if (error instanceof BlobNotFoundError) return null;
-    throw error;
-  }
-}
-
 function isJetStreamBlobRun(value: unknown): value is JetStreamBlobRun {
   if (!value || typeof value !== "object") return false;
   const run = value as Record<string, unknown>;
@@ -151,8 +108,7 @@ function isJetStreamBlobRun(value: unknown): value is JetStreamBlobRun {
 export async function readJetStreamBlobReportJson(
   run: Pick<JetStreamBlobRun, "report">,
 ): Promise<string | null> {
-  const bytes = await readBlobBytes(run.report.path);
-  return bytes ? gunzipSync(bytes).toString("utf8") : null;
+  return readCompressedBlobText(run.report.path, jetStreamBlobAccess());
 }
 
 export async function listJetStreamBlobDailyRuns(
@@ -168,7 +124,7 @@ export async function listJetStreamBlobDailyRuns(
     });
     cursor = page.cursor;
     for (const blob of page.blobs) {
-      const bytes = await readBlobBytes(blob.pathname);
+      const bytes = await readBlobBytes(blob.pathname, jetStreamBlobAccess());
       if (!bytes) continue;
       try {
         const parsed: unknown = JSON.parse(new TextDecoder().decode(bytes));
@@ -193,36 +149,24 @@ export async function publishJetStreamReportsToBlob(
       entry.artifactId,
       prefix,
     );
-    const compressed = gzipSync(`${entry.reportJson.trimEnd()}\n`);
-    const reportBlob = await put(reportPath, compressed, {
+    const reportBlob = await putCompressedReportBlob(
+      reportPath,
+      entry.reportJson,
       access,
-      allowOverwrite: true,
-      cacheControlMaxAge: 31_536_000,
-      contentType: "application/gzip",
-    });
+    );
     const published: JetStreamBlobRun = {
       ...entry,
-      report: {
-        path: reportPath,
-        url: reportBlob.url,
-        downloadUrl: reportBlob.downloadUrl,
-        size: compressed.byteLength,
-      },
+      report: reportBlob,
       publishedAt: new Date().toISOString(),
     };
-    await put(
+    await putDailyBlobPointer(
       jetStreamBlobDailyPathForRun(
         entry.createdAt.slice(0, 10),
         entry.runId,
         prefix,
       ),
-      JSON.stringify(published, null, 2),
-      {
-        access,
-        allowOverwrite: true,
-        cacheControlMaxAge: 900,
-        contentType: "application/json",
-      },
+      published,
+      access,
     );
     publishedRuns.push(published);
   }

--- a/website/src/lib/report-blob.ts
+++ b/website/src/lib/report-blob.ts
@@ -1,0 +1,170 @@
+import { gunzipSync, gzipSync } from "node:zlib";
+import { BlobNotFoundError, get, put } from "@vercel/blob";
+
+export type BlobAccess = "public" | "private";
+
+export type BlobReport = {
+  path: string;
+  url: string;
+  downloadUrl: string;
+  size: number;
+};
+
+export type ProfileReportKind = "aggregate" | "markdown" | "detailsArchive";
+
+export function cleanBlobPrefix(
+  value: string | undefined,
+  fallback: string,
+): string {
+  return (value ?? fallback).trim().replace(/^\/+|\/+$/g, "") || fallback;
+}
+
+export function blobAccess(value: string | undefined): BlobAccess {
+  return value === "private" ? "private" : "public";
+}
+
+export function byCreatedAtThenRunNumber(
+  a: { createdAt: string; runNumber: number },
+  b: { createdAt: string; runNumber: number },
+): number {
+  return (
+    Date.parse(a.createdAt) - Date.parse(b.createdAt) ||
+    a.runNumber - b.runNumber
+  );
+}
+
+async function streamToBytes(
+  stream: ReadableStream<Uint8Array>,
+): Promise<Uint8Array> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+    total += value.byteLength;
+  }
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes;
+}
+
+export async function readBlobBytes(
+  pathname: string,
+  access: BlobAccess,
+): Promise<Uint8Array | null> {
+  try {
+    const result = await get(pathname, { access });
+    if (!result || result.statusCode !== 200 || !result.stream) return null;
+    return await streamToBytes(result.stream);
+  } catch (error) {
+    if (error instanceof BlobNotFoundError) return null;
+    throw error;
+  }
+}
+
+export async function readBlobText(
+  pathname: string,
+  access: BlobAccess,
+): Promise<string | null> {
+  const bytes = await readBlobBytes(pathname, access);
+  return bytes ? new TextDecoder().decode(bytes) : null;
+}
+
+export async function readCompressedBlobText(
+  pathname: string,
+  access: BlobAccess,
+): Promise<string | null> {
+  const bytes = await readBlobBytes(pathname, access);
+  return bytes ? gunzipSync(bytes).toString("utf8") : null;
+}
+
+async function putReportBlob(
+  path: string,
+  bytes: Buffer,
+  contentType: string,
+  access: BlobAccess,
+): Promise<BlobReport> {
+  const blob = await put(path, bytes, {
+    access,
+    allowOverwrite: true,
+    cacheControlMaxAge: 31_536_000,
+    contentType,
+  });
+  return {
+    path,
+    url: blob.url,
+    downloadUrl: blob.downloadUrl,
+    size: bytes.byteLength,
+  };
+}
+
+export function putCompressedReportBlob(
+  path: string,
+  json: string,
+  access: BlobAccess,
+): Promise<BlobReport> {
+  return putReportBlob(
+    path,
+    gzipSync(`${json.trimEnd()}\n`),
+    "application/gzip",
+    access,
+  );
+}
+
+export async function putDailyBlobPointer(
+  path: string,
+  value: unknown,
+  access: BlobAccess,
+): Promise<void> {
+  await put(path, JSON.stringify(value, null, 2), {
+    access,
+    allowOverwrite: true,
+    cacheControlMaxAge: 900,
+    contentType: "application/json",
+  });
+}
+
+export async function publishProfileArtifacts(
+  entry: { aggregateJson: string; markdown?: Buffer; detailsArchive?: Buffer },
+  pathForKind: (kind: ProfileReportKind) => string,
+  access: BlobAccess,
+): Promise<{
+  aggregate: BlobReport;
+  markdown?: BlobReport;
+  detailsArchive?: BlobReport;
+}> {
+  const profileReports: {
+    aggregate: BlobReport;
+    markdown?: BlobReport;
+    detailsArchive?: BlobReport;
+  } = {
+    aggregate: await putCompressedReportBlob(
+      pathForKind("aggregate"),
+      entry.aggregateJson,
+      access,
+    ),
+  };
+  if (entry.markdown) {
+    profileReports.markdown = await putReportBlob(
+      pathForKind("markdown"),
+      entry.markdown,
+      "text/markdown; charset=utf-8",
+      access,
+    );
+  }
+  if (entry.detailsArchive) {
+    profileReports.detailsArchive = await putReportBlob(
+      pathForKind("detailsArchive"),
+      entry.detailsArchive,
+      "application/gzip",
+      access,
+    );
+  }
+  return profileReports;
+}

--- a/website/src/lib/test262-blob-store.ts
+++ b/website/src/lib/test262-blob-store.ts
@@ -1,15 +1,24 @@
-import { gunzipSync, gzipSync } from "node:zlib";
-import { BlobNotFoundError, get, list, put } from "@vercel/blob";
+import { list } from "@vercel/blob";
 import type {
   Test262Report,
   Test262TimelinePoint,
 } from "@/lib/test262-dashboard";
+import {
+  type BlobAccess,
+  type BlobReport,
+  blobAccess,
+  byCreatedAtThenRunNumber,
+  cleanBlobPrefix,
+  type ProfileReportKind,
+  publishProfileArtifacts,
+  putCompressedReportBlob,
+  putDailyBlobPointer,
+  readBlobText,
+  readCompressedBlobText,
+} from "./report-blob";
 
-export type Test262BlobAccess = "public" | "private";
-export type Test262ProfileBlobReportKind =
-  | "aggregate"
-  | "markdown"
-  | "detailsArchive";
+export type Test262BlobAccess = BlobAccess;
+export type Test262ProfileBlobReportKind = ProfileReportKind;
 
 export type Test262BlobRun = Test262TimelinePoint & {
   reportPath: string;
@@ -25,12 +34,7 @@ export type Test262BlobPublishEntry = {
   reportJson: string;
 };
 
-export type Test262ProfileBlobReport = {
-  path: string;
-  url: string;
-  downloadUrl: string;
-  size: number;
-};
+export type Test262ProfileBlobReport = BlobReport;
 
 export type Test262ProfileBlobRun = {
   runId: number;
@@ -62,28 +66,20 @@ export type Test262ProfileBlobPublishEntry = Omit<
 
 const DEFAULT_PREFIX = "test262";
 const DEFAULT_PROFILE_PREFIX = "test262-profiles";
-const DEFAULT_ACCESS: Test262BlobAccess = "public";
-
-function cleanPrefix(value: string | undefined, fallback: string): string {
-  const trimmed = (value ?? fallback).trim().replace(/^\/+|\/+$/g, "");
-  return trimmed || fallback;
-}
 
 export function test262BlobPrefix(): string {
-  return cleanPrefix(process.env.TEST262_BLOB_PREFIX, DEFAULT_PREFIX);
+  return cleanBlobPrefix(process.env.TEST262_BLOB_PREFIX, DEFAULT_PREFIX);
 }
 
 export function test262ProfileBlobPrefix(): string {
-  return cleanPrefix(
+  return cleanBlobPrefix(
     process.env.TEST262_PROFILE_BLOB_PREFIX,
     DEFAULT_PROFILE_PREFIX,
   );
 }
 
 export function test262BlobAccess(): Test262BlobAccess {
-  return process.env.TEST262_BLOB_ACCESS === "private"
-    ? "private"
-    : DEFAULT_ACCESS;
+  return blobAccess(process.env.TEST262_BLOB_ACCESS);
 }
 
 export function test262BlobRunsPrefix(prefix = test262BlobPrefix()): string {
@@ -152,53 +148,6 @@ function profileDailyPathForRun(
   return test262ProfileBlobDailyPathForDay(run.createdAt.slice(0, 10), prefix);
 }
 
-async function streamToBytes(stream: ReadableStream<Uint8Array>) {
-  const reader = stream.getReader();
-  const chunks: Uint8Array[] = [];
-  let total = 0;
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    chunks.push(value);
-    total += value.byteLength;
-  }
-  const out = new Uint8Array(total);
-  let offset = 0;
-  for (const chunk of chunks) {
-    out.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  return out;
-}
-
-async function readBlobText(
-  pathname: string,
-  access = test262BlobAccess(),
-): Promise<string | null> {
-  try {
-    const result = await get(pathname, { access });
-    if (!result || result.statusCode !== 200 || !result.stream) return null;
-    return new TextDecoder().decode(await streamToBytes(result.stream));
-  } catch (err) {
-    if (err instanceof BlobNotFoundError) return null;
-    throw err;
-  }
-}
-
-async function readBlobBytes(
-  pathname: string,
-  access = test262BlobAccess(),
-): Promise<Uint8Array | null> {
-  try {
-    const result = await get(pathname, { access });
-    if (!result || result.statusCode !== 200 || !result.stream) return null;
-    return await streamToBytes(result.stream);
-  } catch (err) {
-    if (err instanceof BlobNotFoundError) return null;
-    throw err;
-  }
-}
-
 function isBlobRun(value: unknown): value is Test262BlobRun {
   if (!value || typeof value !== "object") return false;
   const run = value as Record<string, unknown>;
@@ -221,31 +170,20 @@ function isBlobRun(value: unknown): value is Test262BlobRun {
   );
 }
 
-function byCreatedAtThenRunNumber(
-  a: Pick<Test262TimelinePoint, "createdAt" | "runNumber">,
-  b: Pick<Test262TimelinePoint, "createdAt" | "runNumber">,
-): number {
-  return (
-    Date.parse(a.createdAt) - Date.parse(b.createdAt) ||
-    a.runNumber - b.runNumber
-  );
-}
-
 export async function readTest262BlobReportJson(
   run: Pick<Test262BlobRun, "reportPath">,
 ): Promise<string | null> {
-  const bytes = await readBlobBytes(run.reportPath);
-  return bytes ? gunzipSync(bytes).toString("utf8") : null;
+  return readCompressedBlobText(run.reportPath, test262BlobAccess());
 }
 
 export async function readTest262BlobReportJsonByArtifactId(
   artifactId: number,
 ): Promise<string | null> {
   if (!Number.isSafeInteger(artifactId) || artifactId <= 0) return null;
-  const bytes = await readBlobBytes(
+  return readCompressedBlobText(
     test262BlobReportPathForArtifactId(artifactId),
+    test262BlobAccess(),
   );
-  return bytes ? gunzipSync(bytes).toString("utf8") : null;
 }
 
 export async function listTest262BlobDailyRuns(
@@ -290,31 +228,24 @@ export async function publishTest262ReportsToBlob(
       entry.point.artifactId,
       prefix,
     );
-    const compressed = gzipSync(`${entry.reportJson.trimEnd()}\n`);
-    const reportBlob = await put(reportPath, compressed, {
+    const reportBlob = await putCompressedReportBlob(
+      reportPath,
+      entry.reportJson,
       access,
-      allowOverwrite: true,
-      cacheControlMaxAge: 31_536_000,
-      contentType: "application/gzip",
-    });
+    );
     const published: Test262BlobRun = {
       ...entry.point,
       jsonUrl: `/api/test262/results/${entry.point.artifactId}`,
       reportPath,
       reportUrl: reportBlob.url,
       reportDownloadUrl: reportBlob.downloadUrl,
-      reportCompressedSize: compressed.byteLength,
+      reportCompressedSize: reportBlob.size,
       publishedAt: new Date().toISOString(),
     };
-    await put(
+    await putDailyBlobPointer(
       dailyPathForPoint(published, prefix),
-      JSON.stringify(published, null, 2),
-      {
-        access,
-        allowOverwrite: true,
-        cacheControlMaxAge: 900,
-        contentType: "application/json",
-      },
+      published,
+      access,
     );
     publishedRuns.push(published);
   }
@@ -330,66 +261,16 @@ export async function publishTest262ProfileReportsToBlob(
   const publishedRuns: Test262ProfileBlobRun[] = [];
 
   for (const entry of entries) {
-    const aggregatePath = test262ProfileBlobReportPathForArtifactId(
-      entry.artifactId,
-      "aggregate",
-      prefix,
-    );
-    const aggregateCompressed = gzipSync(`${entry.aggregateJson.trimEnd()}\n`);
-    const aggregateBlob = await put(aggregatePath, aggregateCompressed, {
+    const profileReports = await publishProfileArtifacts(
+      entry,
+      (kind) =>
+        test262ProfileBlobReportPathForArtifactId(
+          entry.artifactId,
+          kind,
+          prefix,
+        ),
       access,
-      allowOverwrite: true,
-      cacheControlMaxAge: 31_536_000,
-      contentType: "application/gzip",
-    });
-    const profileReports: Test262ProfileBlobRun["profileReports"] = {
-      aggregate: {
-        path: aggregatePath,
-        url: aggregateBlob.url,
-        downloadUrl: aggregateBlob.downloadUrl,
-        size: aggregateCompressed.byteLength,
-      },
-    };
-
-    if (entry.markdown) {
-      const markdownPath = test262ProfileBlobReportPathForArtifactId(
-        entry.artifactId,
-        "markdown",
-        prefix,
-      );
-      const markdownBlob = await put(markdownPath, entry.markdown, {
-        access,
-        allowOverwrite: true,
-        cacheControlMaxAge: 31_536_000,
-        contentType: "text/markdown; charset=utf-8",
-      });
-      profileReports.markdown = {
-        path: markdownPath,
-        url: markdownBlob.url,
-        downloadUrl: markdownBlob.downloadUrl,
-        size: entry.markdown.byteLength,
-      };
-    }
-
-    if (entry.detailsArchive) {
-      const archivePath = test262ProfileBlobReportPathForArtifactId(
-        entry.artifactId,
-        "detailsArchive",
-        prefix,
-      );
-      const archiveBlob = await put(archivePath, entry.detailsArchive, {
-        access,
-        allowOverwrite: true,
-        cacheControlMaxAge: 31_536_000,
-        contentType: "application/gzip",
-      });
-      profileReports.detailsArchive = {
-        path: archivePath,
-        url: archiveBlob.url,
-        downloadUrl: archiveBlob.downloadUrl,
-        size: entry.detailsArchive.byteLength,
-      };
-    }
+    );
 
     const published: Test262ProfileBlobRun = {
       runId: entry.runId,
@@ -405,15 +286,10 @@ export async function publishTest262ProfileReportsToBlob(
       profileReports,
       publishedAt: new Date().toISOString(),
     };
-    await put(
+    await putDailyBlobPointer(
       profileDailyPathForRun(published, prefix),
-      JSON.stringify(published, null, 2),
-      {
-        access,
-        allowOverwrite: true,
-        cacheControlMaxAge: 900,
-        contentType: "application/json",
-      },
+      published,
+      access,
     );
     publishedRuns.push(published);
   }

--- a/website/src/lib/web-tooling-blob-store.ts
+++ b/website/src/lib/web-tooling-blob-store.ts
@@ -1,14 +1,16 @@
-import { gzipSync } from "node:zlib";
-import { put } from "@vercel/blob";
+import {
+  type BlobAccess,
+  type BlobReport,
+  blobAccess,
+  byCreatedAtThenRunNumber,
+  cleanBlobPrefix,
+  putCompressedReportBlob,
+  putDailyBlobPointer,
+} from "./report-blob";
 
-export type WebToolingBlobAccess = "public" | "private";
+export type WebToolingBlobAccess = BlobAccess;
 
-export type WebToolingBlobReport = {
-  path: string;
-  url: string;
-  downloadUrl: string;
-  size: number;
-};
+export type WebToolingBlobReport = BlobReport;
 
 export type WebToolingBlobRunSummary = {
   workloadCount: number;
@@ -48,21 +50,13 @@ export type WebToolingBlobPublishEntry = Omit<
 };
 
 const DEFAULT_PREFIX = "web-tooling";
-const DEFAULT_ACCESS: WebToolingBlobAccess = "public";
-
-function cleanPrefix(value: string | undefined, fallback: string): string {
-  const trimmed = (value ?? fallback).trim().replace(/^\/+|\/+$/g, "");
-  return trimmed || fallback;
-}
 
 export function webToolingBlobPrefix(): string {
-  return cleanPrefix(process.env.WEB_TOOLING_BLOB_PREFIX, DEFAULT_PREFIX);
+  return cleanBlobPrefix(process.env.WEB_TOOLING_BLOB_PREFIX, DEFAULT_PREFIX);
 }
 
 export function webToolingBlobAccess(): WebToolingBlobAccess {
-  return process.env.WEB_TOOLING_BLOB_ACCESS === "private"
-    ? "private"
-    : DEFAULT_ACCESS;
+  return blobAccess(process.env.WEB_TOOLING_BLOB_ACCESS);
 }
 
 export function webToolingBlobRunsPrefix(
@@ -98,16 +92,6 @@ function dailyPathForRun(
   return webToolingBlobDailyPathForDay(run.createdAt.slice(0, 10), prefix);
 }
 
-function byCreatedAtThenRunNumber(
-  a: Pick<WebToolingBlobRun, "createdAt" | "runNumber">,
-  b: Pick<WebToolingBlobRun, "createdAt" | "runNumber">,
-): number {
-  return (
-    Date.parse(a.createdAt) - Date.parse(b.createdAt) ||
-    a.runNumber - b.runNumber
-  );
-}
-
 export async function publishWebToolingReportsToBlob(
   entries: WebToolingBlobPublishEntry[],
 ): Promise<WebToolingBlobRun[]> {
@@ -120,13 +104,11 @@ export async function publishWebToolingReportsToBlob(
       entry.artifactId,
       prefix,
     );
-    const compressed = gzipSync(`${entry.reportJson.trimEnd()}\n`);
-    const reportBlob = await put(reportPath, compressed, {
+    const reportBlob = await putCompressedReportBlob(
+      reportPath,
+      entry.reportJson,
       access,
-      allowOverwrite: true,
-      cacheControlMaxAge: 31_536_000,
-      contentType: "application/gzip",
-    });
+    );
 
     const published: WebToolingBlobRun = {
       runId: entry.runId,
@@ -140,23 +122,13 @@ export async function publishWebToolingReportsToBlob(
       updatedAt: entry.updatedAt,
       artifactCreatedAt: entry.artifactCreatedAt,
       summary: entry.summary,
-      report: {
-        path: reportPath,
-        url: reportBlob.url,
-        downloadUrl: reportBlob.downloadUrl,
-        size: compressed.byteLength,
-      },
+      report: reportBlob,
       publishedAt: new Date().toISOString(),
     };
-    await put(
+    await putDailyBlobPointer(
       dailyPathForRun(published, prefix),
-      JSON.stringify(published, null, 2),
-      {
-        access,
-        allowOverwrite: true,
-        cacheControlMaxAge: 900,
-        contentType: "application/json",
-      },
+      published,
+      access,
     );
     publishedRuns.push(published);
   }


### PR DESCRIPTION
## Summary

- Consolidate repeated Blob byte reads, gzip and upload options, prefix/access normalization, profile attachments, and CI metadata parsing across the report publishers. Report schemas, validation, summaries, path selection, and credential ownership remain in their existing adapters.
- Preserve AWFY/Web Tooling/test262 daily pointers, JetStream per-run daily paths, distinct test262 report/profile paths, profile access settings, and timestamp fallbacks. Request-time history retrieval is unchanged.
- Implements audit recommendation S1: 357 fewer production lines, 87 fewer lines overall after CLI regression coverage and contributor documentation. No dependency changes or new deployment boundary.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [x] Updated documentation
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (not applicable: no native source changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change (not applicable: behavior-preserving publishing refactor)

Website dependencies installed with `bun install --frozen-lockfile` and declared `postinstall`. `bun run test`: 211 tests, 581 assertions; includes all six real publisher CLI commands using a mocked Blob transport, metadata/path/access preservation, optional attachments, fragmented report streams, missing/corrupt reads, and failed uploads. `bunx tsc --noEmit` and full `bun run lint` pass.

Independent CI on exact head `89c3b7e61873fb92867e1554c4d821324bc9b16b` passed all 49 checks, including the full interpreter and bytecode suites, native/CLI checks, test262, benchmark guards, and website checks. `./format.pas --check`: 463 files pass.

The timestamp parser now returns `null` for positive integer timestamps outside JavaScript’s Date range, preserving the existing fallback instead of throwing. Boundary coverage accepts the inclusive maximum and rejects larger safe integers; the real profile publisher CLI verifies fallback behavior. The full website suite, TypeScript, Biome (127 files), formatter (463 files), and ordinary hooks passed again for `89c3b7e61873fb92867e1554c4d821324bc9b16b`; all 49 independent CI checks also passed on this updated head.

A separate manual diff review checked storage paths, access selection, timestamp semantics, upload ordering, report-specific validators, and unchanged history retrieval. Live Blob publication and a production website deployment were not performed.

Follow-up #1232 depends on this PR and targets `codex/audit-report-publishing`, keeping its history retrieval and snapshot changes in a separate review.
