### PR TITLE
perf(website): cache dashboard history in immutable snapshots

### DIFF
--- a/docs/adr/0115-immutable-blob-history-snapshots.md
+++ b/docs/adr/0115-immutable-blob-history-snapshots.md
@@ -33,7 +33,8 @@ chunks of at most 128 pointers. The SHA-256 digest of each chunk's ordered
 ```
 
 Snapshots contain the fingerprint and the corresponding parsed pointer
-records. Their serialized content is deterministic and bounded to 1 MiB before
+records. The JetStream adapter omits the duplicate `reportJson` payload that
+legacy daily pointers embed; full reports and raw pointers remain unchanged. Their serialized content is deterministic and bounded to 1 MiB before
 compression. Readers check the version, fingerprint, exact descriptor sequence,
 and report-specific schemas, and bound gzip expansion. Missing, invalid, or
 unreadable snapshots fall back to raw pointers. Unknown historical path shapes,

--- a/docs/adr/0115-immutable-blob-history-snapshots.md
+++ b/docs/adr/0115-immutable-blob-history-snapshots.md
@@ -1,0 +1,82 @@
+# Immutable Blob history snapshots
+
+**Date:** 2026-09-04
+**Area:** `website`, `report-publishing`
+
+AWFY, JetStream, and test262 dashboards keep raw daily pointers as their source
+of truth and use immutable monthly snapshots to reduce history downloads.
+[The shared history helper](../../website/src/lib/blob-history.ts) owns bounded
+reads and projections; each Blob store keeps its report schema and validation.
+
+## Context
+
+The previous readers listed every daily pointer and fetched them serially.
+That made request latency grow with the number of retained runs. Simply keeping
+only recent or successful runs would lose useful history. A mutable summary
+index would need coordination between concurrent and out-of-order publishers.
+
+The installed `@vercel/blob` 2.4.0 source exposes ETags in
+`ListBlobResultBlob`, PUT results, and GET response metadata. Its `get` API
+only bypasses caching for private blobs: `useCache: false` does not make public
+pointer reads fresh. Consequently, an index writer must not associate an old
+CDN response with a newer listed pointer version.
+
+## Decision
+
+Readers still list all raw pointers under each report's `daily/` prefix. Strong
+ETags and pathnames are sorted lexically within each month and divided into
+chunks of at most 128 pointers. The SHA-256 digest of each chunk's ordered
+`[pathname, etag]` pairs names its snapshot:
+
+```text
+<prefix>/history/v1/<YYYY-MM>/<sha256>.json.gz
+```
+
+Snapshots contain the fingerprint and the corresponding parsed pointer
+records. Their serialized content is deterministic and bounded to 1 MiB before
+compression. Readers check the version, fingerprint, exact descriptor sequence,
+and report-specific schemas, and bound gzip expansion. Missing, invalid, or
+unreadable snapshots fall back to raw pointers. Unknown historical path shapes,
+missing ETags, and weak ETags also use raw reads. Malformed raw pointers remain
+excluded as before; transport failures on raw reads still propagate.
+
+Changes to projection semantics, including which raw records qualify, require
+a new snapshot version.
+
+Snapshot and raw reads each run in batches of at most eight per report family.
+Results preserve original listing order before the existing timestamp and run
+number sort, including ties. No retained run is removed for age or failure.
+A snapshot hit needs no per-pointer GETs; listing remains linear in raw pointer
+count, while downloads become one per valid chunk.
+
+CI publishers write the full reports and existing daily pointers first, then
+attempt snapshots only for affected months. They verify every fetched ETag
+against its listed descriptor. Just-written pointer bytes can be reused when
+the PUT ETag matches the listing. A stale public response leaves that generation
+uncached. Snapshot errors cannot turn a successful raw publication into failure.
+The explicit [rebuild command](../../website/scripts/rebuild-history-snapshots.ts)
+uses the same checks to populate older months and repair unavailable snapshots;
+request handling never writes projections.
+
+Distinct generations have distinct paths, so late or concurrent writers cannot
+overwrite the current generation with an older one. Simultaneous writes to the
+same path describe identical pointer versions and serialize identically. There
+is no mutable latest-index pointer or compare-and-swap loop. Existing AWFY and
+test262 daily overwrite behavior, JetStream's per-run daily paths, profile
+publication, and each store's access settings remain unchanged.
+
+## Consequences
+
+Every raw report and pointer remains available under its existing contract.
+Snapshot failure costs bounded fallback reads, with no new availability
+requirement. Blob listing and raw reads retain their existing consistency
+properties; this projection does not promise a transactional cross-page view.
+
+All snapshot generations are retained. Each chunk is bounded, but total storage
+is not: publishing repeatedly within a month retains prior generations, and
+out-of-order inserts may change several sorted chunks. In the worst case, bytes
+retained across a month's publications grow quadratically with its pointer
+count. This is a deliberate storage-for-request-latency tradeoff. There is no
+automatic garbage collection or raw-data deletion. Operators can observe growth
+under `history/v1/`; any future retention policy needs a separate decision that
+accounts for readers using an earlier listing and concurrent publishers.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -124,3 +124,4 @@ Durable architecture and implementation decisions for GocciaScript. New ADRs use
 - [0112 — Native AsyncLocalStorage over continuation snapshots](0112-native-async-local-storage.md)
 - [0113 — Deterministic virtual timer queue](0113-deterministic-virtual-timer-queue.md)
 - [0114 — Unmanaged execution-context records](0114-unmanaged-execution-context-records.md)
+- [0115 — Immutable Blob history snapshots](0115-immutable-blob-history-snapshots.md)

--- a/website/README.md
+++ b/website/README.md
@@ -68,6 +68,36 @@ Two settings live outside this repo:
   logs that it skipped, and the release reaches the site on its next
   deployment instead.
 
+## Dashboard history snapshots
+
+AWFY, JetStream, and test262 history reads use optional monthly Blob snapshots
+and at most eight simultaneous reads per report family. Raw daily pointers
+remain authoritative; missing or invalid snapshots fall back to those pointers.
+CI publishers populate snapshots after uploading reports and daily pointers.
+Request handling only reads Blob storage.
+
+To populate snapshots for existing history, run this from `website/` with
+`BLOB_READ_WRITE_TOKEN` configured:
+
+```bash
+bun run rebuild-history
+```
+
+The command uses the same `AWFY_BLOB_PREFIX` / `AWFY_BLOB_ACCESS`,
+`JETSTREAM_BLOB_PREFIX` / `JETSTREAM_BLOB_ACCESS`, and
+`TEST262_BLOB_PREFIX` / `TEST262_BLOB_ACCESS` settings as publication. It writes
+only missing or invalid snapshot generations, never raw reports or pointers.
+An unchanged rebuild reuses existing snapshots. Stale pointer reads, missing
+strong ETags, and oversized generations are skipped; retry after the underlying
+pointers become readable. Transport or upload failures exit nonzero.
+
+Snapshot generations are retained, with no automatic deletion or retention cap.
+Each stores at most 128 pointer records and 1 MiB of uncompressed JSON. Storage
+grows with publication frequency and with late arrivals that change sorted
+monthly partitions. Monitor the `history/v1/` prefixes alongside raw report
+storage. [ADR 0115](../docs/adr/0115-immutable-blob-history-snapshots.md) records
+the concurrency contract, fallback behavior, and storage tradeoff.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/website/package.json
+++ b/website/package.json
@@ -8,6 +8,7 @@
     "publish-awfy": "bun scripts/publish-awfy-report.ts",
     "publish-jetstream": "bun scripts/publish-jetstream-report.ts",
     "publish-web-tooling": "bun scripts/publish-web-tooling-report.ts",
+    "rebuild-history": "bun scripts/rebuild-history-snapshots.ts",
     "backfill-test262": "bun scripts/backfill-test262-dashboard.ts",
     "prebuild": "bun scripts/fetch-binaries.ts",
     "dev": "bun --bun next dev",

--- a/website/scripts/rebuild-history-snapshots.ts
+++ b/website/scripts/rebuild-history-snapshots.ts
@@ -1,0 +1,31 @@
+#!/usr/bin/env bun
+import { rebuildAwfyBlobHistory } from "../src/lib/awfy-blob-store";
+import { rebuildJetStreamBlobHistory } from "../src/lib/jetstream-blob-store";
+import { rebuildTest262BlobHistory } from "../src/lib/test262-blob-store";
+
+const args = process.argv.slice(2);
+if (args.length === 1 && (args[0] === "--help" || args[0] === "-h")) {
+  console.log(
+    "Usage: bun run rebuild-history\n\nRebuild optional AWFY, JetStream, and test262 history snapshots.\nRequires BLOB_READ_WRITE_TOKEN; uses each report's existing BLOB_PREFIX and BLOB_ACCESS settings.",
+  );
+  process.exit(0);
+}
+if (args.length || !process.env.BLOB_READ_WRITE_TOKEN) {
+  console.error(
+    "rebuild-history takes no arguments and requires BLOB_READ_WRITE_TOKEN; see --help",
+  );
+  process.exit(2);
+}
+
+for (const [name, rebuild] of [
+  ["AWFY", rebuildAwfyBlobHistory],
+  ["JetStream", rebuildJetStreamBlobHistory],
+  ["test262", rebuildTest262BlobHistory],
+] as const) {
+  console.error(
+    `[rebuild-history] ${name}: wrote ${await rebuild()} snapshots`,
+  );
+}
+console.error(
+  "[rebuild-history] Existing, unstable, and oversized generations are skipped; raw reports are unchanged.",
+);

--- a/website/src/__tests__/blob-history.test.ts
+++ b/website/src/__tests__/blob-history.test.ts
@@ -204,7 +204,12 @@ async function load(kind: Kind) {
     ).listJetStreamBlobDailyRuns();
   return (await import("@/lib/test262-blob-store")).listTest262BlobDailyRuns();
 }
-async function publish(kind: Kind, id: number, createdAt?: string) {
+async function publish(
+  kind: Kind,
+  id: number,
+  createdAt?: string,
+  reportJson = '{"targets":[]}',
+) {
   const meta = metadata(id, createdAt);
   if (kind === "test262") {
     const report = { summary: conformanceSummary, results: [] };
@@ -225,7 +230,7 @@ async function publish(kind: Kind, id: number, createdAt?: string) {
   const entry = {
     ...meta,
     summary: workloadSummary,
-    reportJson: '{"targets":[]}',
+    reportJson,
   };
   if (kind === "jetstream")
     return (
@@ -502,4 +507,25 @@ test("oversized generations remain available through raw reads", async () => {
   expect(await rebuild("jetstream")).toBe(0);
   expect(snapshots()).toHaveLength(0);
   expect((await load("jetstream")).map((run) => run.runId)).toEqual([1]);
+});
+
+test("projects large JetStream reports without duplicating their raw payload in history", async () => {
+  const reportJson = JSON.stringify({
+    targets: [],
+    retainedPayload: "x".repeat(1024 * 1024),
+  });
+  await publish("jetstream", 1, undefined, reportJson);
+  const raw = blobs.get("jetstream/daily/2026-09-01/1.json");
+  expect(raw).toBeDefined();
+  expect(JSON.parse(raw?.body.toString() ?? "{}").reportJson).toBe(reportJson);
+  expect(snapshots()).toHaveLength(1);
+  gets.length = 0;
+  const runs = await load("jetstream");
+  expect(runs.map((run) => run.runId)).toEqual([1]);
+  expect("reportJson" in runs[0]).toBe(false);
+  expect(rawGets()).toHaveLength(0);
+  blobs.delete(snapshots()[0]);
+  expect(await rebuild("jetstream")).toBe(1);
+  expect(blobs.get("jetstream/daily/2026-09-01/1.json")).toEqual(raw);
+  expect(blobs.has("jetstream/runs/1/report.json.gz")).toBe(true);
 });

--- a/website/src/__tests__/blob-history.test.ts
+++ b/website/src/__tests__/blob-history.test.ts
@@ -1,0 +1,505 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { gunzipSync, gzipSync } from "node:zlib";
+
+type Kind = "awfy" | "jetstream" | "test262";
+type StoredBlob = { body: Buffer; etag: string };
+const blobs = new Map<string, StoredBlob>();
+const stale = new Map<string, StoredBlob>();
+const gets: string[] = [];
+const writes: string[] = [];
+let active = 0;
+let maximum = 0;
+let pageSize = 1000;
+let omitEtags = false;
+let weakEtags = false;
+let changedGeneration = false;
+const accesses: string[] = [];
+let rawFailure: string | null = null;
+let snapshotFailure = false;
+let beforeSnapshotWrite: (() => Promise<void>) | null = null;
+const environment = { ...process.env };
+const envNames = [
+  "AWFY_BLOB_PREFIX",
+  "JETSTREAM_BLOB_PREFIX",
+  "TEST262_BLOB_PREFIX",
+  "AWFY_BLOB_ACCESS",
+  "JETSTREAM_BLOB_ACCESS",
+  "TEST262_BLOB_ACCESS",
+];
+
+class BlobNotFoundError extends Error {}
+function store(pathname: string, body: string | Buffer) {
+  const bytes = Buffer.from(body);
+  blobs.set(pathname, {
+    body: bytes,
+    etag: createHash("sha256").update(bytes).digest("hex"),
+  });
+}
+
+mock.module("@vercel/blob", () => ({
+  BlobNotFoundError,
+  list: async ({ prefix, cursor }: { prefix: string; cursor?: string }) => {
+    const entries = [...blobs.entries()]
+      .filter(([pathname]) => pathname.startsWith(prefix))
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+    const offset = Number(cursor ?? 0);
+    return {
+      blobs: entries
+        .slice(offset, offset + pageSize)
+        .map(([pathname, value]) => ({
+          pathname,
+          etag: omitEtags
+            ? undefined
+            : weakEtags
+              ? `W/"${value.etag}"`
+              : value.etag,
+        })),
+      cursor: String(offset + pageSize),
+      hasMore: offset + pageSize < entries.length,
+    };
+  },
+  get: async (pathname: string, options: { access: string }) => {
+    accesses.push(options.access);
+    gets.push(pathname);
+    active++;
+    maximum = Math.max(maximum, active);
+    try {
+      await new Promise((resolve) => setTimeout(resolve, gets.length % 3));
+      if (
+        pathname === rawFailure ||
+        (snapshotFailure && pathname.includes("/history/"))
+      )
+        throw new Error("transport failed");
+      const blob = stale.get(pathname) ?? blobs.get(pathname);
+      if (!blob) throw new BlobNotFoundError();
+      return {
+        statusCode: 200,
+        stream: new Response(new Uint8Array(blob.body)).body,
+        blob: { etag: `"${blob.etag}"`, size: blob.body.byteLength },
+      };
+    } finally {
+      active--;
+    }
+  },
+  put: async (
+    pathname: string,
+    body: string | Buffer,
+    options: { access: string },
+  ) => {
+    accesses.push(options.access);
+    if (pathname.includes("/history/")) {
+      if (snapshotFailure) throw new Error("projection upload failed");
+      await beforeSnapshotWrite?.();
+      const previous = blobs.get(pathname);
+      if (previous && !previous.body.equals(Buffer.from(body))) {
+        changedGeneration = true;
+        throw new Error("generation content changed");
+      }
+    }
+    writes.push(pathname);
+    store(pathname, body);
+    return {
+      pathname,
+      url: `https://blob.test/${pathname}`,
+      downloadUrl: `https://blob.test/${pathname}`,
+      etag: blobs.get(pathname)?.etag,
+    };
+  },
+}));
+
+beforeEach(() => {
+  blobs.clear();
+  stale.clear();
+  gets.length = 0;
+  writes.length = 0;
+  active = 0;
+  maximum = 0;
+  pageSize = 1000;
+  omitEtags = false;
+  weakEtags = false;
+  changedGeneration = false;
+  accesses.length = 0;
+  rawFailure = null;
+  snapshotFailure = false;
+  beforeSnapshotWrite = null;
+  for (const name of envNames) delete process.env[name];
+});
+afterAll(() => {
+  for (const name of envNames) {
+    if (environment[name] === undefined) delete process.env[name];
+    else process.env[name] = environment[name];
+  }
+});
+
+function metadata(
+  id: number,
+  createdAt = `2026-09-01T00:${String(id % 60).padStart(2, "0")}:00.000Z`,
+) {
+  return {
+    runId: id,
+    runNumber: id,
+    artifactId: id,
+    title: "CI",
+    headSha: "sha",
+    shortSha: "sha",
+    runUrl: `https://example.test/${id}`,
+    createdAt,
+    updatedAt: createdAt,
+    artifactCreatedAt: createdAt,
+  };
+}
+const workloadSummary = {
+  workloadCount: 1,
+  failedWorkloadCount: 1,
+  repetitions: 1,
+  referenceRatios: { quickjs: null, node: null },
+  engineVersions: {},
+  corpusCommit: "corpus",
+  driverVersion: 1,
+  targetNames: ["failed"],
+};
+const conformanceSummary = {
+  totalDiscovered: 1,
+  totalRun: 1,
+  passed: 0,
+  failed: 1,
+  wrapperInfraFailures: 0,
+  timeouts: 0,
+  durationSeconds: 1,
+  byCategory: [],
+};
+function rawRun(kind: Kind, id: number, createdAt?: string) {
+  const meta = metadata(id, createdAt);
+  return {
+    ...meta,
+    summary: kind === "test262" ? conformanceSummary : workloadSummary,
+    report: {
+      path: `${kind}/runs/${id}/report.json.gz`,
+      url: "https://blob.test/report",
+      downloadUrl: "https://blob.test/report",
+      size: 10,
+    },
+    reportPath: `${kind}/runs/${id}.json.gz`,
+    reportUrl: "https://blob.test/report",
+    reportDownloadUrl: "https://blob.test/report",
+    reportCompressedSize: 10,
+    publishedAt: meta.updatedAt,
+    jsonUrl: `/api/test262/results/${id}`,
+  };
+}
+function seed(
+  kind: Kind,
+  id: number,
+  pathname = `${kind}/daily/2026-09-01/${id}.json`,
+) {
+  store(pathname, JSON.stringify(rawRun(kind, id)));
+}
+async function load(kind: Kind) {
+  if (kind === "awfy")
+    return (await import("@/lib/awfy-blob-store")).listAwfyBlobDailyRuns();
+  if (kind === "jetstream")
+    return (
+      await import("@/lib/jetstream-blob-store")
+    ).listJetStreamBlobDailyRuns();
+  return (await import("@/lib/test262-blob-store")).listTest262BlobDailyRuns();
+}
+async function publish(kind: Kind, id: number, createdAt?: string) {
+  const meta = metadata(id, createdAt);
+  if (kind === "test262") {
+    const report = { summary: conformanceSummary, results: [] };
+    return (
+      await import("@/lib/test262-blob-store")
+    ).publishTest262ReportsToBlob([
+      {
+        point: {
+          ...meta,
+          summary: report.summary,
+          jsonUrl: `/api/test262/results/${id}`,
+        },
+        report,
+        reportJson: JSON.stringify(report),
+      },
+    ]);
+  }
+  const entry = {
+    ...meta,
+    summary: workloadSummary,
+    reportJson: '{"targets":[]}',
+  };
+  if (kind === "jetstream")
+    return (
+      await import("@/lib/jetstream-blob-store")
+    ).publishJetStreamReportsToBlob([entry]);
+  return (await import("@/lib/awfy-blob-store")).publishAwfyReportsToBlob([
+    {
+      ...entry,
+      summary: {
+        ...workloadSummary,
+        targetCount: 1,
+        awfyCount: 1,
+        probeCount: 0,
+      },
+    },
+  ]);
+}
+async function rebuild(kind: Kind) {
+  if (kind === "awfy")
+    return (await import("@/lib/awfy-blob-store")).rebuildAwfyBlobHistory();
+  if (kind === "jetstream")
+    return (
+      await import("@/lib/jetstream-blob-store")
+    ).rebuildJetStreamBlobHistory();
+  return (await import("@/lib/test262-blob-store")).rebuildTest262BlobHistory();
+}
+function snapshots() {
+  return [...blobs.keys()].filter((path) => path.includes("/history/"));
+}
+function rawGets() {
+  return gets.filter((path) => path.includes("/daily/"));
+}
+
+for (const kind of ["awfy", "jetstream", "test262"] as const) {
+  describe(`${kind} history`, () => {
+    test("bounds fallback reads across pages and preserves every degraded run", async () => {
+      pageSize = 11;
+      omitEtags = true;
+      for (let id = 1; id <= 35; id++) seed(kind, id);
+      store(`${kind}/daily/corrupt.json`, "{");
+      const runs = await load(kind);
+      expect(runs.map((run) => run.runId)).toEqual(
+        Array.from({ length: 35 }, (_, index) => index + 1),
+      );
+      expect(
+        runs.every((run) =>
+          "failedWorkloadCount" in run.summary
+            ? run.summary.failedWorkloadCount === 1
+            : run.summary.failed === 1,
+        ),
+      ).toBe(true);
+      expect(maximum).toBe(8);
+      expect(rawGets()).toHaveLength(36);
+    });
+
+    test("serves an unchanged month from one immutable snapshot", async () => {
+      for (let id = 1; id <= 24; id++) seed(kind, id);
+      await publish(kind, 25);
+      expect(snapshots()).toHaveLength(1);
+      const path = snapshots()[0];
+      expect(path).toMatch(
+        new RegExp(`^${kind}/history/v1/2026-09/[a-f0-9]{64}\\.json\\.gz$`),
+      );
+      gets.length = 0;
+      expect(await load(kind)).toHaveLength(25);
+      expect(gets).toEqual([path]);
+    });
+
+    test("falls back for missing, corrupt, and mismatched snapshots", async () => {
+      seed(kind, 1);
+      await publish(kind, 2);
+      const path = snapshots()[0];
+      const original = blobs.get(path);
+      if (!original) throw new Error("expected snapshot");
+      const payload = JSON.parse(gunzipSync(original.body).toString());
+      for (const body of [
+        null,
+        Buffer.from("corrupt"),
+        gzipSync(JSON.stringify({ ...payload, fingerprint: "wrong" })),
+        gzipSync(JSON.stringify({ ...payload, pointers: [] })),
+        gzipSync(
+          JSON.stringify({
+            ...payload,
+            pointers: payload.pointers.map((pointer: object) => ({
+              ...pointer,
+              run: {},
+            })),
+          }),
+        ),
+        gzipSync(Buffer.alloc(1024 * 1024 + 1)),
+      ]) {
+        if (body) store(path, body);
+        else blobs.delete(path);
+        gets.length = 0;
+        expect((await load(kind)).map((run) => run.runId)).toEqual([1, 2]);
+        expect(rawGets()).toHaveLength(2);
+      }
+    });
+
+    test("rebuilds old months without changing raw data or the access boundary", async () => {
+      process.env[`${kind.toUpperCase()}_BLOB_PREFIX`] = "custom";
+      process.env[`${kind.toUpperCase()}_BLOB_ACCESS`] = "private";
+      seed(kind, 1, "custom/daily/2026-08-01.json");
+      seed(kind, 2, "custom/daily/2026-09-01.json");
+      const original = [...blobs.entries()];
+      expect(await rebuild(kind)).toBe(2);
+      expect(await rebuild(kind)).toBe(0);
+      expect(writes).toHaveLength(2);
+      expect(
+        writes.every((path) => path.startsWith("custom/history/v1/")),
+      ).toBe(true);
+      for (const [path, blob] of original)
+        expect(blobs.get(path)).toEqual(blob);
+      gets.length = 0;
+      expect((await load(kind)).map((run) => run.runId)).toEqual([1, 2]);
+      expect(gets).toHaveLength(2);
+      expect(accesses.every((access) => access === "private")).toBe(true);
+    });
+
+    test("propagates raw transport errors without starting another batch", async () => {
+      omitEtags = true;
+      for (let id = 1; id <= 20; id++) seed(kind, id);
+      rawFailure = `${kind}/daily/2026-09-01/1.json`;
+      await expect(load(kind)).rejects.toThrow("transport failed");
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      expect(rawGets()).toHaveLength(8);
+      expect(maximum).toBe(8);
+    });
+  });
+}
+
+test("late concurrent snapshots cannot replace the current generation", async () => {
+  let release = () => {};
+  let started = () => {};
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const ready = new Promise<void>((resolve) => {
+    started = resolve;
+  });
+  beforeSnapshotWrite = async () => {
+    beforeSnapshotWrite = null;
+    started();
+    await gate;
+  };
+  const older = publish("jetstream", 1, "2026-09-02T00:00:00.000Z");
+  await ready;
+  await publish("jetstream", 2, "2026-09-01T00:00:00.000Z");
+  release();
+  await older;
+  expect(snapshots()).toHaveLength(2);
+  gets.length = 0;
+  expect((await load("jetstream")).map((run) => run.runId)).toEqual([2, 1]);
+  expect(rawGets()).toHaveLength(0);
+});
+
+test("does not cache stale public pointer bytes under a new fingerprint", async () => {
+  await publish("jetstream", 1);
+  const path = "jetstream/daily/2026-09-01/1.json";
+  const old = blobs.get(path);
+  if (!old) throw new Error("expected raw pointer");
+  stale.set(path, old);
+  store(path, JSON.stringify(rawRun("jetstream", 10)));
+  await publish("jetstream", 2);
+  expect(snapshots()).toHaveLength(1);
+  stale.clear();
+  await publish("jetstream", 3);
+  gets.length = 0;
+  expect((await load("jetstream")).map((run) => run.runId)).toEqual([2, 3, 10]);
+  expect(rawGets()).toHaveLength(0);
+});
+
+test("bounds snapshot partitions to 128 pointers", async () => {
+  for (let id = 1; id <= 129; id++) seed("jetstream", id);
+  await publish("jetstream", 130);
+  expect(snapshots()).toHaveLength(2);
+  expect(
+    snapshots()
+      .map(
+        (path) =>
+          JSON.parse(
+            gunzipSync(blobs.get(path)?.body ?? Buffer.alloc(0)).toString(),
+          ).pointers.length,
+      )
+      .sort((a, b) => a - b),
+  ).toEqual([2, 128]);
+  gets.length = 0;
+  expect(await load("jetstream")).toHaveLength(130);
+  expect(gets).toHaveLength(2);
+});
+
+test("projection failures leave successful raw publication available", async () => {
+  snapshotFailure = true;
+  const warning = console.warn;
+  console.warn = () => {};
+  try {
+    expect(await publish("jetstream", 1)).toHaveLength(1);
+  } finally {
+    console.warn = warning;
+  }
+  expect(blobs.has("jetstream/runs/1/report.json.gz")).toBe(true);
+  expect((await load("jetstream")).map((run) => run.runId)).toEqual([1]);
+});
+
+test("keeps established daily overwrite and per-run publication shapes", async () => {
+  for (const kind of ["awfy", "test262", "jetstream"] as const) {
+    await publish(kind, 1);
+    await publish(kind, 2);
+    expect((await load(kind)).map((run) => run.runId)).toEqual(
+      kind === "jetstream" ? [1, 2] : [2],
+    );
+    expect(
+      [...blobs.keys()].filter((path) => path.startsWith(`${kind}/runs/`)),
+    ).toHaveLength(2);
+  }
+});
+
+test("preserves listing order for equal timestamps and run numbers across cached and legacy pointers", async () => {
+  for (const [id, pathname] of [
+    [3, "jetstream/daily/000-legacy.json"],
+    [1, "jetstream/daily/2026-09-01/1.json"],
+    [2, "jetstream/daily/2026-09-01/2.json"],
+  ] as const) {
+    store(
+      pathname,
+      JSON.stringify({
+        ...rawRun("jetstream", id, "2026-09-01T00:00:00Z"),
+        runNumber: 1,
+      }),
+    );
+  }
+  await rebuild("jetstream");
+  gets.length = 0;
+  expect((await load("jetstream")).map((run) => run.runId)).toEqual([3, 1, 2]);
+  expect(rawGets()).toEqual(["jetstream/daily/000-legacy.json"]);
+});
+
+test("does not build or select a snapshot from weak ETags", async () => {
+  weakEtags = true;
+  seed("jetstream", 1);
+  expect(await rebuild("jetstream")).toBe(0);
+  expect((await load("jetstream")).map((run) => run.runId)).toEqual([1]);
+  expect(gets).toEqual(["jetstream/daily/2026-09-01/1.json"]);
+});
+
+test("simultaneous rebuilds of one generation write identical bytes", async () => {
+  seed("jetstream", 1);
+  let arrivals = 0;
+  let release = () => {};
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  beforeSnapshotWrite = async () => {
+    if (++arrivals === 2) release();
+    await gate;
+  };
+  const results = await Promise.all([
+    rebuild("jetstream"),
+    rebuild("jetstream"),
+  ]);
+  expect(results).toEqual([1, 1]);
+  expect(snapshots()).toHaveLength(1);
+  expect(changedGeneration).toBe(false);
+});
+
+test("oversized generations remain available through raw reads", async () => {
+  store(
+    "jetstream/daily/2026-09-01/1.json",
+    JSON.stringify({
+      ...rawRun("jetstream", 1),
+      title: "x".repeat(1024 * 1024),
+    }),
+  );
+  expect(await rebuild("jetstream")).toBe(0);
+  expect(snapshots()).toHaveLength(0);
+  expect((await load("jetstream")).map((run) => run.runId)).toEqual([1]);
+});

