### PR TITLE
refactor(runtime): centralize ordered property keys

### DIFF
--- a/docs/core-patterns.md
+++ b/docs/core-patterns.md
@@ -63,6 +63,10 @@ MathObj.DefineProperty('PI', TGocciaNumberLiteralValue.Create(Pi), False);
 MathObj.DefineProperty('floor', TGocciaNativeFunction.Create(@MathFloor), False);
 ```
 
+### Ordered own property keys
+
+`TGocciaObjectValue.GetOwnPropertyKeys` owns string-key enumeration order. Ordinary objects return array indices in ascending numeric order followed by other strings in creation order; exotic values retain their own ordering. `OwnPropertyKeyValues` includes symbols and preserves a proxy trap's mixed string/symbol order. Both executors consume these existing value-layer operations for object spread, rest, and `for...in`, without sorting the returned keys again. Classes include their synthesized `length`, `name`, and `prototype` keys through their override, just as other exotic values include their virtual properties.
+
 ### Parser combinator (binary expressions)
 
 All left-associative binary operator parsers delegate to a shared `ParseBinaryExpression` helper:

--- a/source/units/Goccia.Evaluator.pas
+++ b/source/units/Goccia.Evaluator.pas
@@ -302,11 +302,6 @@ const
   FOR_IN_MAX_PROTOTYPE_CHAIN_DEPTH = 256;
 
 type
-  TForInArrayIndexKey = record
-    Key: string;
-    Index: Int64;
-  end;
-
   TGocciaTemplateObjectArrayValue = class(TGocciaArrayValue)
   public
     function GetOwnPropertyDescriptor(
@@ -405,88 +400,6 @@ begin
   Result := inherited TryDefineProperty(AName, ADescriptor);
 end;
 
-function TryParseForInArrayIndex(const AKey: string; out AIndex: Int64): Boolean;
-var
-  I, J, K: Integer;
-  Digit: Int64;
-  MaxIndex: Int64;
-begin
-  AIndex := 0;
-  Result := False;
-  if AKey = '' then
-    Exit;
-  if (AKey[1] = '0') and (Length(AKey) > 1) then
-    Exit;
-
-  MaxIndex := MAX_ARRAY_LENGTH - 1;
-  for I := 1 to Length(AKey) do
-  begin
-    if (AKey[I] < '0') or (AKey[I] > '9') then
-      Exit;
-    Digit := Ord(AKey[I]) - Ord('0');
-    if AIndex > (MaxIndex - Digit) div 10 then
-      Exit;
-    AIndex := AIndex * 10 + Digit;
-  end;
-
-  Result := True;
-end;
-
-function OrderForInPropertyKeys(const AKeys: TArray<string>): TArray<string>;
-var
-  IndexKeys: TArray<TForInArrayIndexKey>;
-  OtherKeys: TArray<string>;
-  IndexCount, OtherCount: Integer;
-  I, J, ResultIndex: Integer;
-  Index: Int64;
-  Current: TForInArrayIndexKey;
-begin
-  SetLength(IndexKeys, Length(AKeys));
-  SetLength(OtherKeys, Length(AKeys));
-  IndexCount := 0;
-  OtherCount := 0;
-
-  for I := 0 to High(AKeys) do
-  begin
-    if TryParseForInArrayIndex(AKeys[I], Index) then
-    begin
-      IndexKeys[IndexCount].Key := AKeys[I];
-      IndexKeys[IndexCount].Index := Index;
-      Inc(IndexCount);
-    end
-    else
-    begin
-      OtherKeys[OtherCount] := AKeys[I];
-      Inc(OtherCount);
-    end;
-  end;
-
-  for I := 1 to IndexCount - 1 do
-  begin
-    Current := IndexKeys[I];
-    J := I - 1;
-    while (J >= 0) and (IndexKeys[J].Index > Current.Index) do
-    begin
-      IndexKeys[J + 1] := IndexKeys[J];
-      Dec(J);
-    end;
-    IndexKeys[J + 1] := Current;
-  end;
-
-  SetLength(Result, IndexCount + OtherCount);
-  ResultIndex := 0;
-  for I := 0 to IndexCount - 1 do
-  begin
-    Result[ResultIndex] := IndexKeys[I].Key;
-    Inc(ResultIndex);
-  end;
-  for I := 0 to OtherCount - 1 do
-  begin
-    Result[ResultIndex] := OtherKeys[I];
-    Inc(ResultIndex);
-  end;
-end;
-
 procedure EnsureObjectPrototypeInitialized; {$IFDEF FPC}inline;{$ENDIF}
 begin
   if TGocciaObjectValue.SharedObjectPrototype = nil then
@@ -506,104 +419,6 @@ begin
 
   Result := Assigned(AExcludedStringKeys) and
     (AExcludedStringKeys.IndexOf(AKey.ToStringLiteral.Value) >= 0);
-end;
-
-function TryParseArrayPropertyIndex(const AKey: string;
-  out AIndex: Int64): Boolean;
-var
-  Digit: Int64;
-  I: Integer;
-begin
-  AIndex := 0;
-  Result := False;
-  if AKey = '' then
-    Exit;
-  if (AKey[1] = '0') and (Length(AKey) > 1) then
-    Exit;
-
-  for I := 1 to Length(AKey) do
-  begin
-    if (AKey[I] < '0') or (AKey[I] > '9') then
-      Exit;
-    Digit := Ord(AKey[I]) - Ord('0');
-    if AIndex > (MAX_SAFE_INTEGER - Digit) div 10 then
-      Exit;
-    AIndex := AIndex * 10 + Digit;
-  end;
-
-  Result := AIndex < MAX_ARRAY_LENGTH;
-end;
-
-function OrderOwnPropertyStringKeys(const AKeys: TArray<string>):
-  TArray<string>;
-var
-  ParsedIndex, TempIndex: Int64;
-  NumericKeys: TArray<Int64>;
-  OtherKeys: TArray<string>;
-  I, J, K, Count: Integer;
-begin
-  SetLength(NumericKeys, Length(AKeys));
-  SetLength(OtherKeys, Length(AKeys));
-  Count := 0;
-  J := 0;
-
-  for I := 0 to High(AKeys) do
-  begin
-    if TryParseArrayPropertyIndex(AKeys[I], ParsedIndex) then
-    begin
-      NumericKeys[Count] := ParsedIndex;
-      Inc(Count);
-    end
-    else
-    begin
-      OtherKeys[J] := AKeys[I];
-      Inc(J);
-    end;
-  end;
-
-  for I := 1 to Count - 1 do
-  begin
-    TempIndex := NumericKeys[I];
-    K := I - 1;
-    while (K >= 0) and (NumericKeys[K] > TempIndex) do
-    begin
-      NumericKeys[K + 1] := NumericKeys[K];
-      Dec(K);
-    end;
-    NumericKeys[K + 1] := TempIndex;
-  end;
-
-  SetLength(Result, Count + J);
-  for I := 0 to Count - 1 do
-    Result[I] := IntToStr(NumericKeys[I]);
-  for I := 0 to J - 1 do
-    Result[Count + I] := OtherKeys[I];
-end;
-
-function OwnPropertyKeysAsValues(const ASource: TGocciaObjectValue):
-  TArray<TGocciaValue>;
-var
-  I, Count: Integer;
-  StringKeys: TArray<string>;
-  SymbolKeys: TArray<TGocciaSymbolValue>;
-begin
-  if ASource is TGocciaProxyValue then
-    Exit(TGocciaProxyValue(ASource).GetOwnPropertyKeyValues);
-
-  StringKeys := OrderOwnPropertyStringKeys(ASource.GetAllPropertyNames);
-  SymbolKeys := ASource.GetOwnSymbols;
-  SetLength(Result, Length(StringKeys) + Length(SymbolKeys));
-  Count := 0;
-  for I := 0 to High(StringKeys) do
-  begin
-    Result[Count] := TGocciaStringLiteralValue.Create(StringKeys[I]);
-    Inc(Count);
-  end;
-  for I := 0 to High(SymbolKeys) do
-  begin
-    Result[Count] := SymbolKeys[I];
-    Inc(Count);
-  end;
 end;
 
 // ES2026 §7.3.25 CopyDataProperties(target, source, excludedItems).
@@ -627,7 +442,7 @@ begin
 
   SourceObject := ToObject(ASource);
 
-  { The key list is the exposure this loop is built around. OwnPropertyKeysAsValues
+  { The key list is the exposure this loop is built around. OwnPropertyKeyValues
     hands back freshly created string values (and the source's symbols) in a plain
     Pascal array, which is not a root, and the very next thing the loop does is
     call a guest getter — arbitrary collecting script code. Without the frame the
@@ -647,7 +462,7 @@ begin
   try
     Roots.Add(ATarget);
     Roots.Add(SourceObject);
-    Keys := OwnPropertyKeysAsValues(SourceObject);
+    Keys := SourceObject.OwnPropertyKeyValues;
     for Key in Keys do
       Roots.Add(Key);
     for Key in Keys do
@@ -5846,8 +5661,7 @@ begin
     if Assigned(GC) then
       GC.AddTempRoot(Obj);
     // Dedup keys across the prototype chain via O(1) hash-set membership
-    // (native case-sensitive string equality); OrderForInPropertyKeys
-    // (above) owns per-level enumeration order.
+    // (native case-sensitive string equality). Each object owns its key order.
     Visited := TOrderedStringMap<Boolean>.Create;
     try
       Current := Obj;
@@ -5859,7 +5673,7 @@ begin
           ThrowTypeError(Format(SErrorProtoChainDepthExceeded, ['for...in']),
             SSuggestPrototypeChainTooDeep);
 
-        Keys := OrderForInPropertyKeys(Current.GetAllPropertyNames);
+        Keys := Current.GetOwnPropertyKeys;
         for Key in Keys do
         begin
           if Visited.ContainsKey(Key) then

--- a/source/units/Goccia.VM.pas
+++ b/source/units/Goccia.VM.pas
@@ -2127,105 +2127,6 @@ begin
   ATarget.CreateDataPropertyOrThrow(ASymbol, AValue);
 end;
 
-function VMTryParseArrayPropertyIndex(const AKey: string;
-  out AIndex: Int64): Boolean;
-var
-  Digit: Int64;
-  I: Integer;
-begin
-  AIndex := 0;
-  Result := False;
-  if AKey = '' then
-    Exit;
-  if (AKey[1] = '0') and (Length(AKey) > 1) then
-    Exit;
-
-  for I := 1 to Length(AKey) do
-  begin
-    if (AKey[I] < '0') or (AKey[I] > '9') then
-      Exit;
-    Digit := Ord(AKey[I]) - Ord('0');
-    if AIndex > (MAX_SAFE_INTEGER - Digit) div 10 then
-      Exit;
-    AIndex := AIndex * 10 + Digit;
-  end;
-
-  Result := AIndex < MAX_ARRAY_LENGTH;
-end;
-
-function VMOrderOwnPropertyStringKeys(const AKeys: TArray<string>):
-  TArray<string>;
-var
-  ParsedIndex, TempIndex: Int64;
-  NumericKeys: TArray<Int64>;
-  OtherKeys: TArray<string>;
-  I, J, K, Count: Integer;
-begin
-  SetLength(NumericKeys, Length(AKeys));
-  SetLength(OtherKeys, Length(AKeys));
-  Count := 0;
-  J := 0;
-
-  for I := 0 to High(AKeys) do
-  begin
-    if VMTryParseArrayPropertyIndex(AKeys[I], ParsedIndex) then
-    begin
-      NumericKeys[Count] := ParsedIndex;
-      Inc(Count);
-    end
-    else
-    begin
-      OtherKeys[J] := AKeys[I];
-      Inc(J);
-    end;
-  end;
-
-  for I := 1 to Count - 1 do
-  begin
-    TempIndex := NumericKeys[I];
-    K := I - 1;
-    while (K >= 0) and (NumericKeys[K] > TempIndex) do
-    begin
-      NumericKeys[K + 1] := NumericKeys[K];
-      Dec(K);
-    end;
-    NumericKeys[K + 1] := TempIndex;
-  end;
-
-  SetLength(Result, Count + J);
-  for I := 0 to Count - 1 do
-    Result[I] := IntToStr(NumericKeys[I]);
-  for I := 0 to J - 1 do
-    Result[Count + I] := OtherKeys[I];
-end;
-
-function VMOwnPropertyKeysAsValues(
-  const ASource: TGocciaObjectValue): TArray<TGocciaValue>;
-var
-  Count: Integer;
-  I: Integer;
-  StringKeys: TArray<string>;
-  SymbolKeys: TArray<TGocciaSymbolValue>;
-begin
-  if ASource is TGocciaProxyValue then
-    Exit(TGocciaProxyValue(ASource).GetOwnPropertyKeyValues);
-
-  StringKeys := VMOrderOwnPropertyStringKeys(ASource.GetAllPropertyNames);
-  SymbolKeys := ASource.GetOwnSymbols;
-  SetLength(Result, Length(StringKeys) + Length(SymbolKeys));
-  Count := 0;
-  for I := 0 to High(StringKeys) do
-  begin
-    Result[Count] := TGocciaStringLiteralValue.Create(StringKeys[I]);
-    Inc(Count);
-  end;
-  for I := 0 to High(SymbolKeys) do
-  begin
-    Result[Count] := SymbolKeys[I];
-    Inc(Count);
-  end;
-end;
-
 function VMCopyDataPropertyKeyExcluded(const AKey: TGocciaValue;
   const AExclusionKeys: TGocciaArrayValue): Boolean;
 var
@@ -2274,7 +2175,7 @@ begin
   try
     Roots.Add(ATarget);
     Roots.Add(SourceObject);
-    Keys := VMOwnPropertyKeysAsValues(SourceObject);
+    Keys := SourceObject.OwnPropertyKeyValues;
     for Key in Keys do
       Roots.Add(Key);
     for Key in Keys do
@@ -9594,8 +9495,7 @@ begin
     if Assigned(GC) then
       GC.AddTempRoot(Obj);
     // Dedup keys across the prototype chain via O(1) hash-set membership
-    // (native case-sensitive string equality); VMOrderOwnPropertyStringKeys
-    // (above) owns per-level enumeration order.
+    // (native case-sensitive string equality). Each object owns its key order.
     Visited := TOrderedStringMap<Boolean>.Create;
     try
       Current := Obj;
@@ -9607,7 +9507,7 @@ begin
           ThrowTypeError(Format(SErrorProtoChainDepthExceeded, ['for...in']),
             SSuggestPrototypeChainTooDeep);
 
-        Keys := VMOrderOwnPropertyStringKeys(Current.GetAllPropertyNames);
+        Keys := Current.GetOwnPropertyKeys;
         for Key in Keys do
         begin
           if Visited.ContainsKey(Key) then

--- a/source/units/Goccia.Values.ClassValue.pas
+++ b/source/units/Goccia.Values.ClassValue.pas
@@ -185,6 +185,7 @@ type
     procedure SetProperty(const AName: string; const AValue: TGocciaValue); override;
     function GetOwnPropertyDescriptor(const AName: string): TGocciaPropertyDescriptor; override;
     function GetAllPropertyNames: TArray<string>; override;
+    function GetOwnPropertyKeys: TArray<string>; override;
     function HasOwnProperty(const AName: string): Boolean; override;
     function DeleteProperty(const AName: string): Boolean; override;
     function Call(const AArguments: TGocciaArgumentsCollection; const AThisValue: TGocciaValue): TGocciaValue; virtual;
@@ -2504,6 +2505,11 @@ begin
       AppendName(OwnNames[I]);
 
   SetLength(Result, Count);
+end;
+
+function TGocciaClassValue.GetOwnPropertyKeys: TArray<string>;
+begin
+  Result := GetAllPropertyNames;
 end;
 
 function TGocciaClassValue.HasOwnProperty(const AName: string): Boolean;

--- a/source/units/Goccia.Values.ObjectValue.pas
+++ b/source/units/Goccia.Values.ObjectValue.pas
@@ -96,8 +96,11 @@ type
     function GetEnumerablePropertyEntries: TArray<TPair<string, TGocciaValue>>; virtual;
     function GetAllPropertyNames: TArray<string>; virtual;
     function GetOwnPropertyNames: TArray<string>; virtual;
+    // Ordered own string keys. Ordinary objects use ES2026 §10.1.11.1;
+    // exotic overrides preserve their own [[OwnPropertyKeys]] order.
     function GetOwnPropertyKeys: TArray<string>; virtual;
 
+    // Includes symbols and preserves the complete mixed order of proxy traps.
     function OwnPropertyKeyValues: TArray<TGocciaValue>;
     function OwnPropertyDescriptorForKey(
       const AKey: TGocciaValue): TGocciaPropertyDescriptor;
@@ -484,18 +487,18 @@ begin
     Result := TGocciaNullLiteralValue.NullValue;
 end;
 
-function OwnPropertyKeyValues(const AObject: TGocciaObjectValue): TArray<TGocciaValue>;
+function TGocciaObjectValue.OwnPropertyKeyValues: TArray<TGocciaValue>;
 var
   Count: Integer;
   I: Integer;
   StringKeys: TArray<string>;
   SymbolKeys: TArray<TGocciaSymbolValue>;
 begin
-  if AObject is TGocciaProxyValue then
-    Exit(TGocciaProxyValue(AObject).GetOwnPropertyKeyValues);
+  if Self is TGocciaProxyValue then
+    Exit(TGocciaProxyValue(Self).GetOwnPropertyKeyValues);
 
-  StringKeys := AObject.GetOwnPropertyKeys;
-  SymbolKeys := AObject.GetOwnSymbols;
+  StringKeys := GetOwnPropertyKeys;
+  SymbolKeys := GetOwnSymbols;
   SetLength(Result, Length(StringKeys) + Length(SymbolKeys));
   Count := 0;
   for I := 0 to High(StringKeys) do
@@ -534,11 +537,6 @@ begin
     ADescriptor.Free;
     raise;
   end;
-end;
-
-function TGocciaObjectValue.OwnPropertyKeyValues: TArray<TGocciaValue>;
-begin
-  Result := Goccia.Values.ObjectValue.OwnPropertyKeyValues(Self);
 end;
 
 function TGocciaObjectValue.OwnPropertyDescriptorForKey(

--- a/tests/language/expressions/spread/object-sideeffects.js
+++ b/tests/language/expressions/spread/object-sideeffects.js
@@ -40,3 +40,33 @@ test("spread evaluation order with side effects", () => {
   expect(result).toEqual({ start: 0, a: 1, middle: 1.5, b: 2, end: 3 });
   expect(sideEffects).toEqual(["start", "get-a", "middle", "get-b", "end"]);
 });
+
+test("spread reads index keys before other strings and then symbols", () => {
+  const reads = [];
+  const symbol = Symbol("last");
+  const source = {};
+  for (const key of ["4294967295", "01", "4294967294", "2", symbol, "0"]) {
+    Object.defineProperty(source, key, {
+      enumerable: true,
+      get: () => { reads.push(key); return key; },
+    });
+  }
+  const copy = { ...source };
+  expect(reads).toEqual(["0", "2", "4294967294", "4294967295", "01", symbol]);
+  expect(copy[symbol]).toBe(symbol);
+});
+
+test("spread includes redefined enumerable class intrinsic properties", () => {
+  const reads = [];
+  class Source { static value = 1; }
+  for (const key of ["name", "length"]) {
+    Object.defineProperty(Source, key, {
+      configurable: true,
+      enumerable: true,
+      get: () => { reads.push(key); return key; },
+    });
+  }
+  const copy = { ...Source };
+  expect(reads).toEqual(["length", "name"]);
+  expect(copy).toEqual({ length: "length", name: "name", value: 1 });
+});

--- a/tests/language/for-in-loop/basic-enumeration.js
+++ b/tests/language/for-in-loop/basic-enumeration.js
@@ -108,6 +108,28 @@ test("array-index property names are ordered before other string keys", () => {
   expect(keys).toEqual(["0", "1", "2", "p2", "p4", "p1"]);
 });
 
+test("array-index boundaries keep non-index strings in creation order", () => {
+  const obj = { "4294967295": 1, "01": 2, "-0": 3, "4294967294": 4, "2": 5, "0": 6 };
+  const keys = [];
+  for (const key in obj) keys.push(key);
+  expect(keys).toEqual(["0", "2", "4294967294", "4294967295", "01", "-0"]);
+});
+
+test("proxy enumeration preserves the ownKeys trap's string order", () => {
+  const symbol = Symbol("hidden from for-in");
+  let calls = 0;
+  const proxy = new Proxy({ 2: "two", 1: "one", label: "label", [symbol]: true }, {
+    ownKeys: () => {
+      calls++;
+      return ["label", symbol, "2", "1"];
+    },
+  });
+  const keys = [];
+  for (const key in proxy) keys.push(key);
+  expect(keys).toEqual(["label", "2", "1"]);
+  expect(calls).toBe(1);
+});
+
 test("lexical loop head names are in TDZ while evaluating the source", () => {
   let key = "outer";
   expect(() => {


### PR DESCRIPTION
## Summary

- Let the shared object model own property-key order. Remove duplicated numeric-index parsing, sorting, and key materialization from both executors; have spread/rest and for-in consume the existing ordered-key APIs. Net reduction: 226 lines including regression coverage and documentation.
- Preserve ordinary index/string/symbol ordering, proxy trap order, and exotic namespace ordering. Add the class override needed to expose synthetic length/name/prototype keys through the common API. Keep key creation directly in the public method, removing its forwarding wrapper and a production-linker reference to a private helper.
- Add boundary, proxy-order, getter-order, and enumerable class-intrinsic regressions. A separate source review checked every exotic override and unchanged GC-root protection. This implements the property-key ownership recommendation from the September 4 audit.

## Testing

- [x] Verified no regressions and confirmed the change in end-to-end JavaScript tests: for-in 38 tests / 113 assertions and spread 40 / 73 pass in both executors.
- [x] Updated documentation: ordered-key contract in the core-patterns guide.
- [x] Optional: Native ObjectValue tests pass 8/8; production test-runner and FFI fixture builds pass.
- [x] Optional: Existing benchmark, AWFY, and JetStream CI lanes pass. No runtime speedup is claimed; this consolidates duplicated ordering code.

Full local interpreter and bytecode suites each pass 12,822 tests / 28,580 assertions. Formatter passes all 463 files. All 49 CI checks pass at head `4c33cd65216ebbf4fafee76fd1273b7987a85eba`; readiness and source review are complete.

Semantics checked against ECMA-262 ES2026: OrdinaryOwnPropertyKeys §10.1.11.1, CopyDataProperties §7.3.25, EnumerateObjectProperties §14.7.5.9, and module namespace [[OwnPropertyKeys]] §10.4.6.11, snapshot `0248456c758431e4bb8e5d26333ff1865123c9cd`.

The actual CI conformance comparison reports no new ordinary failures, but it has several timeout transitions. Three interleaved rounds over all affected/control cases passed on fresh exact-base/candidate production bare loaders (30/30 runs, no timeouts); no candidate-only failure reproduced. Local diagnostics used macOS arm64/jobs1; CI uses Linux x64/jobs4, and the CI timeout deltas remain visible. This is not a full-conformance claim.
