### PR TITLE
perf(strings): defer copies in bytecode accumulators

### DIFF
--- a/.agent/HANDOFF.md
+++ b/.agent/HANDOFF.md
@@ -1,6 +1,59 @@
 # Handoff
 
-Updated: 2026-08-26 (wave 2 prod-dispatch + JUMP_IF_NOT_LT merged)
+Updated: 2026-09-05 (audit string accumulation optimization)
+
+## September audit: bounded string prefixes
+
+The accepted string implementation is `2128fc2df364098a1f7ffeebbac5e1422a369e2c`
+on `codex/audit-string-accumulators`, against baseline
+`f33d9c6a061e6cb61dce65ffcf8514da1c051870`. This is a Goccia-vs-Goccia
+comparison; no new QuickJS gap or cross-architecture result was measured.
+The August wave sections below retain their original historical context.
+
+The bytecode primitive-string concatenation paths retain immutable prefix
+links bounded at 32. Every append reserves its eventual materialization capacity,
+so reading `Value` does not collect or run guest code. Aliases and UTF-16 contents
+remain intact; ordinary literals remain flat. Under memory pressure, flattening
+the parent allows collection of unaliased intermediate prefixes. See
+[ADR 0116](../docs/adr/0116-bounded-string-prefixes.md) for the representation,
+measured limits, upstream pins, and profile evidence.
+
+Measurements used FPC 3.2.2 production loaders on macOS 26.5.2 arm64, bytecode
+mode, a 256 MiB GC budget, and `/tmp/gocciascript-perf-gate.lock`. Each order
+had one discarded warmup and seven interleaved measured samples, followed by
+reverse order. Engine execution medians in milliseconds were:
+
+| Workload | Baseline AB / BA | Candidate AB / BA |
+|---|---:|---:|
+| Append, 8,000 iterations | 473.3 / 461.9 | 25.3 / 25.9 |
+| JetStream Base64 worker kernel | 1432.0 / 1432.7 | 1111.3 / 1112.3 |
+
+Process CPU timing confirmed both target and transfer improvements. The Json
+parser guard initially varied by order; a five-parse invocation and seven ABBA
+blocks (14 measured samples per binary) found no repeatable regression. No Json
+speedup or whole-JetStream score is claimed. Conservative reserved capacity still
+reaches approximately 240 MiB and seven collections in the append probe; native
+heap allocation reported at completion falls from approximately 109 MiB to 5 MiB.
+Frequent reads force materialization, and bounded prefixes do not make arbitrary
+repeated appends asymptotically linear.
+
+Rejected: reserving flat capacity during `Value` reads. That design could collect
+an unrelated temporary operand during a primitive comparison. Its patch and
+reason are retained with the experiment, and it is absent from the accepted code.
+
+Validation passed in both executors and both production/development builds:
+12,820 tests and 28,654 assertions per run, plus 20 checked native primitive tests,
+formatting, and ordinary hooks. The independent Base64 checksum and AWFY Json's
+upstream verification passed. No other runtime candidate was combined with this
+change, and isolated percentages must not be added to predict a combined result.
+
+Artifacts are retained in the string-accumulators worktree under `tmp/audit/`:
+`string-paired.json`, `string-json-confirmation.json`, `candidate-metadata.json`,
+`baseline-host-sample-current.txt`, and baseline/candidate VM profile reports.
+The measured production candidate SHA-256 is
+`93a7f3c58a33feeec5be0e29516f337662a0257af74f52985e5861e6d61ba183`.
+The remaining representation cost is conservative reserved capacity and forced
+materialization on content reads; profile a real workload before changing either.
 
 ## Experiment
 