--- a/website/src/lib/awfy-blob-store.ts
+++ b/website/src/lib/awfy-blob-store.ts
@@ -1,5 +1,10 @@
 import { gunzipSync, gzipSync } from "node:zlib";
-import { BlobNotFoundError, get, list, put } from "@vercel/blob";
+import { BlobNotFoundError, get, put } from "@vercel/blob";
+import {
+  listBlobHistory,
+  publishBlobHistorySnapshots,
+  rebuildBlobHistorySnapshots,
+} from "./blob-history";
 
 export type AwfyBlobAccess = "public" | "private";
 
@@ -137,11 +142,6 @@ async function readBlobBytes(pathname: string): Promise<Uint8Array | null> {
   }
 }
 
-async function readBlobText(pathname: string): Promise<string | null> {
-  const bytes = await readBlobBytes(pathname);
-  return bytes ? new TextDecoder().decode(bytes) : null;
-}
-
 function isAwfyBlobRun(value: unknown): value is AwfyBlobRun {
   if (!value || typeof value !== "object") return false;
   const run = value as Record<string, unknown>;
@@ -163,31 +163,18 @@ export async function readAwfyBlobReportJson(
   return bytes ? gunzipSync(bytes).toString("utf8") : null;
 }
 
+export async function rebuildAwfyBlobHistory(): Promise<number> {
+  return rebuildBlobHistorySnapshots(
+    awfyBlobPrefix(),
+    awfyBlobAccess(),
+    isAwfyBlobRun,
+  );
+}
+
 export async function listAwfyBlobDailyRuns(
   prefix = awfyBlobPrefix(),
 ): Promise<AwfyBlobRun[]> {
-  const runs: AwfyBlobRun[] = [];
-  let cursor: string | undefined;
-  do {
-    const page = await list({
-      cursor,
-      limit: 1000,
-      prefix: `${awfyBlobDailyPrefix(prefix)}/`,
-    });
-    cursor = page.cursor;
-    for (const blob of page.blobs) {
-      const text = await readBlobText(blob.pathname);
-      if (!text) continue;
-      try {
-        const parsed: unknown = JSON.parse(text);
-        if (isAwfyBlobRun(parsed)) runs.push(parsed);
-      } catch {
-        // Ignore malformed historical pointers and retain the valid timeline.
-      }
-    }
-    if (!page.hasMore) break;
-  } while (cursor);
-  return runs.sort(byCreatedAtThenRunNumber);
+  return listBlobHistory(prefix, awfyBlobAccess(), isAwfyBlobRun);
 }
 
 export async function publishAwfyReportsToBlob(
@@ -196,6 +183,7 @@ export async function publishAwfyReportsToBlob(
   const prefix = awfyBlobPrefix();
   const access = awfyBlobAccess();
   const publishedRuns: AwfyBlobRun[] = [];
+  const pointers: { pathname: string; etag: string; run: AwfyBlobRun }[] = [];
 
   for (const entry of entries) {
     const reportPath = awfyBlobReportPathForArtifactId(
@@ -230,18 +218,17 @@ export async function publishAwfyReportsToBlob(
       },
       publishedAt: new Date().toISOString(),
     };
-    await put(
-      dailyPathForRun(published, prefix),
-      JSON.stringify(published, null, 2),
-      {
-        access,
-        allowOverwrite: true,
-        cacheControlMaxAge: 900,
-        contentType: "application/json",
-      },
-    );
+    const pathname = dailyPathForRun(published, prefix);
+    const pointer = await put(pathname, JSON.stringify(published, null, 2), {
+      access,
+      allowOverwrite: true,
+      cacheControlMaxAge: 900,
+      contentType: "application/json",
+    });
+    pointers.push({ pathname, etag: pointer.etag, run: published });
     publishedRuns.push(published);
   }
 
+  await publishBlobHistorySnapshots(prefix, access, isAwfyBlobRun, pointers);
   return publishedRuns.sort(byCreatedAtThenRunNumber);
 }

--- a/website/src/lib/blob-history.ts
+++ b/website/src/lib/blob-history.ts
@@ -227,6 +227,7 @@ async function writeSnapshots<Run>(
   access: Access,
   isRun: (value: unknown) => value is Run,
   known = new Map<string, LoadedPointer<Run>>(),
+  projectRun: (run: Run) => Run = (run) => run,
 ): Promise<number> {
   let written = 0;
   for (const partition of partitions) {
@@ -254,7 +255,7 @@ async function writeSnapshots<Run>(
       pointers: pointers.map(({ pathname, etag, run }) => ({
         pathname,
         etag,
-        run,
+        run: run === null ? null : projectRun(run),
       })),
     });
     if (Buffer.byteLength(json) > SNAPSHOT_BYTES) continue;
@@ -278,12 +279,13 @@ export async function rebuildBlobHistorySnapshots<Run>(
   prefix: string,
   access: Access,
   isRun: (value: unknown) => value is Run,
+  projectRun?: (run: Run) => Run,
 ): Promise<number> {
   const { partitions } = partitionPointers(
     prefix,
     await listPointers(`${prefix}/daily/`),
   );
-  return writeSnapshots(partitions, access, isRun);
+  return writeSnapshots(partitions, access, isRun, undefined, projectRun);
 }
 
 export async function publishBlobHistorySnapshots<Run>(
@@ -291,6 +293,7 @@ export async function publishBlobHistorySnapshots<Run>(
   access: Access,
   isRun: (value: unknown) => value is Run,
   published: LoadedPointer<Run>[],
+  projectRun?: (run: Run) => Run,
 ): Promise<void> {
   try {
     const known = new Map(
@@ -308,7 +311,7 @@ export async function publishBlobHistorySnapshots<Run>(
         prefix,
         await listPointers(`${prefix}/daily/${month}-`),
       );
-      await writeSnapshots(partitions, access, isRun, known);
+      await writeSnapshots(partitions, access, isRun, known, projectRun);
     }
   } catch (error) {
     console.warn(

--- a/website/src/lib/blob-history.ts
+++ b/website/src/lib/blob-history.ts
@@ -1,0 +1,319 @@
+import { createHash } from "node:crypto";
+import { gunzipSync, gzipSync } from "node:zlib";
+import { BlobNotFoundError, get, list, put } from "@vercel/blob";
+
+const READ_CONCURRENCY = 8;
+const SNAPSHOT_POINTERS = 128;
+const SNAPSHOT_BYTES = 1024 * 1024;
+// Bump when projection semantics change, including which raw records qualify.
+const SNAPSHOT_VERSION = 1;
+
+type Access = "public" | "private";
+type RunOrder = { createdAt: string; runNumber: number };
+type Pointer = { pathname: string; etag?: string; order: number };
+type LoadedPointer<Run> = {
+  pathname: string;
+  etag: string | null;
+  run: Run | null;
+};
+type Partition = {
+  path: string;
+  fingerprint: string;
+  pointers: { pathname: string; etag: string; order: number }[];
+};
+
+function strongEtag(etag: unknown): string | null {
+  if (typeof etag !== "string" || !etag || etag.startsWith("W/")) return null;
+  return etag.startsWith('"') && etag.endsWith('"')
+    ? etag.slice(1, -1) || null
+    : etag;
+}
+
+function pointerMonth(prefix: string, pathname: string): string | null {
+  if (!pathname.startsWith(`${prefix}/daily/`)) return null;
+  const relative = pathname.slice(`${prefix}/daily/`.length);
+  return (
+    /^(\d{4}-(?:0[1-9]|1[0-2]))-\d{2}(?:\.json$|\/)/.exec(relative)?.[1] ?? null
+  );
+}
+
+async function readInBatches<Input, Output>(
+  items: readonly Input[],
+  read: (item: Input) => Promise<Output>,
+): Promise<Output[]> {
+  const results: Output[] = [];
+  for (let offset = 0; offset < items.length; offset += READ_CONCURRENCY) {
+    results.push(
+      ...(await Promise.all(
+        items.slice(offset, offset + READ_CONCURRENCY).map(read),
+      )),
+    );
+  }
+  return results;
+}
+
+async function listPointers(prefix: string): Promise<Pointer[]> {
+  const pointers: Pointer[] = [];
+  let cursor: string | undefined;
+  do {
+    const page = await list({ cursor, limit: 1000, prefix });
+    for (const blob of page.blobs)
+      pointers.push({
+        pathname: blob.pathname,
+        etag: blob.etag,
+        order: pointers.length,
+      });
+    cursor = page.cursor;
+    if (!page.hasMore) break;
+  } while (cursor);
+  return pointers;
+}
+
+function partitionPointers(prefix: string, pointers: Pointer[]) {
+  const months = new Map<
+    string,
+    { pathname: string; etag: string; order: number }[]
+  >();
+  const uncached: Pointer[] = [];
+  for (const pointer of pointers) {
+    const month = pointerMonth(prefix, pointer.pathname);
+    const etag = strongEtag(pointer.etag);
+    if (!month || !etag) {
+      uncached.push(pointer);
+      continue;
+    }
+    const entries = months.get(month) ?? [];
+    entries.push({ pathname: pointer.pathname, etag, order: pointer.order });
+    months.set(month, entries);
+  }
+  const partitions: Partition[] = [];
+  for (const [month, entries] of months) {
+    entries.sort((a, b) =>
+      a.pathname < b.pathname
+        ? -1
+        : a.pathname > b.pathname
+          ? 1
+          : a.etag < b.etag
+            ? -1
+            : a.etag > b.etag
+              ? 1
+              : 0,
+    );
+    for (let offset = 0; offset < entries.length; offset += SNAPSHOT_POINTERS) {
+      const pointers = entries.slice(offset, offset + SNAPSHOT_POINTERS);
+      const fingerprint = createHash("sha256")
+        .update(
+          JSON.stringify(
+            pointers.map(({ pathname, etag }) => [pathname, etag]),
+          ),
+        )
+        .digest("hex");
+      partitions.push({
+        path: `${prefix}/history/v${SNAPSHOT_VERSION}/${month}/${fingerprint}.json.gz`,
+        fingerprint,
+        pointers,
+      });
+    }
+  }
+  return { partitions, uncached };
+}
+
+async function readPointer<Run>(
+  pointer: Pointer,
+  access: Access,
+  isRun: (value: unknown) => value is Run,
+): Promise<LoadedPointer<Run>> {
+  try {
+    const response = await get(pointer.pathname, { access });
+    if (!response || response.statusCode !== 200 || !response.stream)
+      return { pathname: pointer.pathname, etag: null, run: null };
+    const text = await new Response(response.stream).text();
+    let run: Run | null = null;
+    try {
+      const value: unknown = JSON.parse(text);
+      if (isRun(value)) run = value;
+    } catch {
+      // Malformed historical pointers have never been part of the timeline.
+    }
+    return {
+      pathname: pointer.pathname,
+      etag: strongEtag(response.blob.etag),
+      run,
+    };
+  } catch (error) {
+    if (error instanceof BlobNotFoundError)
+      return { pathname: pointer.pathname, etag: null, run: null };
+    throw error;
+  }
+}
+
+async function readSnapshot<Run>(
+  partition: Partition,
+  access: Access,
+  isRun: (value: unknown) => value is Run,
+): Promise<(Run | null)[] | null> {
+  try {
+    const response = await get(partition.path, { access });
+    if (!response || response.statusCode !== 200 || !response.stream)
+      return null;
+    if (response.blob.size > SNAPSHOT_BYTES) {
+      await response.stream.cancel();
+      return null;
+    }
+    const bytes = await new Response(response.stream).arrayBuffer();
+    if (bytes.byteLength > SNAPSHOT_BYTES) return null;
+    const snapshot = JSON.parse(
+      gunzipSync(bytes, { maxOutputLength: SNAPSHOT_BYTES }).toString("utf8"),
+    );
+    if (
+      snapshot?.version !== SNAPSHOT_VERSION ||
+      snapshot.fingerprint !== partition.fingerprint ||
+      !Array.isArray(snapshot.pointers) ||
+      snapshot.pointers.length !== partition.pointers.length
+    )
+      return null;
+    const runs: (Run | null)[] = [];
+    for (const [index, expected] of partition.pointers.entries()) {
+      const pointer = snapshot.pointers[index];
+      if (
+        pointer?.pathname !== expected.pathname ||
+        pointer.etag !== expected.etag
+      )
+        return null;
+      if (pointer.run !== null && !isRun(pointer.run)) return null;
+      runs.push(pointer.run);
+    }
+    return runs;
+  } catch {
+    // Snapshots are optional projections; the raw pointers remain authoritative.
+    return null;
+  }
+}
+
+export async function listBlobHistory<Run extends RunOrder>(
+  prefix: string,
+  access: Access,
+  isRun: (value: unknown) => value is Run,
+): Promise<Run[]> {
+  const pointers = await listPointers(`${prefix}/daily/`);
+  const { partitions, uncached } = partitionPointers(prefix, pointers);
+  const snapshots = await readInBatches(partitions, (partition) =>
+    readSnapshot(partition, access, isRun),
+  );
+  const runs: (Run | null)[] = Array(pointers.length).fill(null);
+  const fallback = [...uncached];
+  for (const [index, snapshot] of snapshots.entries()) {
+    if (snapshot) {
+      for (const [row, run] of snapshot.entries())
+        runs[partitions[index].pointers[row].order] = run;
+    } else fallback.push(...partitions[index].pointers);
+  }
+  const raw = await readInBatches(fallback, (pointer) =>
+    readPointer(pointer, access, isRun),
+  );
+  for (const [index, pointer] of raw.entries())
+    runs[fallback[index].order] = pointer.run;
+  return runs
+    .filter((run): run is Run => run !== null)
+    .sort(
+      (a, b) =>
+        Date.parse(a.createdAt) - Date.parse(b.createdAt) ||
+        a.runNumber - b.runNumber,
+    );
+}
+
+async function writeSnapshots<Run>(
+  partitions: Partition[],
+  access: Access,
+  isRun: (value: unknown) => value is Run,
+  known = new Map<string, LoadedPointer<Run>>(),
+): Promise<number> {
+  let written = 0;
+  for (const partition of partitions) {
+    if (await readSnapshot(partition, access, isRun)) continue;
+    const pointers = await readInBatches(
+      partition.pointers,
+      async (pointer) => {
+        const current = known.get(pointer.pathname);
+        return current?.etag === pointer.etag
+          ? current
+          : readPointer(pointer, access, isRun);
+      },
+    );
+    // Public Blob reads may still serve a previous pointer through the CDN.
+    // Only materialize the generation whose exact ETags were listed.
+    if (
+      pointers.some(
+        (pointer, index) => pointer.etag !== partition.pointers[index].etag,
+      )
+    )
+      continue;
+    const json = JSON.stringify({
+      version: SNAPSHOT_VERSION,
+      fingerprint: partition.fingerprint,
+      pointers: pointers.map(({ pathname, etag, run }) => ({
+        pathname,
+        etag,
+        run,
+      })),
+    });
+    if (Buffer.byteLength(json) > SNAPSHOT_BYTES) continue;
+    const compressed = gzipSync(json);
+    if (compressed.byteLength > SNAPSHOT_BYTES) continue;
+    // Equal fingerprints describe equal raw generations, so simultaneous
+    // writers produce the same content at this immutable pathname.
+    await put(partition.path, compressed, {
+      access,
+      allowOverwrite: true,
+      addRandomSuffix: false,
+      cacheControlMaxAge: 31_536_000,
+      contentType: "application/gzip",
+    });
+    written++;
+  }
+  return written;
+}
+
+export async function rebuildBlobHistorySnapshots<Run>(
+  prefix: string,
+  access: Access,
+  isRun: (value: unknown) => value is Run,
+): Promise<number> {
+  const { partitions } = partitionPointers(
+    prefix,
+    await listPointers(`${prefix}/daily/`),
+  );
+  return writeSnapshots(partitions, access, isRun);
+}
+
+export async function publishBlobHistorySnapshots<Run>(
+  prefix: string,
+  access: Access,
+  isRun: (value: unknown) => value is Run,
+  published: LoadedPointer<Run>[],
+): Promise<void> {
+  try {
+    const known = new Map(
+      published.map((pointer) => [
+        pointer.pathname,
+        { ...pointer, etag: strongEtag(pointer.etag) },
+      ]),
+    );
+    const months = new Set(
+      published.map((pointer) => pointerMonth(prefix, pointer.pathname)),
+    );
+    for (const month of months) {
+      if (!month) continue;
+      const { partitions } = partitionPointers(
+        prefix,
+        await listPointers(`${prefix}/daily/${month}-`),
+      );
+      await writeSnapshots(partitions, access, isRun, known);
+    }
+  } catch (error) {
+    console.warn(
+      "Blob history snapshot publication failed; raw reports remain available:",
+      error,
+    );
+  }
+}

--- a/website/src/lib/jetstream-blob-store.ts
+++ b/website/src/lib/jetstream-blob-store.ts
@@ -160,11 +160,21 @@ export async function readJetStreamBlobReportJson(
   return bytes ? gunzipSync(bytes).toString("utf8") : null;
 }
 
+function compactHistoryRun(run: JetStreamBlobRun): JetStreamBlobRun {
+  // Legacy pointers embed the full report as an extra field. The report artifact
+  // remains authoritative; the timeline needs only the declared run fields.
+  const { reportJson: _reportJson, ...history } = run as JetStreamBlobRun & {
+    reportJson?: unknown;
+  };
+  return history;
+}
+
 export async function rebuildJetStreamBlobHistory(): Promise<number> {
   return rebuildBlobHistorySnapshots(
     jetStreamBlobPrefix(),
     jetStreamBlobAccess(),
     isJetStreamBlobRun,
+    compactHistoryRun,
   );
 }
 
@@ -223,6 +233,7 @@ export async function publishJetStreamReportsToBlob(
     access,
     isJetStreamBlobRun,
     pointers,
+    compactHistoryRun,
   );
   return publishedRuns.sort(byCreatedAtThenRunNumber);
 }

--- a/website/src/lib/jetstream-blob-store.ts
+++ b/website/src/lib/jetstream-blob-store.ts
@@ -1,5 +1,10 @@
 import { gunzipSync, gzipSync } from "node:zlib";
-import { BlobNotFoundError, get, list, put } from "@vercel/blob";
+import { BlobNotFoundError, get, put } from "@vercel/blob";
+import {
+  listBlobHistory,
+  publishBlobHistorySnapshots,
+  rebuildBlobHistorySnapshots,
+} from "./blob-history";
 
 export type JetStreamBlobAccess = "public" | "private";
 
@@ -155,31 +160,18 @@ export async function readJetStreamBlobReportJson(
   return bytes ? gunzipSync(bytes).toString("utf8") : null;
 }
 
+export async function rebuildJetStreamBlobHistory(): Promise<number> {
+  return rebuildBlobHistorySnapshots(
+    jetStreamBlobPrefix(),
+    jetStreamBlobAccess(),
+    isJetStreamBlobRun,
+  );
+}
+
 export async function listJetStreamBlobDailyRuns(
   prefix = jetStreamBlobPrefix(),
 ): Promise<JetStreamBlobRun[]> {
-  const runs: JetStreamBlobRun[] = [];
-  let cursor: string | undefined;
-  do {
-    const page = await list({
-      cursor,
-      limit: 1000,
-      prefix: `${jetStreamBlobDailyPrefix(prefix)}/`,
-    });
-    cursor = page.cursor;
-    for (const blob of page.blobs) {
-      const bytes = await readBlobBytes(blob.pathname);
-      if (!bytes) continue;
-      try {
-        const parsed: unknown = JSON.parse(new TextDecoder().decode(bytes));
-        if (isJetStreamBlobRun(parsed)) runs.push(parsed);
-      } catch {
-        // Ignore malformed historical pointers and retain the valid timeline.
-      }
-    }
-    if (!page.hasMore) break;
-  } while (cursor);
-  return runs.sort(byCreatedAtThenRunNumber);
+  return listBlobHistory(prefix, jetStreamBlobAccess(), isJetStreamBlobRun);
 }
 
 export async function publishJetStreamReportsToBlob(
@@ -188,6 +180,8 @@ export async function publishJetStreamReportsToBlob(
   const prefix = jetStreamBlobPrefix();
   const access = jetStreamBlobAccess();
   const publishedRuns: JetStreamBlobRun[] = [];
+  const pointers: { pathname: string; etag: string; run: JetStreamBlobRun }[] =
+    [];
   for (const entry of entries) {
     const reportPath = jetStreamBlobReportPathForArtifactId(
       entry.artifactId,
@@ -210,21 +204,25 @@ export async function publishJetStreamReportsToBlob(
       },
       publishedAt: new Date().toISOString(),
     };
-    await put(
-      jetStreamBlobDailyPathForRun(
-        entry.createdAt.slice(0, 10),
-        entry.runId,
-        prefix,
-      ),
-      JSON.stringify(published, null, 2),
-      {
-        access,
-        allowOverwrite: true,
-        cacheControlMaxAge: 900,
-        contentType: "application/json",
-      },
+    const pathname = jetStreamBlobDailyPathForRun(
+      entry.createdAt.slice(0, 10),
+      entry.runId,
+      prefix,
     );
+    const pointer = await put(pathname, JSON.stringify(published, null, 2), {
+      access,
+      allowOverwrite: true,
+      cacheControlMaxAge: 900,
+      contentType: "application/json",
+    });
+    pointers.push({ pathname, etag: pointer.etag, run: published });
     publishedRuns.push(published);
   }
+  await publishBlobHistorySnapshots(
+    prefix,
+    access,
+    isJetStreamBlobRun,
+    pointers,
+  );
   return publishedRuns.sort(byCreatedAtThenRunNumber);
 }

--- a/website/src/lib/test262-blob-store.ts
+++ b/website/src/lib/test262-blob-store.ts
@@ -1,9 +1,14 @@
 import { gunzipSync, gzipSync } from "node:zlib";
-import { BlobNotFoundError, get, list, put } from "@vercel/blob";
+import { BlobNotFoundError, get, put } from "@vercel/blob";
 import type {
   Test262Report,
   Test262TimelinePoint,
 } from "@/lib/test262-dashboard";
+import {
+  listBlobHistory,
+  publishBlobHistorySnapshots,
+  rebuildBlobHistorySnapshots,
+} from "./blob-history";
 
 export type Test262BlobAccess = "public" | "private";
 export type Test262ProfileBlobReportKind =
@@ -171,20 +176,6 @@ async function streamToBytes(stream: ReadableStream<Uint8Array>) {
   return out;
 }
 
-async function readBlobText(
-  pathname: string,
-  access = test262BlobAccess(),
-): Promise<string | null> {
-  try {
-    const result = await get(pathname, { access });
-    if (!result || result.statusCode !== 200 || !result.stream) return null;
-    return new TextDecoder().decode(await streamToBytes(result.stream));
-  } catch (err) {
-    if (err instanceof BlobNotFoundError) return null;
-    throw err;
-  }
-}
-
 async function readBlobBytes(
   pathname: string,
   access = test262BlobAccess(),
@@ -248,34 +239,18 @@ export async function readTest262BlobReportJsonByArtifactId(
   return bytes ? gunzipSync(bytes).toString("utf8") : null;
 }
 
+export async function rebuildTest262BlobHistory(): Promise<number> {
+  return rebuildBlobHistorySnapshots(
+    test262BlobPrefix(),
+    test262BlobAccess(),
+    isBlobRun,
+  );
+}
+
 export async function listTest262BlobDailyRuns(
   prefix = test262BlobPrefix(),
 ): Promise<Test262BlobRun[]> {
-  const access = test262BlobAccess();
-  const runs: Test262BlobRun[] = [];
-  let cursor: string | undefined;
-  do {
-    const page = await list({
-      cursor,
-      limit: 1000,
-      prefix: `${test262BlobDailyPrefix(prefix)}/`,
-    });
-    cursor = page.cursor;
-    for (const blob of page.blobs) {
-      const text = await readBlobText(blob.pathname, access);
-      if (!text) continue;
-      let parsed: unknown;
-      try {
-        parsed = JSON.parse(text);
-      } catch {
-        continue;
-      }
-      if (isBlobRun(parsed)) runs.push(parsed);
-    }
-    if (!page.hasMore) break;
-  } while (cursor);
-
-  return runs.sort(byCreatedAtThenRunNumber);
+  return listBlobHistory(prefix, test262BlobAccess(), isBlobRun);
 }
 
 export async function publishTest262ReportsToBlob(
@@ -284,6 +259,8 @@ export async function publishTest262ReportsToBlob(
   const prefix = test262BlobPrefix();
   const access = test262BlobAccess();
   const publishedRuns: Test262BlobRun[] = [];
+  const pointers: { pathname: string; etag: string; run: Test262BlobRun }[] =
+    [];
 
   for (const entry of entries) {
     const reportPath = test262BlobReportPathForArtifactId(
@@ -306,19 +283,18 @@ export async function publishTest262ReportsToBlob(
       reportCompressedSize: compressed.byteLength,
       publishedAt: new Date().toISOString(),
     };
-    await put(
-      dailyPathForPoint(published, prefix),
-      JSON.stringify(published, null, 2),
-      {
-        access,
-        allowOverwrite: true,
-        cacheControlMaxAge: 900,
-        contentType: "application/json",
-      },
-    );
+    const pathname = dailyPathForPoint(published, prefix);
+    const pointer = await put(pathname, JSON.stringify(published, null, 2), {
+      access,
+      allowOverwrite: true,
+      cacheControlMaxAge: 900,
+      contentType: "application/json",
+    });
+    pointers.push({ pathname, etag: pointer.etag, run: published });
     publishedRuns.push(published);
   }
 
+  await publishBlobHistorySnapshots(prefix, access, isBlobRun, pointers);
   return publishedRuns.sort(byCreatedAtThenRunNumber);
 }
 


### PR DESCRIPTION
## Summary

Depends on #1228 and targets `codex/audit-report-publishing` so this remains a history-only review. Publishing head `89c3b7e61873fb92867e1554c4d821324bc9b16b` was integrated by normal merge, without rewriting either branch.

- Cold dashboard history loads previously fetched every pointer serially. Share bounded reads across AWFY, JetStream, and test262, and let CI publishers materialize immutable monthly snapshots after raw publication. Readers still list every raw pointer, then fetch matching snapshots with at most eight concurrent reads per report family. A verified snapshot needs no per-pointer GETs.
- Key snapshot generations by SHA-256 of sorted raw pointer paths and strong ETags. Verify fetched ETags before writing, validate snapshot schema and descriptors before reading, omit JetStream’s duplicate embedded report payload from the compact projection, and fall back to raw pointers for missing, stale, corrupt, or oversized projections. Late/concurrent writers cannot replace another generation. Preserve failures, stable result ordering, all raw artifacts, daily AWFY/test262 pointer behavior, and JetStream per-run paths.
- Add `bun run rebuild-history` for existing months, with the same Blob prefix/access settings. Document the design in ADR 0115 and contributor usage in `website/README.md`. Implements audit recommendation P5; there is no raw deletion or history truncation.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests
- [x] Updated documentation
- [ ] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (not applicable: no native source changed)
- [ ] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change (not applicable: website I/O path; no engine change)

`bun install --frozen-lockfile` and the declared `postinstall` passed. Full combined website suite at merge head `a713ea3d7e3c0183f6555d5404801bfbf6edaf3f`: 236 tests and 716 assertions, including the publishing timestamp boundary and profile fallback regression. The 25 new integration tests exercise all three real readers/publishers against a Blob mock: pagination and the eight-read bound, failures/degraded runs, snapshot-only hits (25 pointers → one GET; 130 pointers → two GETs), fallback behavior, exact ETag checks against stale public reads, out-of-order/concurrent publication, identical bytes for same-generation writers, daily/per-run paths, private access, rebuilding old months, size limits, stable sort ties, and large JetStream reports whose duplicate embedded payload is omitted from snapshots while raw data remains unchanged. Focused tests passed again after the separate diff review.

Full `bunx tsc --noEmit` and `bun run lint` passed again on the combined source (130 files). Rebuild CLI help exits zero; missing credentials and unsupported arguments exit two before storage access. `./format.pas --check` passed for all 463 files. Merge commit hooks ran normally, including documentation links/symbols, Markdown lint, and conformance claims. A separate source review verified all four merge resolutions and byte-matched the combined tree against the previously tested composition, except for the two exact timestamp-fix files from #1228.

Native validation completed in this worktree under the shared host lock: `./build.pas --clean --prod testrunner` and the FFI fixture build passed, and both full `GocciaTestRunner tests --jobs=1` suites (interpreted and bytecode) passed all 12,818 tests / 28,573 assertions with exit zero. The formatter passed again afterward. All 47 applicable CI checks passed on exact head `a713ea3d7e3c0183f6555d5404801bfbf6edaf3f`. The two Vercel checks present on main-based PRs are absent for this stacked base. A local production `bun run build` passed on the same head with Bun 1.4.0 / Next 16.2.9, including normal release vendoring, TypeScript, and all 178 static pages; no release-vendoring override was used. Dynamic performance, compatibility, and API routes compiled. Live Blob writes and production deployment were not performed.

## Design constraints

Snapshots are bounded to 128 pointer records and 1 MiB of decoded JSON. Raw listing remains linear in retained pointer count. Every snapshot generation is retained; total storage is not capped, and late inserts can change several sorted monthly chunks (worst-case retained bytes grow quadratically over a month's publications). This is documented explicitly in ADR 0115. Projection failures leave successful raw publication intact; raw transport failures retain their existing error behavior.

The stack preserves both implementations: the shared daily-pointer upload helper now returns its PUT result/ETag for snapshot generation, while report-specific paths and profile behavior remain in their adapters. The four overlapping files (website README and AWFY, JetStream, and test262 stores) were resolved together; no native source changed during the merge. The earlier native validation remains applicable, and all 47 applicable independent CI checks passed on the exact merge head. No client-time processing, request-time writes, profile publication, credentials, or deployment boundary changed.
