### PR TITLE
refactor(ci): share report publication setup

### DIFF
--- a/.github/scripts/publish-website-report.sh
+++ b/.github/scripts/publish-website-report.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ -z "${BLOB_READ_WRITE_TOKEN:-}" ]; then
+  echo "BLOB_READ_WRITE_TOKEN is not configured; skipping report publish."
+  exit 0
+fi
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../../website"
+
+# RUNNER_TEMP is fresh for each CI job. Multiple publishers in that job share
+# one dependency installation; local invocations always check the lockfile.
+installed="${RUNNER_TEMP:+$RUNNER_TEMP/goccia-website-publisher-installed}"
+if [ -z "$installed" ] || [ ! -f "$installed" ]; then
+  bun install --frozen-lockfile
+  if [ -n "$installed" ]; then
+    touch "$installed"
+  fi
+fi
+
+exec bun "$@"

--- a/.github/scripts/test-report-publishing.js
+++ b/.github/scripts/test-report-publishing.js
@@ -1,0 +1,60 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { mkdtempSync, writeFileSync, readFileSync, rmSync } = require('node:fs');
+const { tmpdir } = require('node:os');
+const { join, resolve } = require('node:path');
+const { spawnSync } = require('node:child_process');
+const upsert = require('./upsert-pr-comment.js');
+
+test('report comments create or update using current and legacy markers', async () => {
+  for (const previous of [null, '<!-- current --> old', '<!-- legacy --> old']) {
+    const calls = [];
+    const github = { rest: { issues: {
+      listComments: async issue => {
+        assert.deepEqual(issue, { owner: 'owner', repo: 'repo', issue_number: 7 });
+        return { data: [{ id: 1, body: 'unrelated' }, { id: 2, body: previous }] };
+      },
+      createComment: async args => calls.push(['create', args]),
+      updateComment: async args => calls.push(['update', args]),
+    } } };
+    await upsert({ github, context: { repo: { owner: 'owner', repo: 'repo' }, issue: { number: 7 } },
+      body: '<!-- current --> new', markers: ['<!-- current -->', '<!-- legacy -->'] });
+    assert.deepEqual(calls, [[previous ? 'update' : 'create', {
+      owner: 'owner', repo: 'repo', ...(previous ? { comment_id: 2 } : { issue_number: 7 }),
+      body: '<!-- current --> new',
+    }]]);
+  }
+});
+
+test('report launcher skips missing tokens, shares installation, and preserves failures and arguments', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'goccia-publish-'));
+  try {
+    const log = join(dir, 'calls.jsonl');
+    writeFileSync(join(dir, 'bun'), `#!/usr/bin/env node
+require('node:fs').appendFileSync(process.env.PUBLISH_TEST_LOG, JSON.stringify({ args: process.argv.slice(2), cwd: process.cwd() }) + '\\n');
+process.exit(Number(process.argv[2] === 'install' ? process.env.INSTALL_EXIT : process.env.PUBLISH_EXIT) || 0);
+`, { mode: 0o755 });
+    const env = { ...process.env, PATH: `${dir}:${process.env.PATH}`, RUNNER_TEMP: dir,
+      PUBLISH_TEST_LOG: log, BLOB_READ_WRITE_TOKEN: '', INSTALL_EXIT: '0', PUBLISH_EXIT: '0' };
+    const run = () => spawnSync('bash', [resolve(__dirname, 'publish-website-report.sh'),
+      'run', 'publish-awfy', '../report with spaces.json'], { env, encoding: 'utf8' });
+    assert.equal(run().status, 0);
+    assert.throws(() => readFileSync(log), { code: 'ENOENT' });
+    env.BLOB_READ_WRITE_TOKEN = 'test-token';
+    env.INSTALL_EXIT = '17';
+    assert.equal(run().status, 17);
+    env.INSTALL_EXIT = '0';
+    assert.equal(run().status, 0);
+    env.PUBLISH_EXIT = '23';
+    assert.equal(run().status, 23);
+    const calls = readFileSync(log, 'utf8').trim().split('\n').map(JSON.parse);
+    assert.deepEqual(calls.map(c => c.args), [
+      ['install', '--frozen-lockfile'], ['install', '--frozen-lockfile'],
+      ['run', 'publish-awfy', '../report with spaces.json'],
+      ['run', 'publish-awfy', '../report with spaces.json'],
+    ]);
+    assert.ok(calls.every(c => c.cwd === resolve(__dirname, '../../website')));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/.github/scripts/test-report-publishing.js
+++ b/.github/scripts/test-report-publishing.js
@@ -6,17 +6,22 @@ const { join, resolve } = require('node:path');
 const { spawnSync } = require('node:child_process');
 const upsert = require('./upsert-pr-comment.js');
 
-test('report comments create or update using current and legacy markers', async () => {
+test('report comments find current and legacy markers on later pages', async () => {
   for (const previous of [null, '<!-- current --> old', '<!-- legacy --> old']) {
     const calls = [];
     const github = { rest: { issues: {
-      listComments: async issue => {
+      listComments: async ({ page = 1, ...issue }) => {
         assert.deepEqual(issue, { owner: 'owner', repo: 'repo', issue_number: 7 });
-        return { data: [{ id: 1, body: 'unrelated' }, { id: 2, body: previous }] };
+        return { data: page === 1 ? [{ id: 1, body: 'unrelated' }] : [{ id: 2, body: previous }] };
       },
       createComment: async args => calls.push(['create', args]),
       updateComment: async args => calls.push(['update', args]),
-    } } };
+    } }, paginate: async (method, issue) => {
+      assert.equal(method, github.rest.issues.listComments);
+      const first = await method(issue);
+      const second = await method({ ...issue, page: 2 });
+      return [...first.data, ...second.data];
+    } };
     await upsert({ github, context: { repo: { owner: 'owner', repo: 'repo' }, issue: { number: 7 } },
       body: '<!-- current --> new', markers: ['<!-- current -->', '<!-- legacy -->'] });
     assert.deepEqual(calls, [[previous ? 'update' : 'create', {

--- a/.github/scripts/upsert-pr-comment.js
+++ b/.github/scripts/upsert-pr-comment.js
@@ -1,7 +1,7 @@
 // Report builders own the body and markers; CI owns the token and permissions.
 module.exports = async ({ github, context, body, markers }) => {
   const issue = { ...context.repo, issue_number: context.issue.number };
-  const { data: comments } = await github.rest.issues.listComments(issue);
+  const comments = await github.paginate(github.rest.issues.listComments, issue);
   const existing = comments.find(comment =>
     comment.body && markers.some(marker => comment.body.includes(marker)));
 

--- a/.github/scripts/upsert-pr-comment.js
+++ b/.github/scripts/upsert-pr-comment.js
@@ -1,0 +1,15 @@
+// Report builders own the body and markers; CI owns the token and permissions.
+module.exports = async ({ github, context, body, markers }) => {
+  const issue = { ...context.repo, issue_number: context.issue.number };
+  const { data: comments } = await github.rest.issues.listComments(issue);
+  const existing = comments.find(comment =>
+    comment.body && markers.some(marker => comment.body.includes(marker)));
+
+  if (existing) {
+    await github.rest.issues.updateComment({
+      ...context.repo, comment_id: existing.id, body,
+    });
+  } else {
+    await github.rest.issues.createComment({ ...issue, body });
+  }
+};

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Check JavaScript test-suite structure
         run: bun run scripts/check-test-structure.ts
 
+      - name: Check CI report publishing helpers
+        run: node --test .github/scripts/test-report-publishing.js
+
   build:
     needs: toolchain
     runs-on: macos-latest
@@ -657,13 +660,7 @@ jobs:
           BLOB_READ_WRITE_TOKEN: ${{ secrets.BLOB_READ_WRITE_TOKEN }}
           TEST262_RUN_CREATED_AT: ${{ github.event.repository.pushed_at }}
         run: |
-          if [ -z "${BLOB_READ_WRITE_TOKEN:-}" ]; then
-            echo "BLOB_READ_WRITE_TOKEN is not configured; skipping dashboard publish."
-            exit 0
-          fi
-          cd website
-          bun install --frozen-lockfile
-          bun run publish-test262 ../test262-results.json
+          bash ./.github/scripts/publish-website-report.sh run publish-test262 ../test262-results.json
 
       - name: Publish test262 profile reports
         if: github.ref == 'refs/heads/main' && hashFiles('test262-profile-aggregate.json') != '' && hashFiles('test262-profile-details/**') != ''
@@ -671,16 +668,10 @@ jobs:
           BLOB_READ_WRITE_TOKEN: ${{ secrets.BLOB_READ_WRITE_TOKEN }}
           TEST262_PROFILE_RUN_CREATED_AT: ${{ github.event.repository.pushed_at }}
         run: |
-          if [ -z "${BLOB_READ_WRITE_TOKEN:-}" ]; then
-            echo "BLOB_READ_WRITE_TOKEN is not configured; skipping profile publish."
-            exit 0
-          fi
-          if [ -d test262-profile-details ]; then
+          if [ -n "${BLOB_READ_WRITE_TOKEN:-}" ] && [ -d test262-profile-details ]; then
             tar -czf test262-profile-details.tar.gz test262-profile-details
           fi
-          cd website
-          bun install --frozen-lockfile
-          bun scripts/publish-test262-profile-reports.ts \
+          bash ./.github/scripts/publish-website-report.sh scripts/publish-test262-profile-reports.ts \
             --aggregate ../test262-profile-aggregate.json \
             --markdown ../test262-profile-aggregate.md \
             --details-archive ../test262-profile-details.tar.gz
@@ -765,13 +756,7 @@ jobs:
           BLOB_READ_WRITE_TOKEN: ${{ secrets.BLOB_READ_WRITE_TOKEN }}
           AWFY_RUN_CREATED_AT: ${{ github.event.repository.pushed_at }}
         run: |
-          if [ -z "${BLOB_READ_WRITE_TOKEN:-}" ]; then
-            echo "BLOB_READ_WRITE_TOKEN is not configured; skipping AWFY publish."
-            exit 0
-          fi
-          cd website
-          bun install --frozen-lockfile
-          bun run publish-awfy ../awfy-report.json
+          bash ./.github/scripts/publish-website-report.sh run publish-awfy ../awfy-report.json
 
       - name: Fail when AWFY validation failed
         if: steps.awfy-report.outcome == 'failure'
@@ -925,13 +910,7 @@ jobs:
           BLOB_READ_WRITE_TOKEN: ${{ secrets.BLOB_READ_WRITE_TOKEN }}
           JETSTREAM_RUN_CREATED_AT: ${{ github.event.repository.pushed_at }}
         run: |
-          if [ -z "${BLOB_READ_WRITE_TOKEN:-}" ]; then
-            echo "BLOB_READ_WRITE_TOKEN is not configured; skipping JetStream publish."
-            exit 0
-          fi
-          cd website
-          bun install --frozen-lockfile
-          bun run publish-jetstream ../jetstream-report.json
+          bash ./.github/scripts/publish-website-report.sh run publish-jetstream ../jetstream-report.json
 
       - name: Fail when JetStream validation failed
         if: steps.jetstream-merge.outcome == 'failure'
@@ -1072,13 +1051,7 @@ jobs:
           BLOB_READ_WRITE_TOKEN: ${{ secrets.BLOB_READ_WRITE_TOKEN }}
           WEB_TOOLING_RUN_CREATED_AT: ${{ github.event.repository.pushed_at }}
         run: |
-          if [ -z "${BLOB_READ_WRITE_TOKEN:-}" ]; then
-            echo "BLOB_READ_WRITE_TOKEN is not configured; skipping Web Tooling publish."
-            exit 0
-          fi
-          cd website
-          bun install --frozen-lockfile
-          bun run publish-web-tooling ../web-tooling-report.json
+          bash ./.github/scripts/publish-website-report.sh run publish-web-tooling ../web-tooling-report.json
 
   benchmark:
     needs: build
@@ -1240,14 +1213,10 @@ jobs:
           BLOB_READ_WRITE_TOKEN: ${{ secrets.BLOB_READ_WRITE_TOKEN }}
           BENCHMARK_PROFILE_RUN_CREATED_AT: ${{ github.event.repository.pushed_at }}
         run: |
-          if [ -z "${BLOB_READ_WRITE_TOKEN:-}" ]; then
-            echo "BLOB_READ_WRITE_TOKEN is not configured; skipping benchmark profile publish."
-            exit 0
+          if [ -n "${BLOB_READ_WRITE_TOKEN:-}" ]; then
+            tar -czf benchmark-profile-details.tar.gz profile-baseline
           fi
-          tar -czf benchmark-profile-details.tar.gz profile-baseline
-          cd website
-          bun install --frozen-lockfile
-          bun scripts/publish-benchmark-profile-reports.ts \
+          bash ./.github/scripts/publish-website-report.sh scripts/publish-benchmark-profile-reports.ts \
             --aggregate ../benchmark-profile-aggregate.json \
             --markdown ../benchmark-profile-aggregate.md \
             --details-archive ../benchmark-profile-details.tar.gz

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -122,6 +122,9 @@ jobs:
       - name: Check JavaScript test-suite structure
         run: bun run scripts/check-test-structure.ts
 
+      - name: Check CI report publishing helpers
+        run: node --test .github/scripts/test-report-publishing.js
+
   test:
     needs: build
     runs-on: ubuntu-latest
@@ -1044,28 +1047,9 @@ jobs:
             const marker = '<!-- benchmark-comparison -->';
             const body = marker + '\n' + inner;
 
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
+            await require('./.github/scripts/upsert-pr-comment.js')({
+              github, context, body, markers: [marker],
             });
-
-            const existing = comments.find(c => c.body && c.body.includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body,
-              });
-            }
 
   awfy-comment:
     needs: awfy-report
@@ -1099,28 +1083,9 @@ jobs:
             const markers = ['<!-- awfy-results -->', '<!-- awfy-smoke -->'];
             const body = fs.readFileSync('awfy-comment.md', 'utf8');
 
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
+            await require('./.github/scripts/upsert-pr-comment.js')({
+              github, context, body, markers: markers,
             });
-
-            const existing = comments.find(c => c.body && markers.some(marker => c.body.includes(marker)));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body,
-              });
-            }
 
   jetstream-comment:
     needs: jetstream-report
@@ -1154,28 +1119,9 @@ jobs:
             const marker = '<!-- jetstream-results -->';
             const body = fs.readFileSync('jetstream-comment.md', 'utf8');
 
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
+            await require('./.github/scripts/upsert-pr-comment.js')({
+              github, context, body, markers: [marker],
             });
-
-            const existing = comments.find(c => c.body && c.body.includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body,
-              });
-            }
 
   web-tooling-comment:
     needs: web-tooling-report
@@ -1209,28 +1155,9 @@ jobs:
             const marker = '<!-- web-tooling-results -->';
             const body = fs.readFileSync('web-tooling-comment.md', 'utf8');
 
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
+            await require('./.github/scripts/upsert-pr-comment.js')({
+              github, context, body, markers: [marker],
             });
-
-            const existing = comments.find(c => c.body && c.body.includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body,
-              });
-            }
 
   timing-comment:
     needs: [test, benchmark, boot-timing]