--- a/docs/adr/0116-bounded-string-prefixes.md
+++ b/docs/adr/0116-bounded-string-prefixes.md
@@ -1,0 +1,75 @@
+# Bounded string prefixes with reserved materialization capacity
+
+**Date:** 2026-09-05
+**Area:** `runtime`, `bytecode`, `gc`
+
+Bytecode string accumulators retain an immutable prefix and a flat suffix once
+the prefix reaches 256 UTF-16 code units. Every concatenation creates a distinct
+runtime value. A chain has at most 32 links; a native `Value` read or the next
+append at the depth limit materializes it with one allocation and a backward
+copy of the chunks. This reduces repeated copying without changing saved
+aliases, UTF-16 contents, or object coercion order.
+
+The append reserves both the eventual flat buffer and the currently retained
+suffix. Materialization consumes already reserved capacity, releases the suffix
+charge, and drops its prefix link. It never triggers GC or invokes guest code.
+That is a correctness requirement: callers such as primitive comparisons can
+hold unrelated operands only in native locals across a `Value` read. An initial
+candidate that reserved during the read was rejected because protecting the
+string being flattened did not protect those other temporaries.
+
+The collector traces each prefix link. Before an append reservation needs a
+collection to fit, it flattens the parent so the collector can discard unaliased
+intermediate nodes. Aliases remain valid even when an ancestor is materialized
+before its descendants. Deferred values belong to the executing runtime; literal
+constants, hint strings, and prototype initialization use ordinary flat strings,
+whose reads do not mutate their representation.
+
+## Evidence
+
+The baseline was `f33d9c6a061e6cb61dce65ffcf8514da1c051870`, built with
+FreePascal 3.2.2 and `./build.pas --prod loader`. Measurements used macOS 26.5.2
+on arm64, bytecode mode, and a 256 MiB GC budget. Each order discarded one
+warmup per binary and retained seven interleaved samples, followed by the
+reverse order. Timings below are median engine execution milliseconds; process
+CPU timings confirmed the direction despite host scheduling noise.
+
+| Workload | Baseline AB / BA | Candidate AB / BA |
+|---|---:|---:|
+| `string-append-30k`, 8,000 iterations | 473.3 / 461.9 | 25.3 / 25.9 |
+| JetStream Base64 worker kernel | 1432.0 / 1432.7 | 1111.3 / 1112.3 |
+
+For the append workload, execution ranges were 442–563 ms on the baseline and
+24–29 ms on the candidate. Base64 ranges were 1233–1819 ms and 997–1409 ms.
+The Base64 kernel came from JetStream revision
+`c603c04db8505477867974a69789309ded2cc948`,
+`worker/bomb-subtests/string-base64.js`. Its body was unchanged, with deterministic
+input and worker-completion shims around it. Its round-trip check and an
+independently computed checksum passed. This is a standalone kernel result, not
+a JetStream suite score.
+
+AWFY Json at revision `74306fec151070fd07157cefeacf19e7e0bcdc89` guarded short
+strings and parser workloads. Initial order-dependent results prompted a longer
+confirmation: seven ABBA blocks, five verified parses per invocation, and 14
+measured samples per binary. CPU medians were 1383 ms and 1318 ms, with overlapping
+ranges; there was no repeatable guard regression. No Json speedup is claimed.
+
+A three-second baseline host sample of the 30,000-iteration append workload
+placed 1550 of 2446 top-of-stack samples in `memmove`, reached through
+`fpc_unicodestr_concat` in VM dispatch. The 8,000-iteration VM profile recorded
+24,102 `OP_ADD` instructions. This identifies repeated payload copying as the
+target rather than reducing the number of runtime string objects.
+
+## Limits
+
+The bounded chain reduces copy frequency; it does not make arbitrary repeated
+appends asymptotically linear. Frequent content reads force materialization.
+Reserved capacity remains charged even before the flat buffer exists: the
+8,000-iteration probe retained an approximately 240 MiB GC-accounted peak and
+seven collections in both builds, while the native heap allocation reported at
+the end of execution fell from approximately 109 MiB to 5 MiB. These counters
+describe different resources and should not be substituted for each other.
+
+This is not content-keyed string interning or a cache of runtime values.
+[ADR 0013](0013-reject-string-interning.md) and
+[ADR 0081](0081-reject-value-caches-for-allocation-reduction.md) remain in force.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -124,3 +124,4 @@ Durable architecture and implementation decisions for GocciaScript. New ADRs use
 - [0112 — Native AsyncLocalStorage over continuation snapshots](0112-native-async-local-storage.md)
 - [0113 — Deterministic virtual timer queue](0113-deterministic-virtual-timer-queue.md)
 - [0114 — Unmanaged execution-context records](0114-unmanaged-execution-context-records.md)
+- [0116 — Bounded string prefixes with reserved materialization capacity](0116-bounded-string-prefixes.md)

--- a/docs/bytecode-vm.md
+++ b/docs/bytecode-vm.md
@@ -130,6 +130,24 @@ Recent VM cleanup and optimization work has focused on reducing per-instruction 
 - keep fast register access limited to proven hot/simple paths; local-slot and complex property paths should only move to fast access when they stay correct and measurably improve throughput
 - the register, local-cell, and argument window fills are GC-safety/correctness critical (the GC marks the whole live window): they are deliberately retained rather than trimmed
 
