### PR TITLE
refactor(builtins): release temporary member definitions after construction

### DIFF
--- a/docs/adding-built-in-types.md
+++ b/docs/adding-built-in-types.md
@@ -167,6 +167,12 @@ The preferred pattern is:
 
 This keeps the JS-visible surface in one place and avoids repeating `RegisterNativeMethod`, `DefineProperty`, and `CreateWithoutPrototype` boilerplate in every type.
 
+Member definitions used only during construction belong in local arrays, or can
+be passed directly from `Members.ToDefinitions` while the collection is alive.
+`RegisterMemberDefinitions` copies the callbacks, values, names, and flags into
+the target's functions and descriptors; it does not retain the definition array.
+These temporary arrays do not need thread-local storage or thread cleanup hooks.
+
 **ExposePrototype** -- Must NOT free the created instance (it becomes the pinned method host). Look up the shared prototype through the realm rather than caching it:
 
 ```pascal

--- a/source/units/Goccia.Builtins.CSV.pas
+++ b/source/units/Goccia.Builtins.CSV.pas
@@ -50,21 +50,12 @@ uses
   Goccia.Constants.ErrorNames,
   Goccia.Constants.PropertyNames,
   Goccia.GarbageCollector,
-  Goccia.ThreadCleanupRegistry,
   Goccia.Utils,
   Goccia.Values.ArrayValue,
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.ObjectValue,
   Goccia.Values.SymbolValue;
-
-threadvar
-  FStaticMembers: TArray<TGocciaMemberDefinition>;
-
-procedure ClearThreadvarMembers;
-begin
-  SetLength(FStaticMembers, 0);
-end;
 
 constructor TGocciaCSVBuiltin.Create(const AName: string;
   const AScope: TGocciaScope; const AThrowError: TGocciaThrowErrorCallback;
@@ -84,12 +75,10 @@ begin
       TGocciaSymbolValue.WellKnownToStringTag,
       TGocciaStringLiteralValue.Create('CSV'),
       [pfConfigurable]);
-    FStaticMembers := Members.ToDefinitions;
+    RegisterMemberDefinitions(FBuiltinObject, Members.ToDefinitions);
   finally
     Members.Free;
   end;
-
-  RegisterMemberDefinitions(FBuiltinObject, FStaticMembers);
   if ADefineGlobalBinding then
     AScope.DefineLexicalBinding(AName, FBuiltinObject, dtLet, True);
 end;
@@ -504,8 +493,5 @@ begin
     Result := TGocciaStringLiteralValue.Create(
       TGocciaCSVStringifier.Stringify(Data, Delimiter, Headers));
 end;
-
-initialization
-  RegisterThreadvarCleanup(@ClearThreadvarMembers);
 
 end.

--- a/source/units/Goccia.Builtins.Console.pas
+++ b/source/units/Goccia.Builtins.Console.pas
@@ -72,17 +72,7 @@ implementation
 uses
   SysUtils,
 
-  TimingUtils,
-
-  Goccia.ThreadCleanupRegistry;
-
-threadvar
-  FStaticMembers: TArray<TGocciaMemberDefinition>;
-
-procedure ClearThreadvarMembers;
-begin
-  SetLength(FStaticMembers, 0);
-end;
+  TimingUtils;
 
 constructor TGocciaConsole.Create(const AName: string; const AScope: TGocciaScope; const AThrowError: TGocciaThrowErrorCallback);
 var
@@ -116,11 +106,10 @@ begin
     Members.AddMethod(ConsoleGroupEnd, 0, gmkStaticMethod);
     Members.AddMethod(ConsoleTrace, -1, gmkStaticMethod);
     Members.AddMethod(ConsoleTable, -1, gmkStaticMethod);
-    FStaticMembers := Members.ToDefinitions;
+    RegisterMemberDefinitions(FBuiltinObject, Members.ToDefinitions);
   finally
     Members.Free;
   end;
-  RegisterMemberDefinitions(FBuiltinObject, FStaticMembers);
 
   AScope.DefineLexicalBinding(AName, FBuiltinObject, dtLet, True);
 end;
@@ -397,8 +386,5 @@ begin
     EmitLine('table', GroupPrefix + FormatForDisplay(AArgs.GetElement(0)));
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
-
-initialization
-  RegisterThreadvarCleanup(@ClearThreadvarMembers);
 
 end.

--- a/source/units/Goccia.Builtins.GlobalArray.pas
+++ b/source/units/Goccia.Builtins.GlobalArray.pas
@@ -41,7 +41,6 @@ uses
   Goccia.InstructionLimit,
   Goccia.MemoryLimit,
   Goccia.MicrotaskQueue,
-  Goccia.ThreadCleanupRegistry,
   Goccia.Timeout,
   Goccia.Utils,
   Goccia.Utils.Arrays,
@@ -62,9 +61,6 @@ uses
   Goccia.Values.SymbolValue,
   Goccia.Values.ToObject,
   Goccia.VM.Exception;
-
-threadvar
-  FStaticMembers: TArray<TGocciaMemberDefinition>;
 
 type
   TArrayFromAsyncSyncIteratorJob = class(TGocciaObjectValue)
@@ -91,11 +87,6 @@ type
       const AThisValue: TGocciaValue): TGocciaValue;
     procedure MarkReferences; override;
   end;
-
-procedure ClearThreadvarMembers;
-begin
-  SetLength(FStaticMembers, 0);
-end;
 
 constructor TArrayFromAsyncSyncIteratorJob.Create(
   const APromise: TGocciaPromiseValue; const AResultObj: TGocciaObjectValue;
@@ -290,11 +281,10 @@ begin
     Members.AddMethod(ArrayFrom, 1, gmkStaticMethod);
     Members.AddMethod(ArrayFromAsync, 1, gmkStaticMethod);
     Members.AddMethod(ArrayOf, -1, gmkStaticMethod);
-    FStaticMembers := Members.ToDefinitions;
+    RegisterMemberDefinitions(FBuiltinObject, Members.ToDefinitions);
   finally
     Members.Free;
   end;
-  RegisterMemberDefinitions(FBuiltinObject, FStaticMembers);
 end;
 
 // ES2026 §23.1.2.2 Array.isArray(arg)
@@ -944,8 +934,5 @@ begin
   ResultObj.SetProperty(PROP_LENGTH, TGocciaNumberLiteralValue.Create(Len));
   Result := ResultObj;
 end;
-
-initialization
-  RegisterThreadvarCleanup(@ClearThreadvarMembers);
 
 end.

--- a/source/units/Goccia.Builtins.GlobalArrayBuffer.pas
+++ b/source/units/Goccia.Builtins.GlobalArrayBuffer.pas
@@ -38,20 +38,11 @@ uses
   Goccia.Constants.PropertyNames,
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
-  Goccia.ThreadCleanupRegistry,
   Goccia.Values.DataViewValue,
   Goccia.Values.ErrorHelper,
   Goccia.Values.FunctionBase,
   Goccia.Values.HoleValue,
   Goccia.Values.TypedArrayValue;
-
-threadvar
-  FStaticMembers: TArray<TGocciaMemberDefinition>;
-
-procedure ClearThreadvarMembers;
-begin
-  SetLength(FStaticMembers, 0);
-end;
 
 const
   NO_MAX_BYTE_LENGTH = -1;
@@ -70,11 +61,10 @@ begin
   Members := TGocciaMemberCollection.Create;
   try
     Members.AddMethod(ArrayBufferIsView, 1, gmkStaticMethod);
-    FStaticMembers := Members.ToDefinitions;
+    RegisterMemberDefinitions(FBuiltinObject, Members.ToDefinitions);
   finally
     Members.Free;
   end;
-  RegisterMemberDefinitions(FBuiltinObject, FStaticMembers);
 end;
 
 // ES2026 §6.2.4.2 ToIndex(value) — local implementation for constructor path
@@ -164,8 +154,5 @@ begin
   else
     Result := TGocciaBooleanLiteralValue.FalseValue;
 end;
-
-initialization
-  RegisterThreadvarCleanup(@ClearThreadvarMembers);
 
 end.

--- a/source/units/Goccia.Builtins.GlobalBigInt.pas
+++ b/source/units/Goccia.Builtins.GlobalBigInt.pas
@@ -42,7 +42,6 @@ uses
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
   Goccia.ObjectModel.Types,
-  Goccia.ThreadCleanupRegistry,
   Goccia.Values.BigIntValue,
   Goccia.Values.ErrorHelper,
   Goccia.Values.HoleValue,
@@ -51,17 +50,10 @@ uses
   Goccia.Values.SymbolValue,
   Goccia.Values.ToPrimitive;
 
-threadvar
-  FStaticMembers: TArray<TGocciaMemberDefinition>;
-
-procedure ClearThreadvarMembers;
-begin
-  SetLength(FStaticMembers, 0);
-end;
-
 constructor TGocciaGlobalBigInt.Create(const AName: string; const AScope: TGocciaScope; const AThrowError: TGocciaThrowErrorCallback);
 var
   PrototypeInitializer: TGocciaBigIntValue;
+  StaticMembers: TArray<TGocciaMemberDefinition>;
   Proto: TGocciaObjectValue;
 begin
   inherited Create(AName, AScope, AThrowError);
@@ -79,13 +71,13 @@ begin
   try
     AddMethod(BigIntAsIntN, 2, gmkStaticMethod, [gmfNotConstructable]);
     AddMethod(BigIntAsUintN, 2, gmkStaticMethod, [gmfNotConstructable]);
-    FStaticMembers := ToDefinitions;
+    StaticMembers := ToDefinitions;
   finally
     Free;
   end;
-  FStaticMembers[0].ExposedName := 'asIntN';
-  FStaticMembers[1].ExposedName := 'asUintN';
-  RegisterMemberDefinitions(FBigIntFunction, FStaticMembers);
+  StaticMembers[0].ExposedName := 'asIntN';
+  StaticMembers[1].ExposedName := 'asUintN';
+  RegisterMemberDefinitions(FBigIntFunction, StaticMembers);
 
   // Set up BigInt.prototype
   Proto := TGocciaObjectValue(TGocciaBigIntValue.SharedPrototype);
@@ -283,8 +275,5 @@ begin
 
   Result := TGocciaBigIntValue.Create(BigIntVal.Value.AsUintN(Bits));
 end;
-
-initialization
-  RegisterThreadvarCleanup(@ClearThreadvarMembers);
 
 end.

--- a/source/units/Goccia.Builtins.GlobalFFI.pas
+++ b/source/units/Goccia.Builtins.GlobalFFI.pas
@@ -44,21 +44,12 @@ uses
   Goccia.Error.Suggestions,
   Goccia.FFI.DynamicLibrary,
   Goccia.FFI.Types,
-  Goccia.ThreadCleanupRegistry,
   Goccia.Values.ErrorHelper,
   Goccia.Values.FFILibrary,
   Goccia.Values.FFIPointer,
   Goccia.Values.FFIType,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.ObjectValue;
-
-threadvar
-  FStaticMembers: TArray<TGocciaMemberDefinition>;
-
-procedure ClearThreadvarMembers;
-begin
-  SetLength(FStaticMembers, 0);
-end;
 
 const
   {$IFDEF DARWIN}
@@ -93,11 +84,10 @@ begin
     Members.AddNamedMethod('metadata', FFIMetadata, 1, gmkStaticMethod);
     Members.AddAccessor(PROP_NULLPTR, FFINullptrGetter, nil, [pfConfigurable], gmkStaticGetter);
     Members.AddAccessor(PROP_SUFFIX, FFISuffixGetter, nil, [pfConfigurable], gmkStaticGetter);
-    FStaticMembers := Members.ToDefinitions;
+    RegisterMemberDefinitions(FBuiltinObject, Members.ToDefinitions);
   finally
     Members.Free;
   end;
-  RegisterMemberDefinitions(FBuiltinObject, FStaticMembers);
 
   AScope.DefineLexicalBinding(AName, FBuiltinObject, dtConst, True);
 end;
@@ -217,8 +207,5 @@ function TGocciaGlobalFFI.FFISuffixGetter(const AArgs: TGocciaArgumentsCollectio
 begin
   Result := TGocciaStringLiteralValue.Create(SHARED_LIBRARY_SUFFIX);
 end;
-
-initialization
-  RegisterThreadvarCleanup(@ClearThreadvarMembers);
 
 end.

--- a/source/units/Goccia.Builtins.GlobalNumber.pas
+++ b/source/units/Goccia.Builtins.GlobalNumber.pas
@@ -38,17 +38,8 @@ uses
   Goccia.Arguments.Validator,
   Goccia.Constants.NumericLimits,
   Goccia.NumberConversion,
-  Goccia.ThreadCleanupRegistry,
   Goccia.Values.NativeFunction,
   Goccia.Values.ObjectPropertyDescriptor;
-
-threadvar
-  FStaticMembers: TArray<TGocciaMemberDefinition>;
-
-procedure ClearThreadvarMembers;
-begin
-  SetLength(FStaticMembers, 0);
-end;
 
 function ASCIIRadixDigitValue(const ACharacter: Char): Integer;
 begin
@@ -85,11 +76,10 @@ begin
     Members.AddMethod(NumberIsNaN, 1, gmkStaticMethod);
     Members.AddMethod(NumberIsInteger, 1, gmkStaticMethod);
     Members.AddMethod(NumberIsSafeInteger, 1, gmkStaticMethod);
-    FStaticMembers := Members.ToDefinitions;
+    RegisterMemberDefinitions(FBuiltinObject, Members.ToDefinitions);
   finally
     Members.Free;
   end;
-  RegisterMemberDefinitions(FBuiltinObject, FStaticMembers);
 end;
 
 // ES2026 §21.1.2.13 Number.parseInt(string, radix)
@@ -430,8 +420,5 @@ begin
   else
     Result := TGocciaBooleanLiteralValue.FalseValue;
 end;
-
-initialization
-  RegisterThreadvarCleanup(@ClearThreadvarMembers);
 
 end.

--- a/source/units/Goccia.Builtins.GlobalObject.pas
+++ b/source/units/Goccia.Builtins.GlobalObject.pas
@@ -60,7 +60,6 @@ uses
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
-  Goccia.ThreadCleanupRegistry,
   Goccia.Utils,
   Goccia.Values.ArrayBufferValue,
   Goccia.Values.ArrayValue,
@@ -77,14 +76,6 @@ uses
   Goccia.Values.ToObject,
   Goccia.Values.ToPrimitive,
   Goccia.Values.TypedArrayValue;
-
-threadvar
-  FStaticMembers: TArray<TGocciaMemberDefinition>;
-
-procedure ClearThreadvarMembers;
-begin
-  SetLength(FStaticMembers, 0);
-end;
 
 type
   TPendingDefineProperty = record
@@ -228,11 +219,10 @@ begin
     Members.AddMethod(ObjectIsExtensible, 1, gmkStaticMethod);
     Members.AddMethod(ObjectSetPrototypeOf, 2, gmkStaticMethod);
     Members.AddMethod(ObjectGroupBy, 2, gmkStaticMethod);
-    FStaticMembers := Members.ToDefinitions;
+    RegisterMemberDefinitions(FBuiltinObject, Members.ToDefinitions);
   finally
     Members.Free;
   end;
-  RegisterMemberDefinitions(FBuiltinObject, FStaticMembers);
   FBuiltinObject.DefineProperty(PROP_LENGTH,
     TGocciaPropertyDescriptorData.Create(TGocciaNumberLiteralValue.Create(1),
       [pfConfigurable]));
@@ -1493,8 +1483,5 @@ begin
     RemoveTempRootIfNeeded(ItemsRoot);
   end;
 end;
-
-initialization
-  RegisterThreadvarCleanup(@ClearThreadvarMembers);
 
 end.

--- a/source/units/Goccia.Builtins.GlobalPromise.pas
+++ b/source/units/Goccia.Builtins.GlobalPromise.pas
@@ -60,7 +60,6 @@ uses
   Goccia.MemoryLimit,
   Goccia.MicrotaskQueue,
   Goccia.Realm,
-  Goccia.ThreadCleanupRegistry,
   Goccia.Timeout,
   Goccia.Utils,
   Goccia.Values.Error,
@@ -75,14 +74,6 @@ uses
   Goccia.Values.SetValue,
   Goccia.Values.SymbolValue,
   Goccia.VM.Exception;
-
-threadvar
-  FStaticMembers: TArray<TGocciaMemberDefinition>;
-
-procedure ClearThreadvarMembers;
-begin
-  SetLength(FStaticMembers, 0);
-end;
 
 type
   TPromiseCapability = record
@@ -1098,11 +1089,10 @@ begin
     Members.AddMethod(PromiseAllSettledKeyed, 1, gmkStaticMethod);
     Members.AddMethod(PromiseWithResolvers, 0, gmkStaticMethod);
     Members.AddMethod(PromiseTry, 1, gmkStaticMethod);
-    FStaticMembers := Members.ToDefinitions;
+    RegisterMemberDefinitions(FPromiseConstructor, Members.ToDefinitions);
   finally
     Members.Free;
   end;
-  RegisterMemberDefinitions(FPromiseConstructor, FStaticMembers);
 
   AScope.DefineLexicalBinding(AName, FPromiseConstructor, dtLet, True);
 end;
@@ -2136,8 +2126,5 @@ begin
   { Step 7: Return promiseCapability.[[Promise]] }
   Result := Capability.Promise;
 end;
-
-initialization
-  RegisterThreadvarCleanup(@ClearThreadvarMembers);
 
 end.

--- a/source/units/Goccia.Builtins.GlobalReflect.pas
+++ b/source/units/Goccia.Builtins.GlobalReflect.pas
@@ -46,7 +46,6 @@ uses
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
-  Goccia.ThreadCleanupRegistry,
   Goccia.Utils,
   Goccia.Values.ArrayValue,
   Goccia.Values.Error,
@@ -56,14 +55,6 @@ uses
   Goccia.Values.ProxyValue,
   Goccia.Values.SymbolValue,
   Goccia.Values.ToPrimitive;
-
-threadvar
-  FStaticMembers: TArray<TGocciaMemberDefinition>;
-
-procedure ClearThreadvarMembers;
-begin
-  SetLength(FStaticMembers, 0);
-end;
 
 { Helper: validate target is an object, throw TypeError if not }
 
@@ -102,11 +93,10 @@ begin
       TGocciaSymbolValue.WellKnownToStringTag,
       TGocciaStringLiteralValue.Create('Reflect'),
       [pfConfigurable]);
-    FStaticMembers := Members.ToDefinitions;
+    RegisterMemberDefinitions(FBuiltinObject, Members.ToDefinitions);
   finally
     Members.Free;
   end;
-  RegisterMemberDefinitions(FBuiltinObject, FStaticMembers);
 
   if ADefineGlobalBinding then
     AScope.DefineLexicalBinding(AName, FBuiltinObject, dtConst, True);
@@ -684,8 +674,5 @@ begin
 
   Result := TGocciaBooleanLiteralValue.TrueValue;
 end;
-
-initialization
-  RegisterThreadvarCleanup(@ClearThreadvarMembers);
 
 end.

--- a/source/units/Goccia.Builtins.GlobalString.pas
+++ b/source/units/Goccia.Builtins.GlobalString.pas
@@ -35,20 +35,11 @@ uses
   Goccia.Constants.PropertyNames,
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
-  Goccia.ThreadCleanupRegistry,
   Goccia.Utils,
   Goccia.Values.ArrayValue,
   Goccia.Values.ErrorHelper,
   Goccia.Values.NativeFunction,
   Goccia.Values.ObjectValue;
-
-threadvar
-  FStaticMembers: TArray<TGocciaMemberDefinition>;
-
-procedure ClearThreadvarMembers;
-begin
-  SetLength(FStaticMembers, 0);
-end;
 
 constructor TGocciaGlobalString.Create(const AName: string; const AScope: TGocciaScope; const AThrowError: TGocciaThrowErrorCallback);
 var
@@ -62,11 +53,10 @@ begin
     Members.AddMethod(StringFromCharCode, 1, gmkStaticMethod);
     Members.AddMethod(StringFromCodePoint, 1, gmkStaticMethod);
     Members.AddMethod(StringRaw, 1, gmkStaticMethod);
-    FStaticMembers := Members.ToDefinitions;
+    RegisterMemberDefinitions(FBuiltinObject, Members.ToDefinitions);
   finally
     Members.Free;
   end;
-  RegisterMemberDefinitions(FBuiltinObject, FStaticMembers);
   FromCharCodeValue := FBuiltinObject.GetProperty(PROP_FROM_CHAR_CODE);
   if FromCharCodeValue is TGocciaNativeFunctionValue then
     TGocciaNativeFunctionValue(FromCharCodeValue).IntrinsicKind :=
@@ -239,8 +229,5 @@ begin
 
   Result := TGocciaStringLiteralValue.Create(SB.ToString);
 end;
-
-initialization
-  RegisterThreadvarCleanup(@ClearThreadvarMembers);
 
 end.

--- a/source/units/Goccia.Builtins.GlobalSymbol.pas
+++ b/source/units/Goccia.Builtins.GlobalSymbol.pas
@@ -47,7 +47,6 @@ uses
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
   Goccia.GarbageCollector,
-  Goccia.ThreadCleanupRegistry,
   Goccia.Values.ErrorHelper,
   Goccia.Values.HoleValue,
   Goccia.Values.ObjectPropertyDescriptor,
@@ -55,8 +54,6 @@ uses
   Goccia.Values.ToPrimitive;
 
 threadvar
-  FStaticMembers: TArray<TGocciaMemberDefinition>;
-
   // ES2026 §20.4.2.2: the GlobalSymbolRegistry is one per agent (thread). Every
   // realm in the thread — the main realm, ShadowRealm child realms, and
   // $262.createRealm realms — shares it, so Symbol.for(key) yields the same
@@ -65,11 +62,6 @@ threadvar
   // realm can read it after teardown regardless of engine creation/teardown order.
   GSharedSymbolRegistry: TOrderedStringMap<TGocciaSymbolValue>;
   GSharedSymbolRegistryRefs: Integer;
-
-procedure ClearThreadvarMembers;
-begin
-  SetLength(FStaticMembers, 0);
-end;
 
 function SharedSymbolRegistry: TOrderedStringMap<TGocciaSymbolValue>;
 begin
@@ -105,11 +97,10 @@ begin
   try
     AddMethod(SymbolFor, 1, gmkStaticMethod, [gmfNotConstructable]);
     AddMethod(SymbolKeyFor, 1, gmkStaticMethod, [gmfNotConstructable]);
-    FStaticMembers := ToDefinitions;
+    RegisterMemberDefinitions(FSymbolFunction, ToDefinitions);
   finally
     Free;
   end;
-  RegisterMemberDefinitions(FSymbolFunction, FStaticMembers);
 
   // Register well-known symbol constants
   FSymbolFunction.RegisterConstant(SYMBOL_MATCH, TGocciaSymbolValue.WellKnownMatch);
@@ -263,8 +254,5 @@ begin
   { Step 4: Return undefined }
   Result := TGocciaUndefinedLiteralValue.UndefinedValue;
 end;
-
-initialization
-  RegisterThreadvarCleanup(@ClearThreadvarMembers);
 
 end.

--- a/source/units/Goccia.Builtins.GlobalURL.pas
+++ b/source/units/Goccia.Builtins.GlobalURL.pas
@@ -44,19 +44,10 @@ uses
   Goccia.Arguments.Validator,
   Goccia.Constants.ConstructorNames,
   Goccia.Constants.PropertyNames,
-  Goccia.ThreadCleanupRegistry,
   Goccia.URL.Parser,
   Goccia.Values.ErrorHelper,
   Goccia.Values.URLSearchParamsValue,
   Goccia.Values.URLValue;
-
-threadvar
-  FStaticMembers: TArray<TGocciaMemberDefinition>;
-
-procedure ClearThreadvarMembers;
-begin
-  SetLength(FStaticMembers, 0);
-end;
 
 { TGocciaGlobalURL }
 
@@ -75,11 +66,10 @@ begin
   try
     Members.AddNamedMethod(PROP_CAN_PARSE, CanParse, 1, gmkStaticMethod);
     Members.AddNamedMethod(PROP_PARSE, Parse, 1, gmkStaticMethod);
-    FStaticMembers := Members.ToDefinitions;
+    RegisterMemberDefinitions(FBuiltinObject, Members.ToDefinitions);
   finally
     Members.Free;
   end;
-  RegisterMemberDefinitions(FBuiltinObject, FStaticMembers);
 end;
 
 // WHATWG URL §4.7.3 URL.canParse(url[, base]) -> boolean
@@ -164,8 +154,5 @@ begin
   // Initialize the shared URLSearchParams prototype lazily
   TGocciaURLSearchParamsValue.ExposePrototype(FBuiltinObject);
 end;
-
-initialization
-  RegisterThreadvarCleanup(@ClearThreadvarMembers);
 
 end.

--- a/source/units/Goccia.Builtins.JSON.pas
+++ b/source/units/Goccia.Builtins.JSON.pas
@@ -63,7 +63,6 @@ uses
   Goccia.Error.Suggestions,
   Goccia.InstructionLimit,
   Goccia.MemoryLimit,
-  Goccia.ThreadCleanupRegistry,
   Goccia.Timeout,
   Goccia.Utils,
   Goccia.Values.BigIntValue,
@@ -78,14 +77,6 @@ uses
   Goccia.Values.ToObject,
   Goccia.Values.WrapperPrimitives,
   Goccia.VM.Exception;
-
-threadvar
-  FStaticMembers: TArray<TGocciaMemberDefinition>;
-
-procedure ClearThreadvarMembers;
-begin
-  SetLength(FStaticMembers, 0);
-end;
 
 constructor TGocciaJSONBuiltin.Create(const AName: string; const AScope: TGocciaScope; const AThrowError: TGocciaThrowErrorCallback);
 var
@@ -107,11 +98,10 @@ begin
       TGocciaSymbolValue.WellKnownToStringTag,
       TGocciaStringLiteralValue.Create('JSON'),
       [pfConfigurable]);
-    FStaticMembers := Members.ToDefinitions;
+    RegisterMemberDefinitions(FBuiltinObject, Members.ToDefinitions);
   finally
     Members.Free;
   end;
-  RegisterMemberDefinitions(FBuiltinObject, FStaticMembers);
 
   AScope.DefineLexicalBinding(AName, FBuiltinObject, dtLet, True);
 end;
@@ -811,8 +801,5 @@ begin
     end;
   end;
 end;
-
-initialization
-  RegisterThreadvarCleanup(@ClearThreadvarMembers);
 
 end.

--- a/source/units/Goccia.Builtins.JSON5.pas
+++ b/source/units/Goccia.Builtins.JSON5.pas
@@ -77,7 +77,6 @@ uses
   Goccia.GarbageCollector,
   Goccia.InstructionLimit,
   Goccia.MemoryLimit,
-  Goccia.ThreadCleanupRegistry,
   Goccia.Timeout,
   Goccia.Utils,
   Goccia.Values.Error,
@@ -90,14 +89,6 @@ uses
   Goccia.Values.ToObject,
   Goccia.Values.WrapperPrimitives,
   Goccia.VM.Exception;
-
-threadvar
-  FStaticMembers: TArray<TGocciaMemberDefinition>;
-
-procedure ClearThreadvarMembers;
-begin
-  SetLength(FStaticMembers, 0);
-end;
 
 function CopyByCodePoints(const AText: string;
   const AMaxChars: Integer): string;
@@ -143,12 +134,10 @@ begin
       TGocciaSymbolValue.WellKnownToStringTag,
       TGocciaStringLiteralValue.Create('JSON5'),
       [pfConfigurable]);
-    FStaticMembers := Members.ToDefinitions;
+    RegisterMemberDefinitions(FBuiltinObject, Members.ToDefinitions);
   finally
     Members.Free;
   end;
-
-  RegisterMemberDefinitions(FBuiltinObject, FStaticMembers);
   if ADefineGlobalBinding then
     AScope.DefineLexicalBinding(AName, FBuiltinObject, dtLet, True);
 end;
@@ -764,8 +753,5 @@ begin
     end;
   end;
 end;
-
-initialization
-  RegisterThreadvarCleanup(@ClearThreadvarMembers);
 
 end.

--- a/source/units/Goccia.Builtins.JSONL.pas
+++ b/source/units/Goccia.Builtins.JSONL.pas
@@ -47,19 +47,10 @@ uses
   Goccia.Constants.PropertyNames,
   Goccia.Error.Messages,
   Goccia.GarbageCollector,
-  Goccia.ThreadCleanupRegistry,
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.ObjectValue,
   Goccia.Values.SymbolValue;
-
-threadvar
-  FStaticMembers: TArray<TGocciaMemberDefinition>;
-
-procedure ClearThreadvarMembers;
-begin
-  SetLength(FStaticMembers, 0);
-end;
 
 constructor TGocciaJSONLBuiltin.Create(const AName: string;
   const AScope: TGocciaScope; const AThrowError: TGocciaThrowErrorCallback;
@@ -78,12 +69,10 @@ begin
       TGocciaSymbolValue.WellKnownToStringTag,
       TGocciaStringLiteralValue.Create('JSONL'),
       [pfConfigurable]);
-    FStaticMembers := Members.ToDefinitions;
+    RegisterMemberDefinitions(FBuiltinObject, Members.ToDefinitions);
   finally
     Members.Free;
   end;
-
-  RegisterMemberDefinitions(FBuiltinObject, FStaticMembers);
   if ADefineGlobalBinding then
     AScope.DefineLexicalBinding(AName, FBuiltinObject, dtLet, True);
 end;
@@ -290,8 +279,5 @@ begin
       ThrowSyntaxError(E.Message);
   end;
 end;
-
-initialization
-  RegisterThreadvarCleanup(@ClearThreadvarMembers);
 
 end.

--- a/source/units/Goccia.Builtins.Math.pas
+++ b/source/units/Goccia.Builtins.Math.pas
@@ -82,7 +82,6 @@ uses
   Goccia.GarbageCollector,
   Goccia.NumberConversion,
   Goccia.NumberExponentiation,
-  Goccia.ThreadCleanupRegistry,
   Goccia.Utils,
   Goccia.Values.ArrayValue,
   Goccia.Values.ClassHelper,
@@ -113,9 +112,6 @@ const
   MATH_PI = 3.141592653589793;
   MATH_SQRT1_2 = 0.7071067811865476;
   MATH_SQRT2 = 1.4142135623730951;
-
-threadvar
-  FStaticMembers: TArray<TGocciaMemberDefinition>;
 
 function IsFiniteIntegral(const AValue: Double): Boolean; {$IFDEF FPC}inline;{$ENDIF}
 begin
@@ -388,11 +384,6 @@ begin
     Result := -Result;
 end;
 
-procedure ClearThreadvarMembers;
-begin
-  SetLength(FStaticMembers, 0);
-end;
-
 { TGocciaMath }
 
 constructor TGocciaMath.Create(const AName: string; const AScope: TGocciaScope;
@@ -458,11 +449,10 @@ begin
       TGocciaSymbolValue.WellKnownToStringTag,
       TGocciaStringLiteralValue.Create('Math'),
       [pfConfigurable]);
-    FStaticMembers := Members.ToDefinitions;
+    RegisterMemberDefinitions(FBuiltinObject, Members.ToDefinitions);
   finally
     Members.Free;
   end;
-  RegisterMemberDefinitions(FBuiltinObject, FStaticMembers);
 
   AScope.DefineLexicalBinding(AName, FBuiltinObject, dtLet, True);
 end;
@@ -1472,8 +1462,5 @@ begin
     Exit(TGocciaNumberLiteralValue.NegativeZeroValue);
   Result := TGocciaNumberLiteralValue.Create(Sum);
 end;
-
-initialization
-  RegisterThreadvarCleanup(@ClearThreadvarMembers);
 
 end.

--- a/source/units/Goccia.Builtins.TOML.pas
+++ b/source/units/Goccia.Builtins.TOML.pas
@@ -35,18 +35,9 @@ uses
 
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
-  Goccia.ThreadCleanupRegistry,
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.SymbolValue;
-
-threadvar
-  FStaticMembers: TArray<TGocciaMemberDefinition>;
-
-procedure ClearThreadvarMembers;
-begin
-  SetLength(FStaticMembers, 0);
-end;
 
 constructor TGocciaTOMLBuiltin.Create(const AName: string;
   const AScope: TGocciaScope; const AThrowError: TGocciaThrowErrorCallback;
@@ -65,12 +56,10 @@ begin
       TGocciaSymbolValue.WellKnownToStringTag,
       TGocciaStringLiteralValue.Create('TOML'),
       [pfConfigurable]);
-    FStaticMembers := Members.ToDefinitions;
+    RegisterMemberDefinitions(FBuiltinObject, Members.ToDefinitions);
   finally
     Members.Free;
   end;
-
-  RegisterMemberDefinitions(FBuiltinObject, FStaticMembers);
   if ADefineGlobalBinding then
     AScope.DefineLexicalBinding(AName, FBuiltinObject, dtLet, True);
 end;
@@ -96,8 +85,5 @@ begin
       ThrowSyntaxError(E.Message, SSuggestTOMLSyntax);
   end;
 end;
-
-initialization
-  RegisterThreadvarCleanup(@ClearThreadvarMembers);
 
 end.

--- a/source/units/Goccia.Builtins.TSV.pas
+++ b/source/units/Goccia.Builtins.TSV.pas
@@ -50,21 +50,12 @@ uses
   Goccia.Constants.ErrorNames,
   Goccia.Constants.PropertyNames,
   Goccia.GarbageCollector,
-  Goccia.ThreadCleanupRegistry,
   Goccia.Utils,
   Goccia.Values.ArrayValue,
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.ObjectValue,
   Goccia.Values.SymbolValue;
-
-threadvar
-  FStaticMembers: TArray<TGocciaMemberDefinition>;
-
-procedure ClearThreadvarMembers;
-begin
-  SetLength(FStaticMembers, 0);
-end;
 
 constructor TGocciaTSVBuiltin.Create(const AName: string;
   const AScope: TGocciaScope; const AThrowError: TGocciaThrowErrorCallback;
@@ -84,12 +75,10 @@ begin
       TGocciaSymbolValue.WellKnownToStringTag,
       TGocciaStringLiteralValue.Create('TSV'),
       [pfConfigurable]);
-    FStaticMembers := Members.ToDefinitions;
+    RegisterMemberDefinitions(FBuiltinObject, Members.ToDefinitions);
   finally
     Members.Free;
   end;
-
-  RegisterMemberDefinitions(FBuiltinObject, FStaticMembers);
   if ADefineGlobalBinding then
     AScope.DefineLexicalBinding(AName, FBuiltinObject, dtLet, True);
 end;
@@ -499,8 +488,5 @@ begin
     Result := TGocciaStringLiteralValue.Create(
       TGocciaTSVStringifier.Stringify(Data, Headers));
 end;
-
-initialization
-  RegisterThreadvarCleanup(@ClearThreadvarMembers);
 
 end.

--- a/source/units/Goccia.Builtins.YAML.pas
+++ b/source/units/Goccia.Builtins.YAML.pas
@@ -37,18 +37,9 @@ uses
 
   Goccia.Error.Messages,
   Goccia.Error.Suggestions,
-  Goccia.ThreadCleanupRegistry,
   Goccia.Values.ErrorHelper,
   Goccia.Values.ObjectPropertyDescriptor,
   Goccia.Values.SymbolValue;
-
-threadvar
-  FStaticMembers: TArray<TGocciaMemberDefinition>;
-
-procedure ClearThreadvarMembers;
-begin
-  SetLength(FStaticMembers, 0);
-end;
 
 constructor TGocciaYAMLBuiltin.Create(const AName: string;
   const AScope: TGocciaScope; const AThrowError: TGocciaThrowErrorCallback;
@@ -68,12 +59,10 @@ begin
       TGocciaSymbolValue.WellKnownToStringTag,
       TGocciaStringLiteralValue.Create('YAML'),
       [pfConfigurable]);
-    FStaticMembers := Members.ToDefinitions;
+    RegisterMemberDefinitions(FBuiltinObject, Members.ToDefinitions);
   finally
     Members.Free;
   end;
-
-  RegisterMemberDefinitions(FBuiltinObject, FStaticMembers);
   if ADefineGlobalBinding then
     AScope.DefineLexicalBinding(AName, FBuiltinObject, dtLet, True);
 end;
@@ -121,8 +110,5 @@ begin
       ThrowSyntaxError(E.Message, SSuggestYAMLSyntax);
   end;
 end;
-
-initialization
-  RegisterThreadvarCleanup(@ClearThreadvarMembers);
 
 end.

--- a/source/units/Goccia.ThreadCleanupLeak.Test.pas
+++ b/source/units/Goccia.ThreadCleanupLeak.Test.pas
@@ -2,9 +2,10 @@
   a thread tears down its runtime.
 
   FPC does not auto-finalize managed threadvars at thread exit, so the per-thread
-  member-definition arrays that every builtin and value type caches
-  (FStaticMembers / FPrototypeMembers : TArray<TGocciaMemberDefinition>, whose
-  records hold strings) stay allocated unless something clears them.
+  prototype-definition arrays that some value types retain
+  (FPrototypeMembers : TArray<TGocciaMemberDefinition>, whose records hold strings)
+  stay allocated unless something clears them. Builtin static-member definitions
+  are temporary constructor data and are released without registry cleanup.
   ShutdownThreadRuntime drains Goccia.ThreadCleanupRegistry on each worker thread,
   and the registry's finalization drains it on the main thread, so the registered
   ClearThreadvarMembers procs release those arrays on whichever thread tears down.
@@ -74,26 +75,22 @@ end;
 
 procedure TLeakTests.TestDrainReclaimsMemberDefinitionThreadvars;
 const
-  // One engine (with the heavyweight globals materialized below) populates many
-  // member-definition arrays (records with strings) whose combined heap is well
-  // above this floor, while collector/allocator noise around a single Collect
-  // stays at the ~1 KiB scale of the idempotent test's tolerance. The floor was
-  // 8 KiB when every builtin was constructed eagerly; lazy materialization
-  // (#747/#790) shrank the boot-time eager footprint, and on 32-bit targets the
-  // smaller records put the eager set just under 8 KiB. 4 KiB stays comfortably
-  // above noise on every target while still catching a regressed (no-op) drain.
+  // Materializing the lazy globals also builds the remaining retained prototype
+  // definitions (including Temporal.PlainDate). Their managed records and strings
+  // exceed this floor even without temporary builtin static-member arrays.
+  // Keep the floor above the idempotent test's collector/allocator tolerance so
+  // a regressed (no-op) drain still fails.
   MIN_RECLAIMED_BYTES = 4 * 1024;
 var
   Populated, Drained: Int64;
 begin
-  // Building a throwaway engine registers every builtin and value type, which
-  // populates this thread's FStaticMembers / FPrototypeMembers threadvars. The
-  // engine objects themselves are freed inside the call; the member-definition
-  // arrays are threadvars and outlive it (the leak this issue is about).
+  // Building a throwaway engine populates the retained FPrototypeMembers
+  // threadvars. The engine objects themselves are freed inside the call; the
+  // retained definition arrays outlive it (the leak this issue is about).
   // Materialize the heavyweight globals too: they are built lazily now
   // (#747/#790), so a bare engine constructor no longer populates their
   // member-definition threadvars. Touching them keeps this leak gate exercising
-  // the largest threadvar populators (Temporal's classes, Intl's constructors).
+  // retained prototype definitions such as Temporal.PlainDate's.
   EnsureSharedPrototypesInitialized(MaterializeLazyBuiltins);
   TGarbageCollector.Instance.Collect;
   Populated := Int64(GetHeapStatus.TotalAllocated);
@@ -116,7 +113,7 @@ var
   I: Integer;
 begin
   // Reading each lazy global through the scope forces its backing object to
-  // materialize, populating that builtin's member-definition threadvars.
+  // materialize, including any retained prototype-definition threadvars.
   for I := Low(LazyGlobals) to High(LazyGlobals) do
     AEngine.Interpreter.GlobalScope.GetValue(LazyGlobals[I]);
 end;


### PR DESCRIPTION
## Summary

- Release temporary member-definition arrays after construction across twenty builtins, removing obsolete per-thread cleanup. Most builders register their definitions directly; BigInt keeps a constructor-local array for its existing `asIntN`/`asUintN` name overrides.
- Preserve all 157 member declarations and their order, callbacks, arities, flags and aliases, plus live Symbol registry state and retained prototype cleanup. Update construction guidance and lifecycle-test comments without changing the original leak assertions.
- Separate manual diff review found no actionable issues. No linked issue; this implements the approved temporary-definition audit finding.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [x] Updated documentation
- [x] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change

Clean production test-runner build passed. Full production JavaScript suites passed in both modes with one worker: **12,818 tests, 28,573 assertions each**. The checked development build and its FFI fixture also passed, as did an earlier full development interpreter run. Native development checks passed: thread cleanup leak **3/3**, shared prototype realm reuse **1/1**, and threading **15/15**. Formatter **463 files**, diff check, and all ordinary commit hooks passed. No performance claim is made.

An initial development bytecode attempt was interrupted to reduce host contention. A later two-worker development interpreter attempt failed with `EObjectCheck` in `AsyncHooks/run.js`; the unchanged audit baseline also exhibited worker failures. Focused reruns of that file passed with both default workers and two workers, and the final clean production suites above passed in both modes. All 49 CI checks passed at `78e84ee88107149e50c60b3be3f08cbfb97116b5`; readiness review is complete.