@@ -1529,28 +1456,9 @@ jobs:
             const marker = '<!-- test262-results -->';
             const body = fs.readFileSync('test262-comment.md', 'utf8');
 
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
+            await require('./.github/scripts/upsert-pr-comment.js')({
+              github, context, body, markers: [marker],
             });
-
-            const existing = comments.find(c => c.body && c.body.includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body,
-              });
-            }
 
       - name: Fail on regression
         if: steps.build_comment.outcome == 'failure'

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -668,6 +668,8 @@ RegExp embeds this generated UCD resource by default through `source/units/Gocci
 
 GitHub Actions CI is split into two workflow files:
 
+Report publication uses `.github/scripts/publish-website-report.sh` for the optional Blob token check and one website dependency installation per CI job. The workflow retains report arguments, timestamps, artifact conditions, and profile archive creation. Checked-out PR report jobs share `.github/scripts/upsert-pr-comment.js`; report builders retain their markdown and comment markers.
+
 ### `ci.yml` — Push to main + tags
 
 Job graph: `build -> test / toml-compliance / json5-compliance / test262 / awfy / jetstream / web-tooling / benchmark / cli -> artifacts/release`.


### PR DESCRIPTION
## Summary

- Centralize six website report launchers and five PR comment update blocks in small CI helpers. Website publishers share one successful dependency install per job, including the two test262 publishing steps.
- Preserve workflow triggers, permissions, matrices, conditions, credentials, report arguments, markdown, current/legacy comment markers, and error propagation. The timing comment remains self-contained because its job does not check out source.
- Add focused launcher/comment tests to both workflows and document ownership in the build-system guide. This implements the repeated CI setup/publication recommendation from the September 4 audit.

## Testing

- [x] Native test runner build passed; all 12,818 JavaScript tests / 28,573 assertions passed in both executors (sequential suite runs with two workers).
- [x] Updated build-system documentation.
- [x] Publishing helper tests pass: missing token, failed install, per-job install reuse, argument boundaries, publisher failure, comment creation and current/legacy marker updates, including markers found on later comment pages.
- [x] Actionlint workflow/schema validation and shellcheck for the new launcher pass. Full actionlint also reports five pre-existing shellcheck warnings in the unchanged cross-compile script.
- [x] Compared parsed baseline/candidate workflows: job contracts, conditions, credentials, action pins, permissions, matrices, and triggers unchanged.
- [x] Final Pascal format check passed (463 files).
- [x] Both full JavaScript suites and a separate manual diff review passed. All 49 CI checks passed at `b12f7bccae317cdc429aa639f08bbdeb701456d6`.