+### Growing String Accumulators
+
+Primitive string additions and `OP_CONCAT` can retain an immutable prefix
+instead of copying it on every append. Prefixes shorter than 256 UTF-16 code
+units stay flat; a deferred chain has at most 32 links. Reading the native
+`TGocciaStringLiteralValue.Value` property materializes the chain, and reaching
+the depth limit materializes the prefix before appending. Earlier aliases keep
+their original contents. Object coercions retain the existing `ToPrimitive`
+ordering and rooted arithmetic path.
+
+Materialization never collects or calls guest code: append creation reserves
+the eventual flat buffer in advance. This preserves the existing rooting
+contract of primitive comparisons and other string reads. The representation
+reduces copying, while its reserved capacity still counts against the memory
+limit. See [ADR 0116](adr/0116-bounded-string-prefixes.md) for the measurements
+and [GC accounting](garbage-collector.md#what-bytesallocated-tracks) for the
+reservation lifetime.
+
 ### Inline Caches
 
 Four per-site inline caches live on `TGocciaFunctionTemplate`, all indexed by the instruction's name-constant index, all runtime-only (never serialised to `.gbc`):

--- a/docs/garbage-collector.md
+++ b/docs/garbage-collector.md
@@ -141,6 +141,17 @@ The formula is `min(physicalMemory / 2, platformCap)`.
 
 `BytesAllocated` sums `InstanceSize` of each `TGCManagedObject` registered with the GC. This covers the Delphi/FPC object instance (vtable, fields, padding). Backing storage allocated separately by an object splits into two cases. Storage with a clear owner and a release hook is **charged** to `BytesAllocated` through the `TryReserveExternalBytes` contract — string payloads (`TGocciaStringLiteralValue`) and `ArrayBuffer`/`SharedArrayBuffer` backing stores reserve on allocation and release when the owner is destroyed; `ArrayBuffer`/`SharedArrayBuffer` additionally release the freed bytes when a resize shrinks the backing store (`SetData`/`SetDataLength` release `-Delta` whenever `Delta < 0`), so the charge tracks the live payload rather than the peak. Either way they do count. Storage that is only **gated** (checked before allocation, never charged) does not — dynamic array element buffers in `TGocciaArrayValue` are bounded per-allocation by the growth gate below, not summed into `BytesAllocated`. The ceiling is therefore an approximate safety net, not a precise memory accounting system.
 
+Deferred string prefixes reserve their eventual flat buffer **plus** their
+retained suffix when created. `MarkReferences` traces the prefix, with at most
+32 links. Materialization consumes that reservation without collecting and
+releases the suffix charge; destruction releases the remaining reservation.
+When an append needs a collection to fit, it first materializes its prefix so
+the collection can reclaim unaliased intermediate nodes and their reservations.
+This accounting is deliberately conservative: a deferred string's charged
+capacity can exceed its currently allocated native buffer. It preserves
+non-collecting primitive reads while reducing physical copying; see
+[ADR 0116](adr/0116-bounded-string-prefixes.md).
+
 ### Gated growth points
 
 Backing storage sized by the running script is checked against the ceiling *before* it is allocated, without being charged to it (`Goccia.MemoryLimit`: `CanAllocateNativeBytes` / `RequireNativeBytes`, raising the host-catchable `TGocciaMemoryLimitError`). Two growth points are gated: array element extension (`ExtendElementsWithHoles`) and object property storage, where the map's entry and bucket arrays grow past a small-block threshold. Both belong to containers with no hook to release a reservation, so a charge would leak budget the engine could never give back; a gate bounds the peak instead. What is reported to the gate is the *transient* footprint — the block being allocated plus the block still live while it is — because `SetLength` may allocate and copy rather than extend in place, and compaction holds both entry arrays at once by construction.

--- a/perf/probes/string-append-30k.js
+++ b/perf/probes/string-append-30k.js
@@ -11,5 +11,16 @@ __gocciaRegisterProbe({
     }
     return s.length + ":" + h;
   },
-  verify: (checksum) => typeof checksum === "string" && checksum.indexOf(":") > 0,
+  verify: (checksum, innerIterations) => {
+    const chunks = [];
+    for (let i = 0; i < innerIterations; i = i + 1) {
+      chunks.push("chunk", String(i), ";");
+    }
+    const expected = chunks.join("");
+    let hash = 0;
+    for (let i = 0; i < expected.length; i = i + 791) {
+      hash = (hash + expected.charCodeAt(i)) | 0;
+    }
+    return checksum === expected.length + ":" + hash;
+  },
 });

--- a/source/units/Goccia.VM.DispatchCase.inc
+++ b/source/units/Goccia.VM.DispatchCase.inc
@@ -592,8 +592,8 @@
            (FRegisters[B].ObjectValue is TGocciaStringLiteralValue) and
            (FRegisters[C].Kind = grkObject) and
            (FRegisters[C].ObjectValue is TGocciaStringLiteralValue) then
