### PR TITLE
refactor(csv-tsv): share callback conversion and chunk results

### DIFF
--- a/docs/built-ins-data-formats.md
+++ b/docs/built-ins-data-formats.md
@@ -136,6 +136,8 @@ After `import * as JSONL from "goccia:jsonl"`, `JSONL.parse(...)` and `JSONL.par
 
 TSV uses IANA `text/tab-separated-values` semantics, which differ fundamentally from CSV: instead of RFC 4180 double-quote escaping, TSV uses **backslash escaping** (`\t` for tab, `\n` for newline, `\r` for carriage return, `\\` for literal backslash). Unrecognized escape sequences preserve the backslash. The reviver, replacer, `parseChunk`, and edge case handling match CSV.
 
+CSV and TSV share callback selection, reviver argument construction, replacer row conversion, and chunk result assembly in `Goccia.Builtins.DelimitedText`. The adapters retain their own options, parser calls, reviver contexts, and stringifiers. Shared conversion roots intermediate values across callbacks; each adapter keeps the converted array rooted until serialization finishes.
+
 ## TOML (`goccia:toml`, `Goccia.Builtins.TOML.pas`)
 
 | Method | Description |

--- a/source/units/Goccia.Builtins.CSV.pas
+++ b/source/units/Goccia.Builtins.CSV.pas
@@ -24,12 +24,6 @@ type
     procedure ReadOptions(const AArgs: TGocciaArgumentsCollection;
       const AOptionsIndex: Integer; out ADelimiter: Char;
       out AHeaders: Boolean; out ASkipEmptyLines: Boolean);
-    function GetReviver(const AArgs: TGocciaArgumentsCollection;
-      const AReviverIndex: Integer): TGocciaValue;
-    function GetReplacer(const AArgs: TGocciaArgumentsCollection;
-      const AReplacerIndex: Integer): TGocciaValue;
-    function BuildChunkResultObject(
-      const AChunkResult: TGocciaCSVChunkParseResult): TGocciaValue;
   published
     function CSVParse(const AArgs: TGocciaArgumentsCollection;
       const AThisValue: TGocciaValue): TGocciaValue;
@@ -47,8 +41,7 @@ type
 implementation
 
 uses
-  Goccia.Constants.ErrorNames,
-  Goccia.Constants.PropertyNames,
+  Goccia.Builtins.DelimitedText,
   Goccia.GarbageCollector,
   Goccia.ThreadCleanupRegistry,
   Goccia.Utils,
@@ -136,82 +129,13 @@ begin
     ASkipEmptyLines := TGocciaBooleanLiteralValue(Prop).Value;
 end;
 
-function TGocciaCSVBuiltin.GetReviver(
-  const AArgs: TGocciaArgumentsCollection;
-  const AReviverIndex: Integer): TGocciaValue;
-begin
-  Result := nil;
-  if AArgs.Length > AReviverIndex then
-  begin
-    Result := AArgs.GetElement(AReviverIndex);
-    if not Result.IsCallable then
-      Result := nil;
-  end;
-end;
-
-function TGocciaCSVBuiltin.GetReplacer(
-  const AArgs: TGocciaArgumentsCollection;
-  const AReplacerIndex: Integer): TGocciaValue;
-begin
-  Result := nil;
-  if AArgs.Length > AReplacerIndex then
-  begin
-    Result := AArgs.GetElement(AReplacerIndex);
-    if not Result.IsCallable then
-      Result := nil;
-  end;
-end;
-
-function TGocciaCSVBuiltin.BuildChunkResultObject(
-  const AChunkResult: TGocciaCSVChunkParseResult): TGocciaValue;
-var
-  ErrorValue: TGocciaValue;
-  ResultObject: TGocciaObjectValue;
-  ValuesRoot: TGocciaTempRoot;
-  ResultRoot: TGocciaTempRoot;
-  ErrorRoot: TGocciaTempRoot;
-begin
-  { CreateErrorObject allocates and property storage is charged on
-    assignment — both GC safe points — so the parsed values array, the result
-    object, and the error object are all rooted until the assignments below
-    store them. }
-  InitializeTempRoot(ValuesRoot);
-  InitializeTempRoot(ResultRoot);
-  InitializeTempRoot(ErrorRoot);
-  AddTempRootIfNeeded(ValuesRoot, AChunkResult.Values);
-  try
-    ResultObject := TGocciaObjectValue.Create;
-    AddTempRootIfNeeded(ResultRoot, ResultObject);
-    if AChunkResult.ErrorMessage = '' then
-      ErrorValue := TGocciaNullLiteralValue.NullValue
-    else
-    begin
-      ErrorValue := CreateErrorObject(SYNTAX_ERROR_NAME,
-        AChunkResult.ErrorMessage, 1);
-      AddTempRootIfNeeded(ErrorRoot, ErrorValue);
-    end;
-
-    ResultObject.AssignProperty(PROP_VALUES, AChunkResult.Values);
-    ResultObject.AssignProperty(PROP_READ,
-      TGocciaNumberLiteralValue.Create(AChunkResult.Read));
-    ResultObject.AssignProperty(PROP_DONE,
-      TGocciaBooleanLiteralValue.Create(AChunkResult.Done));
-    ResultObject.AssignProperty(PROP_ERROR, ErrorValue);
-    Result := ResultObject;
-  finally
-    RemoveTempRootIfNeeded(ErrorRoot);
-    RemoveTempRootIfNeeded(ResultRoot);
-    RemoveTempRootIfNeeded(ValuesRoot);
-  end;
-end;
-
 function TGocciaCSVBuiltin.CSVParse(
   const AArgs: TGocciaArgumentsCollection;
   const AThisValue: TGocciaValue): TGocciaValue;
 var
-  Args: TGocciaArgumentsCollection;
   Context: TGocciaObjectValue;
   Delimiter: Char;
+  FieldValue: string;
   FieldInfoRows: TArray<TArray<TGocciaCSVFieldInfo>>;
   Headers: Boolean;
   HeaderRow: TArray<TGocciaCSVFieldInfo>;
@@ -235,7 +159,7 @@ begin
 
   Text := AArgs.GetElement(0).ToStringLiteral.Value;
   ReadOptions(AArgs, 1, Delimiter, Headers, SkipEmptyLines);
-  Reviver := GetReviver(AArgs, 2);
+  Reviver := GetDelimitedTextCallback(AArgs, 2);
 
   { The reviver is arbitrary JS and every field string is charged against the
     memory ceiling, so both are GC safe points; the result array, the
@@ -280,21 +204,12 @@ begin
             Context.AssignProperty('column',
               TGocciaNumberLiteralValue.Create(J));
 
-            Args := TGocciaArgumentsCollection.CreateWithCapacity(3);
-            try
-              Args.Add(TGocciaStringLiteralValue.Create(Key));
-              if J < Length(FieldInfoRows[I]) then
-                Args.Add(
-                  TGocciaStringLiteralValue.Create(FieldInfoRows[I][J].Value))
-              else
-                Args.Add(TGocciaStringLiteralValue.Create(''));
-              Args.Add(Context);
-
-              ReviverResult := InvokeCallable(Reviver, Args,
-                TGocciaUndefinedLiteralValue.UndefinedValue);
-            finally
-              Args.Free;
-            end;
+            if J < Length(FieldInfoRows[I]) then
+              FieldValue := FieldInfoRows[I][J].Value
+            else
+              FieldValue := '';
+            ReviverResult := InvokeDelimitedTextReviver(Reviver,
+              TGocciaStringLiteralValue.Create(Key), FieldValue, Context);
             Obj.AssignProperty(Key, ReviverResult);
           end;
           ParsedResult.Elements.Add(Obj);
@@ -317,18 +232,9 @@ begin
             Context.AssignProperty('column',
               TGocciaNumberLiteralValue.Create(J));
 
-            Args := TGocciaArgumentsCollection.CreateWithCapacity(3);
-            try
-              Args.Add(TGocciaNumberLiteralValue.Create(J));
-              Args.Add(
-                TGocciaStringLiteralValue.Create(FieldInfoRows[I][J].Value));
-              Args.Add(Context);
-
-              ReviverResult := InvokeCallable(Reviver, Args,
-                TGocciaUndefinedLiteralValue.UndefinedValue);
-            finally
-              Args.Free;
-            end;
+            ReviverResult := InvokeDelimitedTextReviver(Reviver,
+              TGocciaNumberLiteralValue.Create(J),
+              FieldInfoRows[I][J].Value, Context);
             Row.Elements.Add(ReviverResult);
           end;
           ParsedResult.Elements.Add(Row);
@@ -384,7 +290,8 @@ begin
   try
     ChunkResult := FParser.ParseChunk(Text, Delimiter, Headers,
       SkipEmptyLines, StartOffset, EndOffset);
-    Result := BuildChunkResultObject(ChunkResult);
+    Result := BuildDelimitedTextChunkResult(ChunkResult.Values,
+      ChunkResult.Read, ChunkResult.Done, ChunkResult.ErrorMessage);
   except
     on E: EGocciaCSVParseError do
       ThrowSyntaxError(E.Message);
@@ -395,108 +302,31 @@ function TGocciaCSVBuiltin.CSVStringify(
   const AArgs: TGocciaArgumentsCollection;
   const AThisValue: TGocciaValue): TGocciaValue;
 var
-  Args: TGocciaArgumentsCollection;
-  Arr: TGocciaArrayValue;
   Data: TGocciaValue;
   Delimiter: Char;
   Headers: Boolean;
-  I, J: Integer;
-  Item: TGocciaValue;
-  Key: string;
-  Keys: TArray<string>;
-  Obj: TGocciaObjectValue;
   Replacer: TGocciaValue;
-  ReplacerResult: TGocciaValue;
   ReplacedArr: TGocciaArrayValue;
-  ReplacedObj: TGocciaObjectValue;
-  ReplacedRow: TGocciaArrayValue;
-  Row: TGocciaArrayValue;
   SkipEmptyLines: Boolean;
   ReplacedArrRoot: TGocciaTempRoot;
-  ReplacedRowRoot: TGocciaTempRoot;
 begin
   TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'CSV.stringify',
     ThrowError);
 
   Data := AArgs.GetElement(0);
   ReadOptions(AArgs, 1, Delimiter, Headers, SkipEmptyLines);
-  Replacer := GetReplacer(AArgs, 2);
+  Replacer := GetDelimitedTextCallback(AArgs, 2);
 
   if Assigned(Replacer) and (Data is TGocciaArrayValue) then
   begin
-    { The replacer is arbitrary JS (a GC safe point); the replaced rows exist
-      only in this frame until stringified, so they need temp roots. }
     InitializeTempRoot(ReplacedArrRoot);
-    InitializeTempRoot(ReplacedRowRoot);
     try
-    Arr := TGocciaArrayValue(Data);
-    ReplacedArr := TGocciaArrayValue.Create;
-    AddTempRootIfNeeded(ReplacedArrRoot, ReplacedArr);
-
-    if (Arr.Elements.Count > 0) and
-       (Arr.Elements[0] is TGocciaObjectValue) and
-       not (Arr.Elements[0] is TGocciaArrayValue) then
-    begin
-      Keys := TGocciaObjectValue(Arr.Elements[0]).GetOwnPropertyKeys;
-      for I := 0 to Arr.Elements.Count - 1 do
-      begin
-        if not (Arr.Elements[I] is TGocciaObjectValue) then
-          Continue;
-        Obj := TGocciaObjectValue(Arr.Elements[I]);
-        ReplacedObj := TGocciaObjectValue.Create;
-        AddTempRootIfNeeded(ReplacedRowRoot, ReplacedObj);
-        for J := 0 to Length(Keys) - 1 do
-        begin
-          Key := Keys[J];
-          Item := Obj.GetProperty(Key);
-          if not Assigned(Item) then
-            Item := TGocciaUndefinedLiteralValue.UndefinedValue;
-
-          Args := TGocciaArgumentsCollection.CreateWithCapacity(2);
-          try
-            Args.Add(TGocciaStringLiteralValue.Create(Key));
-            Args.Add(Item);
-            ReplacerResult := InvokeCallable(Replacer, Args,
-              TGocciaUndefinedLiteralValue.UndefinedValue);
-          finally
-            Args.Free;
-          end;
-          ReplacedObj.AssignProperty(Key, ReplacerResult);
-        end;
-        ReplacedArr.Elements.Add(ReplacedObj);
-      end;
-    end
-    else
-    begin
-      for I := 0 to Arr.Elements.Count - 1 do
-      begin
-        if Arr.Elements[I] is TGocciaArrayValue then
-        begin
-          Row := TGocciaArrayValue(Arr.Elements[I]);
-          ReplacedRow := TGocciaArrayValue.Create;
-          AddTempRootIfNeeded(ReplacedRowRoot, ReplacedRow);
-          for J := 0 to Row.Elements.Count - 1 do
-          begin
-            Args := TGocciaArgumentsCollection.CreateWithCapacity(2);
-            try
-              Args.Add(TGocciaNumberLiteralValue.Create(J));
-              Args.Add(Row.Elements[J]);
-              ReplacerResult := InvokeCallable(Replacer, Args,
-                TGocciaUndefinedLiteralValue.UndefinedValue);
-            finally
-              Args.Free;
-            end;
-            ReplacedRow.Elements.Add(ReplacerResult);
-          end;
-          ReplacedArr.Elements.Add(ReplacedRow);
-        end;
-      end;
-    end;
-
-    Result := TGocciaStringLiteralValue.Create(
-      TGocciaCSVStringifier.Stringify(ReplacedArr, Delimiter, Headers));
+      ReplacedArr := ApplyDelimitedTextReplacer(TGocciaArrayValue(Data),
+        Replacer);
+      AddTempRootIfNeeded(ReplacedArrRoot, ReplacedArr);
+      Result := TGocciaStringLiteralValue.Create(
+        TGocciaCSVStringifier.Stringify(ReplacedArr, Delimiter, Headers));
     finally
-      RemoveTempRootIfNeeded(ReplacedRowRoot);
       RemoveTempRootIfNeeded(ReplacedArrRoot);
     end;
   end

--- a/source/units/Goccia.Builtins.DelimitedText.pas
+++ b/source/units/Goccia.Builtins.DelimitedText.pas
@@ -1,0 +1,204 @@
+unit Goccia.Builtins.DelimitedText;
+
+{$I Goccia.inc}
+
+interface
+
+uses
+  Goccia.Arguments.Collection,
+  Goccia.Values.ArrayValue,
+  Goccia.Values.ObjectValue,
+  Goccia.Values.Primitives;
+
+function GetDelimitedTextCallback(const AArgs: TGocciaArgumentsCollection;
+  const AIndex: Integer): TGocciaValue;
+function BuildDelimitedTextChunkResult(const AValues: TGocciaArrayValue;
+  const ARead: Integer; const ADone: Boolean;
+  const AErrorMessage: string): TGocciaValue;
+function InvokeDelimitedTextReviver(const AReviver, AKey: TGocciaValue;
+  const AValue: string; const AContext: TGocciaObjectValue): TGocciaValue;
+// The caller roots the returned array across its format-specific stringifier.
+function ApplyDelimitedTextReplacer(const AData: TGocciaArrayValue;
+  const AReplacer: TGocciaValue): TGocciaArrayValue;
+
+implementation
+
+uses
+  Goccia.Constants.ErrorNames,
+  Goccia.Constants.PropertyNames,
+  Goccia.GarbageCollector,
+  Goccia.Utils,
+  Goccia.Values.ErrorHelper;
+
+function GetDelimitedTextCallback(
+  const AArgs: TGocciaArgumentsCollection;
+  const AIndex: Integer): TGocciaValue;
+begin
+  Result := nil;
+  if AArgs.Length > AIndex then
+  begin
+    Result := AArgs.GetElement(AIndex);
+    if not Result.IsCallable then
+      Result := nil;
+  end;
+end;
+
+function BuildDelimitedTextChunkResult(const AValues: TGocciaArrayValue;
+  const ARead: Integer; const ADone: Boolean;
+  const AErrorMessage: string): TGocciaValue;
+var
+  ErrorValue: TGocciaValue;
+  ResultObject: TGocciaObjectValue;
+  ValuesRoot: TGocciaTempRoot;
+  ResultRoot: TGocciaTempRoot;
+  ErrorRoot: TGocciaTempRoot;
+begin
+  { CreateErrorObject allocates and property storage is charged on
+    assignment — both GC safe points — so the parsed values array, the result
+    object, and the error object are all rooted until the assignments below
+    store them. }
+  InitializeTempRoot(ValuesRoot);
+  InitializeTempRoot(ResultRoot);
+  InitializeTempRoot(ErrorRoot);
+  AddTempRootIfNeeded(ValuesRoot, AValues);
+  try
+    ResultObject := TGocciaObjectValue.Create;
+    AddTempRootIfNeeded(ResultRoot, ResultObject);
+    if AErrorMessage = '' then
+      ErrorValue := TGocciaNullLiteralValue.NullValue
+    else
+    begin
+      ErrorValue := CreateErrorObject(SYNTAX_ERROR_NAME,
+        AErrorMessage, 1);
+      AddTempRootIfNeeded(ErrorRoot, ErrorValue);
+    end;
+
+    ResultObject.AssignProperty(PROP_VALUES, AValues);
+    ResultObject.AssignProperty(PROP_READ,
+      TGocciaNumberLiteralValue.Create(ARead));
+    ResultObject.AssignProperty(PROP_DONE,
+      TGocciaBooleanLiteralValue.Create(ADone));
+    ResultObject.AssignProperty(PROP_ERROR, ErrorValue);
+    Result := ResultObject;
+  finally
+    RemoveTempRootIfNeeded(ErrorRoot);
+    RemoveTempRootIfNeeded(ResultRoot);
+    RemoveTempRootIfNeeded(ValuesRoot);
+  end;
+end;
+
+function InvokeDelimitedTextReviver(const AReviver, AKey: TGocciaValue;
+  const AValue: string; const AContext: TGocciaObjectValue): TGocciaValue;
+var
+  Args: TGocciaArgumentsCollection;
+begin
+  Args := TGocciaArgumentsCollection.CreateWithCapacity(3);
+  try
+    // Root the key before allocating the field value; the caller roots context.
+    Args.Add(AKey);
+    Args.Add(TGocciaStringLiteralValue.Create(AValue));
+    Args.Add(AContext);
+    Result := InvokeCallable(AReviver, Args,
+      TGocciaUndefinedLiteralValue.UndefinedValue);
+  finally
+    Args.Free;
+  end;
+end;
+
+function ApplyDelimitedTextReplacer(const AData: TGocciaArrayValue;
+  const AReplacer: TGocciaValue): TGocciaArrayValue;
+var
+  Args: TGocciaArgumentsCollection;
+  I, J: Integer;
+  Item: TGocciaValue;
+  Key: string;
+  Keys: TArray<string>;
+  Obj: TGocciaObjectValue;
+  ReplacerResult: TGocciaValue;
+  ReplacedArr: TGocciaArrayValue;
+  ReplacedObj: TGocciaObjectValue;
+  ReplacedRow: TGocciaArrayValue;
+  Row: TGocciaArrayValue;
+  ReplacedArrRoot: TGocciaTempRoot;
+  ReplacedRowRoot: TGocciaTempRoot;
+  ItemRoot: TGocciaTempRoot;
+begin
+  // Callbacks and getters can collect before a converted row is stored.
+  InitializeTempRoot(ReplacedArrRoot);
+  InitializeTempRoot(ReplacedRowRoot);
+  InitializeTempRoot(ItemRoot);
+  try
+  ReplacedArr := TGocciaArrayValue.Create;
+  AddTempRootIfNeeded(ReplacedArrRoot, ReplacedArr);
+
+  if (AData.Elements.Count > 0) and
+     (AData.Elements[0] is TGocciaObjectValue) and
+     not (AData.Elements[0] is TGocciaArrayValue) then
+  begin
+    Keys := TGocciaObjectValue(AData.Elements[0]).GetOwnPropertyKeys;
+    for I := 0 to AData.Elements.Count - 1 do
+    begin
+      if not (AData.Elements[I] is TGocciaObjectValue) then
+        Continue;
+      Obj := TGocciaObjectValue(AData.Elements[I]);
+      ReplacedObj := TGocciaObjectValue.Create;
+      AddTempRootIfNeeded(ReplacedRowRoot, ReplacedObj);
+      for J := 0 to Length(Keys) - 1 do
+      begin
+        Key := Keys[J];
+        Item := Obj.GetProperty(Key);
+        if not Assigned(Item) then
+          Item := TGocciaUndefinedLiteralValue.UndefinedValue;
+
+        AddTempRootIfNeeded(ItemRoot, Item);
+        Args := TGocciaArgumentsCollection.CreateWithCapacity(2);
+        try
+          Args.Add(TGocciaStringLiteralValue.Create(Key));
+          Args.Add(Item);
+          RemoveTempRootIfNeeded(ItemRoot);
+          ReplacerResult := InvokeCallable(AReplacer, Args,
+            TGocciaUndefinedLiteralValue.UndefinedValue);
+        finally
+          Args.Free;
+        end;
+        ReplacedObj.AssignProperty(Key, ReplacerResult);
+      end;
+      ReplacedArr.Elements.Add(ReplacedObj);
+    end;
+  end
+  else
+  begin
+    for I := 0 to AData.Elements.Count - 1 do
+    begin
+      if AData.Elements[I] is TGocciaArrayValue then
+      begin
+        Row := TGocciaArrayValue(AData.Elements[I]);
+        ReplacedRow := TGocciaArrayValue.Create;
+        AddTempRootIfNeeded(ReplacedRowRoot, ReplacedRow);
+        for J := 0 to Row.Elements.Count - 1 do
+        begin
+          Args := TGocciaArgumentsCollection.CreateWithCapacity(2);
+          try
+            Args.Add(TGocciaNumberLiteralValue.Create(J));
+            Args.Add(Row.Elements[J]);
+            ReplacerResult := InvokeCallable(AReplacer, Args,
+              TGocciaUndefinedLiteralValue.UndefinedValue);
+          finally
+            Args.Free;
+          end;
+          ReplacedRow.Elements.Add(ReplacerResult);
+        end;
+        ReplacedArr.Elements.Add(ReplacedRow);
+      end;
+    end;
+  end;
+
+  Result := ReplacedArr;
+  finally
+    RemoveTempRootIfNeeded(ItemRoot);
+    RemoveTempRootIfNeeded(ReplacedRowRoot);
+    RemoveTempRootIfNeeded(ReplacedArrRoot);
+  end;
+end;
+
+end.

--- a/source/units/Goccia.Builtins.TSV.pas
+++ b/source/units/Goccia.Builtins.TSV.pas
@@ -24,12 +24,6 @@ type
     procedure ReadOptions(const AArgs: TGocciaArgumentsCollection;
       const AOptionsIndex: Integer; out AHeaders: Boolean;
       out ASkipEmptyLines: Boolean);
-    function GetReviver(const AArgs: TGocciaArgumentsCollection;
-      const AReviverIndex: Integer): TGocciaValue;
-    function GetReplacer(const AArgs: TGocciaArgumentsCollection;
-      const AReplacerIndex: Integer): TGocciaValue;
-    function BuildChunkResultObject(
-      const AChunkResult: TGocciaTSVChunkParseResult): TGocciaValue;
   published
     function TSVParse(const AArgs: TGocciaArgumentsCollection;
       const AThisValue: TGocciaValue): TGocciaValue;
@@ -47,8 +41,7 @@ type
 implementation
 
 uses
-  Goccia.Constants.ErrorNames,
-  Goccia.Constants.PropertyNames,
+  Goccia.Builtins.DelimitedText,
   Goccia.GarbageCollector,
   Goccia.ThreadCleanupRegistry,
   Goccia.Utils,
@@ -127,81 +120,12 @@ begin
     ASkipEmptyLines := TGocciaBooleanLiteralValue(Prop).Value;
 end;
 
-function TGocciaTSVBuiltin.GetReviver(
-  const AArgs: TGocciaArgumentsCollection;
-  const AReviverIndex: Integer): TGocciaValue;
-begin
-  Result := nil;
-  if AArgs.Length > AReviverIndex then
-  begin
-    Result := AArgs.GetElement(AReviverIndex);
-    if not Result.IsCallable then
-      Result := nil;
-  end;
-end;
-
-function TGocciaTSVBuiltin.GetReplacer(
-  const AArgs: TGocciaArgumentsCollection;
-  const AReplacerIndex: Integer): TGocciaValue;
-begin
-  Result := nil;
-  if AArgs.Length > AReplacerIndex then
-  begin
-    Result := AArgs.GetElement(AReplacerIndex);
-    if not Result.IsCallable then
-      Result := nil;
-  end;
-end;
-
-function TGocciaTSVBuiltin.BuildChunkResultObject(
-  const AChunkResult: TGocciaTSVChunkParseResult): TGocciaValue;
-var
-  ErrorValue: TGocciaValue;
-  ResultObject: TGocciaObjectValue;
-  ValuesRoot: TGocciaTempRoot;
-  ResultRoot: TGocciaTempRoot;
-  ErrorRoot: TGocciaTempRoot;
-begin
-  { CreateErrorObject allocates and property storage is charged on
-    assignment — both GC safe points — so the parsed values array, the result
-    object, and the error object are all rooted until the assignments below
-    store them. }
-  InitializeTempRoot(ValuesRoot);
-  InitializeTempRoot(ResultRoot);
-  InitializeTempRoot(ErrorRoot);
-  AddTempRootIfNeeded(ValuesRoot, AChunkResult.Values);
-  try
-    ResultObject := TGocciaObjectValue.Create;
-    AddTempRootIfNeeded(ResultRoot, ResultObject);
-    if AChunkResult.ErrorMessage = '' then
-      ErrorValue := TGocciaNullLiteralValue.NullValue
-    else
-    begin
-      ErrorValue := CreateErrorObject(SYNTAX_ERROR_NAME,
-        AChunkResult.ErrorMessage, 1);
-      AddTempRootIfNeeded(ErrorRoot, ErrorValue);
-    end;
-
-    ResultObject.AssignProperty(PROP_VALUES, AChunkResult.Values);
-    ResultObject.AssignProperty(PROP_READ,
-      TGocciaNumberLiteralValue.Create(AChunkResult.Read));
-    ResultObject.AssignProperty(PROP_DONE,
-      TGocciaBooleanLiteralValue.Create(AChunkResult.Done));
-    ResultObject.AssignProperty(PROP_ERROR, ErrorValue);
-    Result := ResultObject;
-  finally
-    RemoveTempRootIfNeeded(ErrorRoot);
-    RemoveTempRootIfNeeded(ResultRoot);
-    RemoveTempRootIfNeeded(ValuesRoot);
-  end;
-end;
-
 function TGocciaTSVBuiltin.TSVParse(
   const AArgs: TGocciaArgumentsCollection;
   const AThisValue: TGocciaValue): TGocciaValue;
 var
-  Args: TGocciaArgumentsCollection;
   Context: TGocciaObjectValue;
+  FieldValue: string;
   FieldInfoRows: TArray<TArray<TGocciaTSVFieldInfo>>;
   Headers: Boolean;
   HeaderRow: TArray<TGocciaTSVFieldInfo>;
@@ -225,7 +149,7 @@ begin
 
   Text := AArgs.GetElement(0).ToStringLiteral.Value;
   ReadOptions(AArgs, 1, Headers, SkipEmptyLines);
-  Reviver := GetReviver(AArgs, 2);
+  Reviver := GetDelimitedTextCallback(AArgs, 2);
 
   { The reviver is arbitrary JS and every field string is charged against the
     memory ceiling, so both are GC safe points; the result array, the
@@ -266,21 +190,12 @@ begin
             Context.AssignProperty('column',
               TGocciaNumberLiteralValue.Create(J));
 
-            Args := TGocciaArgumentsCollection.CreateWithCapacity(3);
-            try
-              Args.Add(TGocciaStringLiteralValue.Create(Key));
-              if J < Length(FieldInfoRows[I]) then
-                Args.Add(
-                  TGocciaStringLiteralValue.Create(FieldInfoRows[I][J].Value))
-              else
-                Args.Add(TGocciaStringLiteralValue.Create(''));
-              Args.Add(Context);
-
-              ReviverResult := InvokeCallable(Reviver, Args,
-                TGocciaUndefinedLiteralValue.UndefinedValue);
-            finally
-              Args.Free;
-            end;
+            if J < Length(FieldInfoRows[I]) then
+              FieldValue := FieldInfoRows[I][J].Value
+            else
+              FieldValue := '';
+            ReviverResult := InvokeDelimitedTextReviver(Reviver,
+              TGocciaStringLiteralValue.Create(Key), FieldValue, Context);
             Obj.AssignProperty(Key, ReviverResult);
           end;
           ParsedResult.Elements.Add(Obj);
@@ -301,18 +216,9 @@ begin
             Context.AssignProperty('column',
               TGocciaNumberLiteralValue.Create(J));
 
-            Args := TGocciaArgumentsCollection.CreateWithCapacity(3);
-            try
-              Args.Add(TGocciaNumberLiteralValue.Create(J));
-              Args.Add(
-                TGocciaStringLiteralValue.Create(FieldInfoRows[I][J].Value));
-              Args.Add(Context);
-
-              ReviverResult := InvokeCallable(Reviver, Args,
-                TGocciaUndefinedLiteralValue.UndefinedValue);
-            finally
-              Args.Free;
-            end;
+            ReviverResult := InvokeDelimitedTextReviver(Reviver,
+              TGocciaNumberLiteralValue.Create(J),
+              FieldInfoRows[I][J].Value, Context);
             Row.Elements.Add(ReviverResult);
           end;
           ParsedResult.Elements.Add(Row);
@@ -380,7 +286,8 @@ begin
   try
     ChunkResult := FParser.ParseChunk(Text, Headers, SkipEmptyLines,
       StartOffset, EndOffset);
-    Result := BuildChunkResultObject(ChunkResult);
+    Result := BuildDelimitedTextChunkResult(ChunkResult.Values,
+      ChunkResult.Read, ChunkResult.Done, ChunkResult.ErrorMessage);
   except
     on E: EGocciaTSVParseError do
       ThrowSyntaxError(E.Message);
@@ -391,107 +298,30 @@ function TGocciaTSVBuiltin.TSVStringify(
   const AArgs: TGocciaArgumentsCollection;
   const AThisValue: TGocciaValue): TGocciaValue;
 var
-  Args: TGocciaArgumentsCollection;
-  Arr: TGocciaArrayValue;
   Data: TGocciaValue;
   Headers: Boolean;
-  I, J: Integer;
-  Item: TGocciaValue;
-  Key: string;
-  Keys: TArray<string>;
-  Obj: TGocciaObjectValue;
   Replacer: TGocciaValue;
-  ReplacerResult: TGocciaValue;
   ReplacedArr: TGocciaArrayValue;
-  ReplacedObj: TGocciaObjectValue;
-  ReplacedRow: TGocciaArrayValue;
-  Row: TGocciaArrayValue;
   SkipEmptyLines: Boolean;
   ReplacedArrRoot: TGocciaTempRoot;
-  ReplacedRowRoot: TGocciaTempRoot;
 begin
   TGocciaArgumentValidator.RequireAtLeast(AArgs, 1, 'TSV.stringify',
     ThrowError);
 
   Data := AArgs.GetElement(0);
   ReadOptions(AArgs, 1, Headers, SkipEmptyLines);
-  Replacer := GetReplacer(AArgs, 2);
+  Replacer := GetDelimitedTextCallback(AArgs, 2);
 
   if Assigned(Replacer) and (Data is TGocciaArrayValue) then
   begin
-    { The replacer is arbitrary JS (a GC safe point); the replaced rows exist
-      only in this frame until stringified, so they need temp roots. }
     InitializeTempRoot(ReplacedArrRoot);
-    InitializeTempRoot(ReplacedRowRoot);
     try
-    Arr := TGocciaArrayValue(Data);
-    ReplacedArr := TGocciaArrayValue.Create;
-    AddTempRootIfNeeded(ReplacedArrRoot, ReplacedArr);
-
-    if (Arr.Elements.Count > 0) and
-       (Arr.Elements[0] is TGocciaObjectValue) and
-       not (Arr.Elements[0] is TGocciaArrayValue) then
-    begin
-      Keys := TGocciaObjectValue(Arr.Elements[0]).GetOwnPropertyKeys;
-      for I := 0 to Arr.Elements.Count - 1 do
-      begin
-        if not (Arr.Elements[I] is TGocciaObjectValue) then
-          Continue;
-        Obj := TGocciaObjectValue(Arr.Elements[I]);
-        ReplacedObj := TGocciaObjectValue.Create;
-        AddTempRootIfNeeded(ReplacedRowRoot, ReplacedObj);
-        for J := 0 to Length(Keys) - 1 do
-        begin
-          Key := Keys[J];
-          Item := Obj.GetProperty(Key);
-          if not Assigned(Item) then
-            Item := TGocciaUndefinedLiteralValue.UndefinedValue;
-
-          Args := TGocciaArgumentsCollection.CreateWithCapacity(2);
-          try
-            Args.Add(TGocciaStringLiteralValue.Create(Key));
-            Args.Add(Item);
-            ReplacerResult := InvokeCallable(Replacer, Args,
-              TGocciaUndefinedLiteralValue.UndefinedValue);
-          finally
-            Args.Free;
-          end;
-          ReplacedObj.AssignProperty(Key, ReplacerResult);
-        end;
-        ReplacedArr.Elements.Add(ReplacedObj);
-      end;
-    end
-    else
-    begin
-      for I := 0 to Arr.Elements.Count - 1 do
-      begin
-        if Arr.Elements[I] is TGocciaArrayValue then
-        begin
-          Row := TGocciaArrayValue(Arr.Elements[I]);
-          ReplacedRow := TGocciaArrayValue.Create;
-          AddTempRootIfNeeded(ReplacedRowRoot, ReplacedRow);
-          for J := 0 to Row.Elements.Count - 1 do
-          begin
-            Args := TGocciaArgumentsCollection.CreateWithCapacity(2);
-            try
-              Args.Add(TGocciaNumberLiteralValue.Create(J));
-              Args.Add(Row.Elements[J]);
-              ReplacerResult := InvokeCallable(Replacer, Args,
-                TGocciaUndefinedLiteralValue.UndefinedValue);
-            finally
-              Args.Free;
-            end;
-            ReplacedRow.Elements.Add(ReplacerResult);
-          end;
-          ReplacedArr.Elements.Add(ReplacedRow);
-        end;
-      end;
-    end;
-
-    Result := TGocciaStringLiteralValue.Create(
-      TGocciaTSVStringifier.Stringify(ReplacedArr, Headers));
+      ReplacedArr := ApplyDelimitedTextReplacer(TGocciaArrayValue(Data),
+        Replacer);
+      AddTempRootIfNeeded(ReplacedArrRoot, ReplacedArr);
+      Result := TGocciaStringLiteralValue.Create(
+        TGocciaTSVStringifier.Stringify(ReplacedArr, Headers));
     finally
-      RemoveTempRootIfNeeded(ReplacedRowRoot);
       RemoveTempRootIfNeeded(ReplacedArrRoot);
     end;
   end

--- a/tests/built-ins/CSV/parse.js
+++ b/tests/built-ins/CSV/parse.js
@@ -414,3 +414,27 @@ describe("CSV metadata", () => {
     expect(CSV[Symbol.toStringTag]).toBe("Module");
   });
 });
+
+describe.runIf(typeof Goccia !== "undefined")("CSV.parse GC roots", () => {
+  test("keeps revived rows and contexts through later callback collections", () => {
+    const rows = CSV.parse("a,b\nx,y\nz", {}, (key, value, context) => {
+      Goccia.gc();
+      return { key, value, context };
+    });
+
+    expect(rows[0].b).toEqual({
+      key: "b",
+      value: "y",
+      context: { row: 0, column: 1, quoted: false },
+    });
+    expect(rows[1].b.value).toBe("");
+    const arrays = CSV.parse("x,y\nz", { headers: false }, (key, value) => {
+      Goccia.gc();
+      return { key, value };
+    });
+    expect(arrays).toEqual([
+      [{ key: 0, value: "x" }, { key: 1, value: "y" }],
+      [{ key: 0, value: "z" }],
+    ]);
+  });
+});

--- a/tests/built-ins/CSV/stringify.js
+++ b/tests/built-ins/CSV/stringify.js
@@ -170,3 +170,21 @@ describe("CSV.stringify error handling", () => {
     expect(() => CSV.stringify()).toThrow();
   });
 });
+
+describe.runIf(typeof Goccia !== "undefined")("CSV.stringify GC roots", () => {
+  test("keeps converted object and array rows through later callbacks", () => {
+    const calls = [];
+    const replacer = (key, value) => {
+      Goccia.gc();
+      calls.push(key);
+      return value + "!";
+    };
+    expect(CSV.stringify([{ a: "x", b: "y" }, { a: "z", b: "w" }], {}, replacer))
+      .toBe("a,b\nx!,y!\nz!,w!");
+    expect(calls).toEqual(["a", "b", "a", "b"]);
+    calls.length = 0;
+    expect(CSV.stringify([["x", "y"], ["z", "w"]], { headers: false }, replacer))
+      .toBe("x!,y!\nz!,w!");
+    expect(calls).toEqual([0, 1, 0, 1]);
+  });
+});

--- a/tests/built-ins/TSV/parse.js
+++ b/tests/built-ins/TSV/parse.js
@@ -267,3 +267,27 @@ describe("TSV metadata", () => {
     expect(TSV[Symbol.toStringTag]).toBe("Module");
   });
 });
+
+describe.runIf(typeof Goccia !== "undefined")("TSV.parse GC roots", () => {
+  test("keeps revived rows and contexts through later callback collections", () => {
+    const rows = TSV.parse("a\tb\nx\ty\nz", {}, (key, value, context) => {
+      Goccia.gc();
+      return { key, value, context };
+    });
+
+    expect(rows[0].b).toEqual({
+      key: "b",
+      value: "y",
+      context: { row: 0, column: 1 },
+    });
+    expect(rows[1].b.value).toBe("");
+    const arrays = TSV.parse("x\ty\nz", { headers: false }, (key, value) => {
+      Goccia.gc();
+      return { key, value };
+    });
+    expect(arrays).toEqual([
+      [{ key: 0, value: "x" }, { key: 1, value: "y" }],
+      [{ key: 0, value: "z" }],
+    ]);
+  });
+});

--- a/tests/built-ins/TSV/stringify.js
+++ b/tests/built-ins/TSV/stringify.js
@@ -145,3 +145,21 @@ describe("TSV.stringify error handling", () => {
     expect(() => TSV.stringify()).toThrow();
   });
 });
+
+describe.runIf(typeof Goccia !== "undefined")("TSV.stringify GC roots", () => {
+  test("keeps converted object and array rows through later callbacks", () => {
+    const calls = [];
+    const replacer = (key, value) => {
+      Goccia.gc();
+      calls.push(key);
+      return value + "!";
+    };
+    expect(TSV.stringify([{ a: "x", b: "y" }, { a: "z", b: "w" }], {}, replacer))
+      .toBe("a\tb\nx!\ty!\nz!\tw!");
+    expect(calls).toEqual(["a", "b", "a", "b"]);
+    calls.length = 0;
+    expect(TSV.stringify([["x", "y"], ["z", "w"]], { headers: false }, replacer))
+      .toBe("x!\ty!\nz!\tw!");
+    expect(calls).toEqual([0, 1, 0, 1]);
+  });
+});


### PR DESCRIPTION
## Summary

- Centralize duplicated CSV/TSV callback selection, chunk result assembly, reviver arguments, and replacer row conversion in a stateless runtime helper. Temporary values remain rooted across callbacks and serialization, including getter-produced replacer values while the key is allocated.
- Preserve parser grammars, CSV delimiter/quoting and `context.quoted`, TSV escapes, options/getter order, chunk offsets, callback keys/order and format-specific errors. Constructor member definitions remain outside this PR's scope.
- Document adapter ownership and add explicit-GC regressions through both public APIs. Separate manual diff review found no actionable issues. No linked issue; this implements the approved CSV/TSV audit finding.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests — focused local suites and both full CI suites pass.
- [x] Updated documentation
- [x] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed)
- [x] Optional: Existing benchmark, AWFY, and JetStream CI lanes pass; no speedup is claimed.

Clean production testrunner/loader builds and the FFI fixture passed. Focused CSV and TSV suites passed in both execution modes: **143 tests, 282 assertions per mode**, including four added explicit-GC callback regressions. The existing CLI builtin-builder memory sweep passed at six limits plus its 128 MiB success control in both modes. The native GC suite (**12/12**), formatter **464 files**, test-structure check **1,600 files**, and diff check passed. No CSV/TSV native parser test programs exist in this checkout; the parsers are unchanged.

All 49 checks pass at head `40ba37c3876492d0d2bf613437cc423f5217e2a8`, including both full JavaScript suites. Local validation was serialized and focused after unrelated baseline worker failures and long shared-host queues. No CSV/TSV runtime check failed. Readiness and source review are complete.

The actual CI conformance comparison reports no new ordinary failures. Its new/resolved timeout pair occurs in unchanged bare-loader code; CSV/TSV extensions are not installed by that runtime. This is not a full-conformance claim.
