### PR TITLE
fix(profiling): count allocations in host-run bytecode callbacks

### DIFF
--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -89,6 +89,18 @@ Scalar Fast-Path:
 
 Per-function breakdown: self-time (exclusive — time in the function minus time in callees), total-time (inclusive), call count, and allocation count (heap-allocated `TGocciaValue` instances created during that function's execution).
 
+Allocation counts belong to the active profiled function, including allocations
+made by native built-ins on its behalf. Collection follows each native entry
+into the VM, so host-invoked benchmark callbacks and resumed generators or async
+functions are included after module execution finishes. Nested VM entries
+restore their caller's allocation-profiling state on return or exception;
+ordinary bytecode calls use the existing function profiling stack.
+
+With `--profile-deterministic`, BenchmarkRunner resets the counters after module
+registration and executes each registered benchmark once. The resulting
+function allocation counts describe that benchmark execution, including its
+setup and teardown, rather than the discarded registration phase.
+
 ```text
 Function Profile:
   Self Time    Total Time      Calls     Allocs  Function                       Location

--- a/scripts/test-cli-apps.ts
+++ b/scripts/test-cli-apps.ts
@@ -38,6 +38,7 @@ import {
 import { containsLine, normalizeLineEndings, runLoaderJson } from "./test-cli/assertions";
 import { makeTmpFactory, clean } from "./test-cli/tmpdir";
 import { runWithPeakRss, assertPeakRssBelow, assertPeakRssAbove } from "./test-cli/rss";
+import { verifyAllocationProfiles } from "./test-cli-profiling";
 
 const makeTmp = makeTmpFactory("goccia-apps-");
 
@@ -4859,6 +4860,8 @@ await section("TestRunner: --output=compact-json omits build, memory, stdout, st
 // GocciaBenchmarkRunner
 // ============================================================================
 
+await section("Allocation profiling: host callbacks and native re-entry...", verifyAllocationProfiles);
+
 {
   const tmp = makeTmp();
   const benchEnv = {
@@ -5112,8 +5115,8 @@ await section("TestRunner: --output=compact-json omits build, memory, stdout, st
         throw new Error("Deterministic profile should include opcode counts");
       if (!Array.isArray(profile.functions) || profile.functions.length === 0)
         throw new Error("Deterministic profile should include function counts");
-      if (!profile.functions.some((fn: Record<string, unknown>) => typeof fn.allocations === "number"))
-        throw new Error("Deterministic profile should include function allocation counts");
+      if (!profile.functions.some((fn: Record<string, unknown>) => typeof fn.allocations === "number" && fn.allocations > 0))
+        throw new Error("Deterministic profile should include positive function allocation counts");
     }
     const scriptRunProfileBench = join(tmp, "profile-deterministic-script-run.js");
     const scriptRunProfileOut = join(tmp, "profile-script-run.json");

--- a/scripts/test-cli-profiling.ts
+++ b/scripts/test-cli-profiling.ts
@@ -1,0 +1,92 @@
+#!/usr/bin/env bun
+/** Allocation profiling through the real loader and host-run benchmarks.
+ * Also called by test-cli-apps.ts, so the CLI CI gate runs these regressions.
+ */
+import { readFileSync, writeFileSync } from "fs";
+import { join, resolve } from "path";
+import { BENCHRUNNER, LOADER } from "./test-cli/binaries";
+import { clean, mkdtemp } from "./test-cli/tmpdir";
+
+type FunctionProfile = { name: string; calls: number; allocations: number };
+
+export function verifyAllocationProfiles(): void {
+  const tmp = mkdtemp("goccia-profiling-");
+  try {
+    for (const host of ["loader", "benchmark"] as const) {
+      let previousAllocations = 0;
+      for (const count of [1, 100]) {
+        const source = join(tmp, `${host}-${count}.mjs`);
+        const output = join(tmp, `${host}-${count}.json`);
+        writeFileSync(source, [
+          ...(host === "benchmark" ? ['import { bench } from "goccia:microbench";'] : []),
+          "const allocateObjects = () => {",
+          "  const objects = [];",
+          ...Array.from({ length: count }, (_, index) => `  objects.push({ value: ${index} });`),
+          "  return objects;",
+          "};",
+          "const nestedAllocation = () => ({ nested: true });",
+          "const nestedThrow = () => { throw { failed: true }; };",
+          "const workload = () => {",
+          "  [0].map(nestedAllocation);",
+          "  try { [0].map(nestedThrow); } catch {}",
+          "  return allocateObjects();",
+          "};",
+          ...(host === "benchmark" ? [
+            'bench("allocations", workload);',
+            "const afterAwait = () => ({ resumed: true });",
+            "const setupAllocation = () => ({ setup: true });",
+            "const teardownAllocation = () => ({ teardown: true });",
+            'bench("generator and async", {',
+            "  *run() {",
+            "    setupAllocation();",
+            "    try {",
+            "      yield async () => { await Promise.resolve(); return afterAwait(); };",
+            "    } finally { teardownAllocation(); }",
+            "  },",
+            "}.run);",
+          ] : ["workload();"]),
+        ].join("\n"));
+        const proc = Bun.spawnSync([
+          resolve(host === "benchmark" ? BENCHRUNNER : LOADER), source,
+          "--profile=all", `--profile-output=${output}`,
+          ...(host === "benchmark"
+            ? ["--profile-deterministic", "--no-progress", "--format=compact-json"]
+            : ["--output=json"]),
+        ], { stdout: "pipe", stderr: "pipe", timeout: 120_000 });
+        if (proc.exitCode !== 0)
+          throw new Error(`${host} profiling exited ${proc.exitCode}: ${proc.stderr.toString()}\n${proc.stdout.toString()}`);
+        if (host === "benchmark") {
+          const report = JSON.parse(proc.stdout.toString());
+          const benchmarks = report.files?.[0]?.benchmarks;
+          if (benchmarks?.length !== 2 || benchmarks.some((bench: { iterations: number }) => bench.iterations !== 1))
+            throw new Error("Deterministic benchmark must run exactly once");
+        }
+        const profile = JSON.parse(readFileSync(output, "utf-8"));
+        const names = ["allocateObjects", "nestedAllocation", "nestedThrow"];
+        if (host === "benchmark") names.push("afterAwait", "setupAllocation", "teardownAllocation");
+        for (const name of names) {
+          const fn = profile.functions?.find((entry: FunctionProfile) => entry.name === name);
+          if (fn?.calls !== 1 || !Number.isSafeInteger(fn.allocations) || fn.allocations <= 0)
+            throw new Error(`${host}: ${name} must record one call and positive allocations: ${JSON.stringify(fn)}`);
+          if (name === "allocateObjects") {
+            if (fn.allocations < count || fn.allocations <= previousAllocations)
+              throw new Error(`${host}: allocations must grow with objects created: ${fn.allocations} after ${previousAllocations}`);
+            previousAllocations = fn.allocations;
+          }
+        }
+        if (host === "benchmark") {
+          // The JSON report omits functions with no calls after ResetCounts.
+          if (profile.functions.some((entry: FunctionProfile) => entry.name === "<module>"))
+            throw new Error("Deterministic profiling must exclude module registration allocations");
+        }
+      }
+    }
+  } finally {
+    clean(tmp);
+  }
+}
+
+if (import.meta.main) {
+  verifyAllocationProfiles();
+  console.log("Allocation profiling checks passed (loader, benchmark, nested calls, exceptions, async, generators).");
+}

--- a/source/units/Goccia.Executor.Bytecode.pas
+++ b/source/units/Goccia.Executor.Bytecode.pas
@@ -250,11 +250,9 @@ begin
     and TGocciaProfiler.Instance.Enabled
     and (pmFunctions in TGocciaProfiler.Instance.Mode);
   FVM.GlobalBackedTopLevel := FGlobalBackedTopLevel;
-  GProfilingAllocations := FVM.ProfilingFunctions;
   try
     Result := FVM.ExecuteModule(TGocciaBytecodeModule(AModule));
   finally
-    GProfilingAllocations := False;
     GC.Enabled := WasEnabled;
   end;
 end;

--- a/source/units/Goccia.VM.Test.pas
+++ b/source/units/Goccia.VM.Test.pas
@@ -656,6 +656,7 @@ end;
 
 procedure TTestGocciaVM.TestRestoreAllocationProfiling;
 var
+  CallerObject: TGocciaObjectValue;
   Template: TGocciaFunctionTemplate;
   VM: TGocciaVM;
   PreviousEnabled, Profiled, Throws, RaisedExpected: Boolean;
@@ -695,9 +696,13 @@ begin
             CallerIndex).Allocations).ToBe(0);
           // The caller remains on the profiling stack after either exit path.
           GProfilingAllocations := True;
-          TGocciaObjectValue.Create;
-          Expect<Int64>(TGocciaProfiler.Instance.GetFunctionProfile(
-            CallerIndex).Allocations).ToBe(1);
+          CallerObject := TGocciaObjectValue.Create;
+          try
+            Expect<Int64>(TGocciaProfiler.Instance.GetFunctionProfile(
+              CallerIndex).Allocations).ToBe(1);
+          finally
+            CallerObject.Free;
+          end;
         end;
   finally
     GProfilingAllocations := False;

--- a/source/units/Goccia.VM.Test.pas
+++ b/source/units/Goccia.VM.Test.pas
@@ -14,6 +14,7 @@ uses
   Goccia.Constants.PropertyNames,
   Goccia.ExecutionContext,
   Goccia.Modules,
+  Goccia.Profiler,
   Goccia.Realm,
   Goccia.Scope,
   Goccia.TestSetup,
@@ -46,6 +47,8 @@ type
     procedure TestExecuteIndexedObjectOps;
     procedure TestExecuteClosureCall;
     procedure TestExecuteCapturedClosure;
+    procedure TestProfileHostCallbackAllocations;
+    procedure TestRestoreAllocationProfiling;
     procedure TestDetachedModuleNamespaceImportRaisesSyntaxError;
   protected
     procedure BeforeEach; override;
@@ -92,6 +95,9 @@ begin
   Test('Execute indexed object ops', TestExecuteIndexedObjectOps);
   Test('Execute closure call', TestExecuteClosureCall);
   Test('Execute captured closure', TestExecuteCapturedClosure);
+  Test('Profile host callback allocations', TestProfileHostCallbackAllocations);
+  Test('Restore allocation profiling after return and throw',
+    TestRestoreAllocationProfiling);
   Test('Detached module namespace import raises SyntaxError',
     TestDetachedModuleNamespaceImportRaisesSyntaxError);
 end;
@@ -601,6 +607,103 @@ begin
     CallArgs.Free;
     VM.Free;
     Template.Free;
+  end;
+end;
+
+procedure TTestGocciaVM.TestProfileHostCallbackAllocations;
+var
+  Template, ChildTemplate: TGocciaFunctionTemplate;
+  VM: TGocciaVM;
+  Callback: TGocciaFunctionBase;
+  Arguments: TGocciaArgumentsCollection;
+  FirstAllocations: Int64;
+begin
+  TGocciaProfiler.Initialize;
+  Template := TGocciaFunctionTemplate.Create('register');
+  ChildTemplate := TGocciaFunctionTemplate.Create('allocate');
+  VM := TGocciaVM.Create;
+  Arguments := TGocciaArgumentsCollection.Create;
+  try
+    VM.ProfilingFunctions := True;
+    ChildTemplate.MaxRegisters := 1;
+    ChildTemplate.EmitInstruction(EncodeABC(OP_NEW_OBJECT, 0, 0, 0));
+    ChildTemplate.EmitInstruction(EncodeABC(OP_RETURN, 0, 0, 0));
+    Template.MaxRegisters := 1;
+    Template.AddFunction(ChildTemplate);
+    Template.EmitInstruction(EncodeABx(OP_CLOSURE, 0, 0));
+    Template.EmitInstruction(EncodeABC(OP_RETURN, 0, 0, 0));
+    Callback := TGocciaFunctionBase(VM.ExecuteFunction(Template));
+    TGocciaProfiler.Instance.ResetCounts;
+
+    Callback.Call(Arguments, TGocciaUndefinedLiteralValue.UndefinedValue);
+    FirstAllocations := TGocciaProfiler.Instance.GetFunctionProfile(
+      ChildTemplate.ProfileIndex).Allocations;
+    Expect<Boolean>(FirstAllocations > 0).ToBe(True);
+    Expect<Boolean>(GProfilingAllocations).ToBe(False);
+    Callback.Call(Arguments, TGocciaUndefinedLiteralValue.UndefinedValue);
+    Expect<Int64>(TGocciaProfiler.Instance.GetFunctionProfile(
+      ChildTemplate.ProfileIndex).Allocations).ToBe(FirstAllocations * 2);
+    Expect<Int64>(TGocciaProfiler.Instance.GetFunctionProfile(
+      Template.ProfileIndex).Allocations).ToBe(0);
+    Expect<Boolean>(GProfilingAllocations).ToBe(False);
+  finally
+    Arguments.Free;
+    VM.Free;
+    Template.Free;
+    TGocciaProfiler.Shutdown;
+  end;
+end;
+
+procedure TTestGocciaVM.TestRestoreAllocationProfiling;
+var
+  Template: TGocciaFunctionTemplate;
+  VM: TGocciaVM;
+  PreviousEnabled, Profiled, Throws, RaisedExpected: Boolean;
+  CallerIndex: Integer;
+begin
+  TGocciaProfiler.Initialize;
+  Template := TGocciaFunctionTemplate.Create('allocate');
+  VM := TGocciaVM.Create;
+  try
+    Template.MaxRegisters := 1;
+    Template.EmitInstruction(EncodeABC(OP_NEW_OBJECT, 0, 0, 0));
+    Template.EmitInstruction(EncodeABC(OP_RETURN, 0, 0, 0));
+    CallerIndex := TGocciaProfiler.Instance.RegisterTemplate('caller', '', 0);
+    for PreviousEnabled := False to True do
+      for Profiled := False to True do
+        for Throws := False to True do
+        begin
+          TGocciaProfiler.Instance.ResetCounts;
+          TGocciaProfiler.Instance.PushFunction(CallerIndex, 0);
+          GProfilingAllocations := PreviousEnabled;
+          VM.ProfilingFunctions := Profiled;
+          if Throws then
+            Template.PatchInstruction(1, EncodeABC(OP_THROW, 0, 0, 0))
+          else
+            Template.PatchInstruction(1, EncodeABC(OP_RETURN, 0, 0, 0));
+          RaisedExpected := False;
+          try
+            VM.ExecuteFunction(Template);
+          except
+            on E: EGocciaBytecodeThrow do
+              RaisedExpected := True;
+          end;
+          Expect<Boolean>(RaisedExpected).ToBe(Throws);
+          Expect<Boolean>(GProfilingAllocations).ToBe(PreviousEnabled);
+          // An unprofiled entry must not charge its objects to the caller.
+          Expect<Int64>(TGocciaProfiler.Instance.GetFunctionProfile(
+            CallerIndex).Allocations).ToBe(0);
+          // The caller remains on the profiling stack after either exit path.
+          GProfilingAllocations := True;
+          TGocciaObjectValue.Create;
+          Expect<Int64>(TGocciaProfiler.Instance.GetFunctionProfile(
+            CallerIndex).Allocations).ToBe(1);
+        end;
+  finally
+    GProfilingAllocations := False;
+    VM.Free;
+    Template.Free;
+    TGocciaProfiler.Shutdown;
   end;
 end;
 

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -14452,6 +14452,7 @@ var
   UseProdDispatch: Boolean;
   GC: TGarbageCollector;
   PreviousMemoryPressureCountdown: PInteger;
+  PreviousProfilingAllocations: Boolean;
   // Scratch active-root frame for opcode arms that materialize a fresh operand
   // and then re-enter guest code (key coercion / custom-matcher lookup) before
   // consuming it. Re-Initialized per use, so sharing one record is safe.
@@ -14634,6 +14635,10 @@ begin
       GC.ExchangeMemoryPressureCountdown(@FMemoryPressureCheckCountdown)
   else
     PreviousMemoryPressureCountdown := nil;
+  // Host callbacks can enter after module execution has finished. Scope the
+  // allocation switch to native VM entries; trampoline calls keep this state.
+  PreviousProfilingAllocations := GProfilingAllocations;
+  GProfilingAllocations := FProfilingFunctions;
   try
     FLastClosureThisValue := AThisValue;
     PushSavedStateRoot(SavedClosure, SavedNewTarget, SavedArgumentBase,
@@ -14937,6 +14942,7 @@ LInnerLoopsDone:
       end;
     end;
   finally
+    GProfilingAllocations := PreviousProfilingAllocations;
     if Assigned(GC) then
       GC.ExchangeMemoryPressureCountdown(
         PreviousMemoryPressureCountdown);


### PR DESCRIPTION
## Summary

- BenchmarkRunner invokes registered callbacks after module execution, when allocation collection had already been disabled. Scope allocation profiling to each native VM entry and restore the caller's state on return or exception. The audit probe still executes 101 `OP_NEW_OBJECT` instructions and now reports 306 allocations instead of zero.
- Reuse the existing VM cleanup block without adding checks to ordinary bytecode calls or instructions. Keep deterministic benchmark registration excluded. Update the authoritative profiling guide and add positive/increasing allocation checks for host callbacks, native re-entry, exceptions, async continuations, and generator setup/teardown.
- Separate manual diff review checked entry/exit pairing, unprofiled nested execution, callback attribution, and test integration. Full JavaScript suites pass in both execution modes; all 49 CI checks passed at final head `1b7ac4c3295edde64b69a09f8038f779dfeb75e8`.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests — focused `bun run scripts/test-cli-profiling.ts` passes. Full interpreter and bytecode suites with `--jobs=2` each pass 12,818 tests and 28,573 assertions across 1,615 files, with no failures or skips. Loader, BenchmarkRunner, and TestRunner development builds pass.
- [x] Updated documentation — `docs/profiling.md`.
- [x] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed) — `Goccia.VM.Test`: 19/19 pass. Both new tests fail on the unchanged baseline.
- [x] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change — deterministic benchmark regression passes, including allocation growth from 1 to 100 constructed objects. The same CLI test fails on the baseline with one callback invocation and zero allocations.

`./format.pas --check` passes. Allocation increases in the deterministic profile comparison are expected accounting corrections.

The standalone VM test now owns and frees its caller object explicitly because that native suite does not initialize the garbage collector. All 19 native VM tests, the formatter, and ordinary hooks passed again after this test-only review fix. CI initially hit a connection reset while downloading Node, before running Prettier; rerunning the failed infrastructure and dependent report jobs succeeded without source changes.