-          SetRegisterFast(A, TGocciaStringLiteralValue.Create(
-            TGocciaStringLiteralValue(FRegisters[B].ObjectValue).Value +
+          SetRegisterFast(A, TGocciaStringLiteralValue.Concatenate(
+            TGocciaStringLiteralValue(FRegisters[B].ObjectValue),
             TGocciaStringLiteralValue(FRegisters[C].ObjectValue).Value))
         else
           SetRegisterFast(A, TGocciaStringLiteralValue.Create(
@@ -1405,9 +1405,17 @@
                 (not ((FRegisters[C].Kind = grkObject) and
                       Assigned(FRegisters[C].ObjectValue) and
                       (not FRegisters[C].ObjectValue.IsPrimitive))) then
-          SetRegisterFast(A, TGocciaStringLiteralValue.Create(
-            VMRegisterToStringFast(FRegisters[B]).Value +
-            VMRegisterToStringFast(FRegisters[C]).Value))
+          begin
+            if (FRegisters[B].Kind = grkObject) and
+               (FRegisters[B].ObjectValue is TGocciaStringLiteralValue) then
+              SetRegisterFast(A, TGocciaStringLiteralValue.Concatenate(
+                TGocciaStringLiteralValue(FRegisters[B].ObjectValue),
+                VMRegisterToStringFast(FRegisters[C]).Value))
+            else
+              SetRegisterFast(A, TGocciaStringLiteralValue.Create(
+                VMRegisterToStringFast(FRegisters[B]).Value +
+                VMRegisterToStringFast(FRegisters[C]).Value));
+          end
         else
         begin
           LeftValue := GetRegisterFast(B);

--- a/source/units/Goccia.Values.Primitives.Test.pas
+++ b/source/units/Goccia.Values.Primitives.Test.pas
@@ -23,6 +23,11 @@ type
     procedure TestStringValuePreservesUnicode;
     procedure TestStringValueAccountsForBackingStore;
     procedure TestStringValueMemoryLimitRaisesOnce;
+    procedure TestStringConcatenationPreservesAliases;
+    procedure TestStringConcatenationTracesPrefixes;
+    procedure TestStringConcatenationMaterializationDoesNotCollect;
+    procedure TestStringConcatenationMemoryLimit;
+    procedure TestStringConcatenationLimitedAccumulator;
     procedure TestNumberValue;
     procedure TestNumberValueNaN;
     procedure TestNumberValueInfinity;
@@ -46,6 +51,16 @@ begin
     TestStringValueAccountsForBackingStore);
   Test('String value memory limit raises without recursion',
     TestStringValueMemoryLimitRaisesOnce);
+  Test('String concatenation preserves aliases and UTF-16 contents',
+    TestStringConcatenationPreservesAliases);
+  Test('String concatenation traces prefixes and releases backing stores',
+    TestStringConcatenationTracesPrefixes);
+  Test('String concatenation materialization never collects',
+    TestStringConcatenationMaterializationDoesNotCollect);
+  Test('String concatenation reserves materialization capacity',
+    TestStringConcatenationMemoryLimit);
+  Test('String accumulator drops deferred capacity under memory pressure',
+    TestStringConcatenationLimitedAccumulator);
   Test('Number value', TestNumberValue);
   Test('NaN value', TestNumberValueNaN);
   Test('Infinity value', TestNumberValueInfinity);
@@ -169,6 +184,185 @@ begin
     Expect<Boolean>(GC.MemoryLimitFiring).ToBe(False);
   finally
     GC.MaxBytes := OldMaxBytes;
+    GC.Collect;
+    if OwnsGarbageCollector then
+      TGarbageCollector.Shutdown;
+  end;
+end;
+
+procedure TTestPrimitives.TestStringConcatenationPreservesAliases;
+var
+  AliasValue, CopiedValue, Value: TGocciaStringLiteralValue;
+  Expected, Suffix: string;
+  I: Integer;
+begin
+  Expected := StringOfChar(' ', 256);
+  AliasValue := TGocciaStringLiteralValue.Create(Expected);
+  Value := TGocciaStringLiteralValue.Concatenate(AliasValue, '12');
+  Expect<Double>(Value.ToNumberLiteral.Value).ToBe(12);
+  Expect<Boolean>(Value.ToBooleanLiteral.Value).ToBe(True);
+  Expected := Expected + '12';
+  for I := 1 to 80 do
+  begin
+    Suffix := #$D83D + #$DE80 + #$D800 + IntToStr(I);
+    Value := TGocciaStringLiteralValue.Concatenate(Value, Suffix);
+    Expected := Expected + Suffix;
+  end;
+  CopiedValue := TGocciaStringLiteralValue(Value.RuntimeCopy);
+  Expect<string>(CopiedValue.Value).ToBe(Expected);
+  Expect<string>(Value.Value).ToBe(Expected);
+  Expect<string>(AliasValue.Value).ToBe(StringOfChar(' ', 256));
+  Expect<string>(TGocciaStringLiteralValue.Concatenate(Value, '').Value).ToBe(Expected);
+end;
+
+procedure TTestPrimitives.TestStringConcatenationTracesPrefixes;
+var
+  BaselineBytes: Int64;
+  Expected, FlatValue: string;
+  GC: TGarbageCollector;
+  I: Integer;
+  OwnsGarbageCollector: Boolean;
+  Value: TGocciaStringLiteralValue;
+begin
+  OwnsGarbageCollector := TGarbageCollector.Instance = nil;
+  if OwnsGarbageCollector then
+    TGarbageCollector.Initialize;
+  GC := TGarbageCollector.Instance;
+  try
+    GC.Collect;
+    BaselineBytes := GC.BytesAllocated;
+    Expected := StringOfChar('x', 256);
+    Value := TGocciaStringLiteralValue.Create(Expected);
+    for I := 1 to 20 do
+    begin
+      Value := TGocciaStringLiteralValue.Concatenate(Value, #$D800);
+      Expected := Expected + #$D800;
+    end;
+    GC.AddRootObject(Value);
+    try
+      GC.Collect;
+      FlatValue := Value.Value;
+      Expect<Integer>(Length(FlatValue)).ToBe(276);
+      Expect<Integer>(Ord(FlatValue[276])).ToBe($D800);
+      Expect<string>(FlatValue).ToBe(Expected);
+      GC.Collect;
+      Expect<Boolean>(GC.BytesAllocated >= BaselineBytes + 276 * SizeOf(Char)).ToBe(True);
+    finally
+      GC.RemoveRootObject(Value);
+      GC.Collect;
+    end;
+    Expect<Int64>(GC.BytesAllocated).ToBe(BaselineBytes);
+  finally
+    if OwnsGarbageCollector then
+      TGarbageCollector.Shutdown;
+  end;
+end;
+
+procedure TTestPrimitives.TestStringConcatenationMaterializationDoesNotCollect;
+var
+  Flattened: string;
+  GC: TGarbageCollector;
+  OldMaxBytes: Int64;
+  CollectionsBefore: Integer;
+  OwnsGarbageCollector: Boolean;
+  PeerValue, Value: TGocciaStringLiteralValue;
+begin
+  OwnsGarbageCollector := TGarbageCollector.Instance = nil;
+  if OwnsGarbageCollector then
+    TGarbageCollector.Initialize;
+  GC := TGarbageCollector.Instance;
+  OldMaxBytes := GC.MaxBytes;
+  Value := TGocciaStringLiteralValue.Concatenate(
+    TGocciaStringLiteralValue.Create(StringOfChar('x', 256)), 'suffix');
+  GC.AddRootObject(Value);
+  try
+    GC.Collect;
+    PeerValue := TGocciaStringLiteralValue.Create('unrooted peer');
+    GC.MaxBytes := GC.BytesAllocated + 1;
+    CollectionsBefore := GC.TotalCollections;
+    Flattened := Value.Value;
+    Expect<Integer>(GC.TotalCollections).ToBe(CollectionsBefore);
+    Expect<string>(PeerValue.Value).ToBe('unrooted peer');
+    Expect<string>(Flattened).ToBe(StringOfChar('x', 256) + 'suffix');
+    Expect<Boolean>(GC.MemoryLimitFiring).ToBe(False);
+    GC.MaxBytes := OldMaxBytes;
+    GC.Collect;
+    Expect<string>(Value.Value).ToBe(StringOfChar('x', 256) + 'suffix');
+  finally
+    GC.MaxBytes := OldMaxBytes;
+    GC.RemoveRootObject(Value);
+    GC.Collect;
+    if OwnsGarbageCollector then
+      TGarbageCollector.Shutdown;
+  end;
+end;
+
+procedure TTestPrimitives.TestStringConcatenationMemoryLimit;
+var
+  GC: TGarbageCollector;
+  OldMaxBytes: Int64;
+  OwnsGarbageCollector, RaisedMemoryLimit: Boolean;
+  Prefix: TGocciaStringLiteralValue;
+begin
+  OwnsGarbageCollector := TGarbageCollector.Instance = nil;
+  if OwnsGarbageCollector then
+    TGarbageCollector.Initialize;
+  GC := TGarbageCollector.Instance;
+  OldMaxBytes := GC.MaxBytes;
+  Prefix := TGocciaStringLiteralValue.Create(StringOfChar('x', 256));
+  GC.AddRootObject(Prefix);
+  try
+    GC.Collect;
+    GC.MaxBytes := GC.BytesAllocated + 128;
+    RaisedMemoryLimit := False;
+    try
+      TGocciaStringLiteralValue.Concatenate(Prefix, 'y');
+    except
+      on E: TGocciaThrowValue do
+        RaisedMemoryLimit := True;
+    end;
+    Expect<Boolean>(RaisedMemoryLimit).ToBe(True);
+    Expect<Boolean>(GC.MemoryLimitFiring).ToBe(False);
+    Expect<string>(Prefix.Value).ToBe(StringOfChar('x', 256));
+  finally
+    GC.MaxBytes := OldMaxBytes;
+    GC.RemoveRootObject(Prefix);
+    GC.Collect;
+    if OwnsGarbageCollector then
+      TGarbageCollector.Shutdown;
+  end;
+end;
+
+procedure TTestPrimitives.TestStringConcatenationLimitedAccumulator;
+var
+  GC: TGarbageCollector;
+  I: Integer;
+  OldMaxBytes: Int64;
+  OwnsGarbageCollector: Boolean;
+  NextValue, Value: TGocciaStringLiteralValue;
+begin
+  OwnsGarbageCollector := TGarbageCollector.Instance = nil;
+  if OwnsGarbageCollector then
+    TGarbageCollector.Initialize;
+  GC := TGarbageCollector.Instance;
+  OldMaxBytes := GC.MaxBytes;
+  Value := TGocciaStringLiteralValue.Create(StringOfChar('x', 1024));
+  GC.AddRootObject(Value);
+  try
+    GC.Collect;
+    GC.MaxBytes := GC.BytesAllocated + 16 * 1024;
+    for I := 1 to 80 do
+    begin
+      NextValue := TGocciaStringLiteralValue.Concatenate(Value, 'x');
+      GC.AddRootObject(NextValue);
+      GC.RemoveRootObject(Value);
+      Value := NextValue;
+    end;
+    Expect<string>(Value.Value).ToBe(StringOfChar('x', 1104));
+    Expect<Boolean>(GC.BytesAllocated <= GC.MaxBytes).ToBe(True);
+  finally
+    GC.MaxBytes := OldMaxBytes;
+    GC.RemoveRootObject(Value);
     GC.Collect;
     if OwnsGarbageCollector then
       TGarbageCollector.Shutdown;

--- a/source/units/Goccia.Values.Primitives.pas
+++ b/source/units/Goccia.Values.Primitives.pas
@@ -145,9 +145,20 @@ type
   private
     FValue: string;
     FChargedBytes: Int64;
+    FPrefix: TGocciaStringLiteralValue;
+    FLength: SizeInt;
+    FDepth: Integer;
+    constructor CreateConcatenation(const APrefix: TGocciaStringLiteralValue;
+      const ASuffix: string);
+    function ReserveBackingStore(const ABytes: Int64): Int64;
+    procedure Flatten;
+    function GetValue: string; {$IFDEF FPC}inline;{$ENDIF}
   public
     constructor Create(const AValue: string);
     destructor Destroy; override;
+    class function Concatenate(const APrefix: TGocciaStringLiteralValue;
+      const ASuffix: string): TGocciaStringLiteralValue; static;
+    procedure MarkReferences; override;
 
     function IsPrimitive: Boolean; override;
     function TypeName: string; override;
@@ -158,7 +169,7 @@ type
     function ToNumberLiteral: TGocciaNumberLiteralValue; override;
     function ToStringLiteral: TGocciaStringLiteralValue; override;
 
-    property Value: string read FValue;
+    property Value: string read GetValue;
   end;
 
   procedure PinPrimitiveSingletons;
@@ -629,17 +640,45 @@ begin
 end;
 
 constructor TGocciaStringLiteralValue.Create(const AValue: string);
-var
-  ChargedBytes: Int64;
-  GC: TGarbageCollector;
 begin
   inherited Create;
-  FChargedBytes := 0;
-  ChargedBytes := Int64(Length(AValue)) * SizeOf(Char);
+  FValue := AValue;
+  FLength := Length(AValue);
+  FChargedBytes := ReserveBackingStore(Int64(FLength) * SizeOf(Char));
+end;
+
+constructor TGocciaStringLiteralValue.CreateConcatenation(
+  const APrefix: TGocciaStringLiteralValue; const ASuffix: string);
+begin
+  inherited Create;
+  FPrefix := APrefix;
+  FValue := ASuffix;
+  FLength := APrefix.FLength + Length(ASuffix);
+  FDepth := APrefix.FDepth + 1;
+  // Reserve the eventual flat buffer as well as the currently retained suffix.
+  // Reading Value must remain a non-collecting operation: callers can hold
+  // unrelated primitive operands only in native locals across that read.
+  FChargedBytes := ReserveBackingStore(
+    (Int64(FLength) + Length(ASuffix)) * SizeOf(Char));
+end;
+
+function TGocciaStringLiteralValue.ReserveBackingStore(const ABytes: Int64): Int64;
+var
+  GC: TGarbageCollector;
+begin
+  Result := 0;
   GC := TGarbageCollector.Instance;
   if Assigned(GC) and not GC.MemoryLimitFiring then
   begin
-    if not GC.TryReserveExternalBytes(ChargedBytes, Self) then
+    if Assigned(FPrefix) and (GC.MaxBytes > 0) and
+       (GC.BytesAllocated > GC.MaxBytes - ABytes) then
+    begin
+      // Let the reservation's collection discard unaliased intermediate
+      // prefixes instead of keeping all their deferred capacity live.
+      FPrefix.Flatten;
+      FDepth := 1;
+    end;
+    if not GC.TryReserveExternalBytes(ABytes, Self) then
     begin
       // The RangeError itself allocates short strings. Suppress accounting
       // while constructing it so a failed reservation cannot recurse until
@@ -651,9 +690,73 @@ begin
         GC.MemoryLimitFiring := False;
       end;
     end;
-    FChargedBytes := ChargedBytes;
+    Result := ABytes;
   end;
-  FValue := AValue;
+end;
+
+class function TGocciaStringLiteralValue.Concatenate(
+  const APrefix: TGocciaStringLiteralValue;
+  const ASuffix: string): TGocciaStringLiteralValue;
+const
+  MIN_PREFIX_LENGTH = 256;
+  MAX_PREFIX_DEPTH = 32;
+begin
+  if APrefix.FLength < MIN_PREFIX_LENGTH then
+    Exit(TGocciaStringLiteralValue.Create(APrefix.Value + ASuffix));
+  // Bound both retained intermediate objects and the GC tracing depth.
+  if APrefix.FDepth >= MAX_PREFIX_DEPTH then
+    APrefix.Flatten;
+  Result := TGocciaStringLiteralValue.CreateConcatenation(APrefix, ASuffix);
+end;
+
+procedure TGocciaStringLiteralValue.Flatten;
+var
+  Current: TGocciaStringLiteralValue;
+  FlatValue: string;
+  Offset, SuffixLength, OriginalSuffixLength: SizeInt;
+  GC: TGarbageCollector;
+begin
+  if not Assigned(FPrefix) then
+    Exit;
+  // Capacity was reserved at creation. No GC or guest code may run here.
+  SetLength(FlatValue, FLength);
+  Offset := FLength;
+  Current := Self;
+  repeat
+    SuffixLength := Length(Current.FValue);
+    Dec(Offset, SuffixLength);
+    if SuffixLength > 0 then
+      Move(Current.FValue[1], FlatValue[Offset + 1],
+        SuffixLength * SizeOf(Char));
+    Current := Current.FPrefix;
+  until not Assigned(Current);
+  OriginalSuffixLength := Length(FValue);
+  FValue := FlatValue;
+  FPrefix := nil;
+  FDepth := 0;
+  if FChargedBytes > 0 then
+  begin
+    GC := TGarbageCollector.Instance;
+    if Assigned(GC) then
+      GC.ReleaseExternalBytes(Int64(OriginalSuffixLength) * SizeOf(Char));
+    Dec(FChargedBytes, Int64(OriginalSuffixLength) * SizeOf(Char));
+  end;
+end;
+
+function TGocciaStringLiteralValue.GetValue: string;
+begin
+  if Assigned(FPrefix) then
+    Flatten;
+  Result := FValue;
+end;
+
+procedure TGocciaStringLiteralValue.MarkReferences;
+begin
+  if GCMarked then
+    Exit;
+  inherited;
+  if Assigned(FPrefix) then
+    FPrefix.MarkReferences;
 end;
 
 destructor TGocciaStringLiteralValue.Destroy;
@@ -679,12 +782,12 @@ end;
 
 function TGocciaStringLiteralValue.RuntimeCopy: TGocciaValue;
 begin
-  Result := TGocciaStringLiteralValue.Create(FValue);
+  Result := TGocciaStringLiteralValue.Create(Value);
 end;
 
 function TGocciaStringLiteralValue.ToBooleanLiteral: TGocciaBooleanLiteralValue;
 begin
-  if FValue <> EMPTY_STRING then
+  if FLength > 0 then
     Result := TGocciaBooleanLiteralValue.TrueValue
   else
     Result := TGocciaBooleanLiteralValue.FalseValue;
@@ -696,7 +799,7 @@ begin
   // shared NumericText.StringToNumber so this runtime coercion path and the
   // compiler's constant folding (Goccia.Compiler.ConstantValue) cannot drift.
   // Create stores the raw Double verbatim, preserving NaN, +/-Infinity, and -0.
-  Result := TGocciaNumberLiteralValue.Create(StringToNumber(FValue));
+  Result := TGocciaNumberLiteralValue.Create(StringToNumber(Value));
 end;
 
 function TGocciaStringLiteralValue.ToStringLiteral: TGocciaStringLiteralValue;

--- a/tests/language/expressions/string/string-accumulators.js
+++ b/tests/language/expressions/string/string-accumulators.js
@@ -1,0 +1,68 @@
+/*---
+description: Growing string accumulators preserve aliases, coercion order, UTF-16 contents, and GC reachability
+features: [string-concatenation, Symbol.toPrimitive]
+---*/
+
+test("growing strings preserve earlier aliases across reads and collection", () => {
+  for (const initialLength of [255, 256, 257]) {
+    const initial = "x".repeat(initialLength);
+    let accumulated = initial;
+    const chunks = [initial];
+    const aliases = [];
+    for (const index of Array.from({ length: 96 }, (_, i) => i)) {
+      const suffix = "\uD83D\uDE80\uD800" + index + ";";
+      accumulated = accumulated + suffix;
+      chunks.push(suffix);
+      if ([0, 30, 31, 32, 33, 63, 64, 95].includes(index)) {
+        const saved = accumulated;
+        aliases.push({ value: saved, read: () => saved, expected: chunks.join("") });
+      }
+    }
+    if (typeof Goccia !== "undefined") Goccia.gc();
+    for (const alias of aliases.toReversed()) {
+      expect(alias.value).toBe(alias.expected);
+      expect(alias.read()).toBe(alias.expected);
+    }
+    const expected = chunks.join("");
+    expect(accumulated).toBe(expected);
+    expect(accumulated.length).toBe(expected.length);
+    expect(accumulated.charCodeAt(initialLength)).toBe(0xD83D);
+    expect(accumulated.charCodeAt(initialLength + 2)).toBe(0xD800);
+    expect(accumulated.slice(initialLength)).toBe(expected.slice(initialLength));
+    expect(JSON.parse(JSON.stringify(accumulated))).toBe(expected);
+    expect({ [accumulated]: 42 }[expected]).toBe(42);
+    expect(accumulated + "").toBe(expected);
+    expect(initial).toBe("x".repeat(initialLength));
+  }
+});
+
+test("growing strings preserve primitive and object coercion", () => {
+  const prefix = " ".repeat(256);
+  let numeric = prefix;
+  numeric += "-";
+  numeric += 0;
+  expect(Object.is(Number(numeric), -0)).toBe(true);
+  expect(Boolean(numeric)).toBe(true);
+
+  const events = [];
+  const left = {
+    [Symbol.toPrimitive](hint) {
+      events.push("left:" + hint);
+      if (typeof Goccia !== "undefined") Goccia.gc();
+      return prefix + "left";
+    },
+  };
+  const right = {
+    [Symbol.toPrimitive](hint) {
+      events.push("right:" + hint);
+      if (typeof Goccia !== "undefined") Goccia.gc();
+      return "right";
+    },
+  };
+  expect(left + right).toBe(prefix + "leftright");
+  expect(events).toEqual(["left:default", "right:default"]);
+  expect(prefix + 12 + true + null + undefined).toBe(
+    prefix + "12truenullundefined",
+  );
+  expect(() => prefix + Symbol("suffix")).toThrow(TypeError);
+});


### PR DESCRIPTION
## Summary

- Repeated bytecode string appends retain bounded immutable prefixes once the prefix reaches 256 UTF-16 code units. Materialization copies the chunks once, at a content read or the 32-link limit. Saved aliases and object-coercion order remain intact.
- Reserve materialization capacity at append creation so primitive string reads never trigger GC. Trace prefix references and release unused reservations; flatten early under memory pressure. Document the representation and measured limits in ADR 0116 and the bytecode/GC guides. Strengthen the append probe's independent verifier.
- Against production baseline `f33d9c6a061e6cb61dce65ffcf8514da1c051870` on macOS arm64/FPC 3.2.2, seven interleaved samples plus seven reverse-order samples reduced 8,000-iteration append execution medians from 473/462 ms to 25/26 ms. The unchanged JetStream Base64 worker kernel improved from 1432/1433 ms to 1111/1112 ms (about 22%); this is a standalone kernel result, not a suite score. Batched AWFY Json confirmation found no repeatable regression. ADR 0116 records pins, spreads, and the host/VM profile evidence.
- Native heap allocation reported after the append workload falls from about 109 MiB to 5 MiB. Conservative reserved capacity still produces an approximately 240 MiB GC-accounted peak and seven collections. Separate manual diff review checked non-collecting reads, prefix lifetime, alias preservation, UTF-16 contents, budget refusal/release, and worker/runtime ownership.

## Testing

- [x] Verified no regressions and confirmed the new feature or bugfix in end-to-end JavaScript/TypeScript tests — full interpreter and bytecode suites each pass 12,820 tests / 28,654 assertions across 1,616 files in production and development builds, with `--jobs=2`. The development build was retried clean after the known stale-FPC-artifact failure. Focused string/addition/comparison suites also pass both modes. Bun independently passes the new tests (81 assertions).
- [x] Updated documentation — bytecode and GC guides, ADR 0116, ADR index.
- [x] Optional: Verified no regressions and confirmed the new feature or bugfix in native Pascal tests (if AST, scope, evaluator, or value types changed) — checked `Goccia.Values.Primitives.Test`: 20/20, including aliases, lone surrogates, GC reachability, non-collecting reads, reservation refusal, and low-budget accumulation.
- [x] Optional: Verified no benchmark regressions or confirmed benchmark coverage for the change — independently verified append checksums, JetStream Base64 transfer, AWFY Json guard; production baseline/candidate builds and serialized AB/BA/ABBA measurements. Probe verifier checks golden results for 0, 1000, 8000, and 30000 iterations and rejects corrupt checksums.

`./format.pas --check` passes all 463 Pascal files. Production loader identity is retained with the raw timing, memory, VM-profile, and host-sample artifacts; the engine source is unchanged from the measured candidate.

## Pending performance check

The first Linux x64 CI report shows an ai-astar score reduction from 1.78151 to 1.68809 (about 5.2%), with disjoint five-sample ranges. This differs from the local acceptance guards and is under paired reproduction and source investigation. The PR remains draft until this signal is resolved; green workflow status alone is not treated as evidence of no performance regressions. [CI run](https://github.com/frostney/GocciaScript/actions/runs/33929357892).
