### PR TITLE
fix(compliance): use detected CPU count for default workers

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -484,7 +484,7 @@ For TOML 1.1.0 checks against a prepared checkout of the official `toml-test` co
 ./build/GocciaTOMLComplianceRunner --suite-dir=/path/to/toml-test --output=tmp/toml-suite-results.json
 ```
 
-The runner verifies the checkout against `tests/compliance/toml-test.pin` without fetching or cloning. It launches its private worker mode once per case, applies a bounded `--jobs` limit, and classifies mismatches, false accepts, false rejects, timeouts, crashes, and infrastructure failures. Valid cases are compared with the official tagged JSON fixtures through `TGocciaTOMLParser.ParseDocument(...)`, preserving scalar distinctions such as `integer`, `float`, `datetime`, `datetime-local`, `date-local`, and `time-local`.
+The runner verifies the checkout against `tests/compliance/toml-test.pin` without fetching or cloning. It launches its private worker mode once per case, applies a bounded `--jobs` limit (defaulting to the online processor count through the same detector as TestRunner), and classifies mismatches, false accepts, false rejects, timeouts, crashes, and infrastructure failures. Valid cases are compared with the official tagged JSON fixtures through `TGocciaTOMLParser.ParseDocument(...)`, preserving scalar distinctions such as `integer`, `float`, `datetime`, `datetime-local`, `date-local`, and `time-local`.
 
 The runner prints a human summary, optionally writes the shared compliance JSON envelope with `--output`, and exits non-zero for compliance or infrastructure failures.
 

--- a/source/app/Goccia.CLI.Application.pas
+++ b/source/app/Goccia.CLI.Application.pas
@@ -164,6 +164,7 @@ uses
 
   CLI.Parser,
   HTTPTypes,
+  ProcessorDetection,
   TextEncoding,
   TextSemantics,
 
@@ -351,40 +352,6 @@ begin
   RegisterConfigParser(EXT_JSON5, @ParseJSON5Config);
   RegisterConfigParser(EXT_TOML, @ParseTOMLConfig);
   GConfigParsersRegistered := True;
-end;
-
-{ FPC 3.2.2 GetCPUCount uses wrong _SC_NPROCESSORS_ONLN constants on
-  macOS (expects Linux 84, actual macOS value is 58) and may also fail
-  on some Linux configurations.  Call sysconf / sysctlbyname directly
-  with the correct per-OS constant so we always detect all cores. }
-
-{$IFDEF UNIX}
-function libc_sysconf(Name: Integer): Int64; cdecl; external 'c' name 'sysconf';
-{$ENDIF}
-
-function GetProcessorCount: Integer;
-{$IFDEF UNIX}
-const
-  {$IFDEF DARWIN}
-  SC_NPROCESSORS_ONLN = 58;
-  {$ELSE}
-  SC_NPROCESSORS_ONLN = 84;   { Linux }
-  {$ENDIF}
-var
-  N: Int64;
-{$ENDIF}
-begin
-  {$IFDEF UNIX}
-  N := libc_sysconf(SC_NPROCESSORS_ONLN);
-  if N > 0 then
-    Result := Integer(N)
-  else
-    Result := 1;
-  {$ELSE}
-  Result := TThread.ProcessorCount;
-  if Result < 1 then
-    Result := 1;
-  {$ENDIF}
 end;
 
 { TGocciaCLIApplication }

--- a/source/app/compliance/Goccia.Compliance.Workers.Test.pas
+++ b/source/app/compliance/Goccia.Compliance.Workers.Test.pas
@@ -6,15 +6,26 @@ uses
   {$IFDEF UNIX}
   cthreads,
   {$ENDIF}
+  Classes,
   Process,
   SysUtils,
 
   ProcessorDetection,
   TestingPascalLibrary,
 
+  Goccia.CLI.Application,
   Goccia.Compliance;
 
 type
+  TWorkerTestApplication = class(TGocciaCLIApplication)
+  protected
+    procedure Configure; override;
+    function UsageLine: string; override;
+    procedure ExecuteWithPaths(const APaths: TStringList); override;
+  public
+    function JobsForFiles(const AFileCount: Integer): Integer;
+  end;
+
   TComplianceWorkerTests = class(TTestSuite)
   private
     procedure TestPositiveWorkerCount;
@@ -24,6 +35,24 @@ type
   public
     procedure SetupTests; override;
   end;
+
+procedure TWorkerTestApplication.Configure;
+begin
+end;
+
+function TWorkerTestApplication.UsageLine: string;
+begin
+  Result := 'worker-count-test';
+end;
+
+procedure TWorkerTestApplication.ExecuteWithPaths(const APaths: TStringList);
+begin
+end;
+
+function TWorkerTestApplication.JobsForFiles(const AFileCount: Integer): Integer;
+begin
+  Result := GetJobCount(AFileCount);
+end;
 
 procedure TComplianceWorkerTests.SetupTests;
 begin
@@ -44,12 +73,20 @@ procedure TComplianceWorkerTests.TestMacOSWorkerCount;
 var
   Output: AnsiString;
   ProcessorCount: Integer;
+  Application: TWorkerTestApplication;
 begin
   Expect<Boolean>(RunCommand('/usr/bin/getconf', ['NPROCESSORS_ONLN'], Output)).ToBe(True);
   ProcessorCount := StrToInt(Trim(string(Output)));
   Expect<Boolean>(ProcessorCount > 0).ToBe(True);
   Expect<Integer>(GetProcessorCount).ToBe(ProcessorCount);
   Expect<Integer>(DefaultComplianceJobs).ToBe(ProcessorCount);
+  Application := TWorkerTestApplication.Create('worker-count-test');
+  try
+    Expect<Integer>(Application.JobsForFiles(ProcessorCount + 1)).ToBe(ProcessorCount);
+    Expect<Integer>(Application.JobsForFiles(1)).ToBe(1);
+  finally
+    Application.Free;
+  end;
 end;
 {$ENDIF}
 

--- a/source/app/compliance/Goccia.Compliance.Workers.Test.pas
+++ b/source/app/compliance/Goccia.Compliance.Workers.Test.pas
@@ -1,0 +1,60 @@
+program Goccia.Compliance.Workers.Test;
+
+{$I Goccia.inc}
+
+uses
+  {$IFDEF UNIX}
+  cthreads,
+  {$ENDIF}
+  Process,
+  SysUtils,
+
+  ProcessorDetection,
+  TestingPascalLibrary,
+
+  Goccia.Compliance;
+
+type
+  TComplianceWorkerTests = class(TTestSuite)
+  private
+    procedure TestPositiveWorkerCount;
+    {$IFDEF DARWIN}
+    procedure TestMacOSWorkerCount;
+    {$ENDIF}
+  public
+    procedure SetupTests; override;
+  end;
+
+procedure TComplianceWorkerTests.SetupTests;
+begin
+  Test('Default worker counts are positive', TestPositiveWorkerCount);
+  {$IFDEF DARWIN}
+  Test('CLI and compliance defaults match macOS online CPUs', TestMacOSWorkerCount);
+  {$ENDIF}
+end;
+
+procedure TComplianceWorkerTests.TestPositiveWorkerCount;
+begin
+  Expect<Boolean>(GetProcessorCount > 0).ToBe(True);
+  Expect<Boolean>(DefaultComplianceJobs > 0).ToBe(True);
+end;
+
+{$IFDEF DARWIN}
+procedure TComplianceWorkerTests.TestMacOSWorkerCount;
+var
+  Output: AnsiString;
+  ProcessorCount: Integer;
+begin
+  Expect<Boolean>(RunCommand('/usr/bin/getconf', ['NPROCESSORS_ONLN'], Output)).ToBe(True);
+  ProcessorCount := StrToInt(Trim(string(Output)));
+  Expect<Boolean>(ProcessorCount > 0).ToBe(True);
+  Expect<Integer>(GetProcessorCount).ToBe(ProcessorCount);
+  Expect<Integer>(DefaultComplianceJobs).ToBe(ProcessorCount);
+end;
+{$ENDIF}
+
+begin
+  TestRunnerProgram.AddSuite(TComplianceWorkerTests.Create('Compliance worker defaults'));
+  TestRunnerProgram.Run;
+  ExitCode := TestResultToExitCode;
+end.

--- a/source/app/compliance/Goccia.Compliance.pas
+++ b/source/app/compliance/Goccia.Compliance.pas
@@ -106,6 +106,7 @@ uses
 
   FileUtils,
   Pipes,
+  ProcessorDetection,
   StringBuffer,
   TextEncoding,
 
@@ -389,9 +390,7 @@ end;
 
 function DefaultComplianceJobs: Integer;
 begin
-  Result := TThread.ProcessorCount;
-  if Result < 1 then
-    Result := 1;
+  Result := GetProcessorCount;
 end;
 
 procedure WriteJSONFile(const APath, AJSON: string);

--- a/source/shared/ProcessorDetection.pas
+++ b/source/shared/ProcessorDetection.pas
@@ -16,7 +16,8 @@ uses
   the native online processor count for both CLI and compliance workers. }
 
 {$IFDEF UNIX}
-function libc_sysconf(Name: Integer): Int64; cdecl; external 'c' name 'sysconf';
+// C long is pointer-sized on the supported UNIX targets.
+function libc_sysconf(Name: Integer): NativeInt; cdecl; external 'c' name 'sysconf';
 {$ENDIF}
 
 function GetProcessorCount: Integer;
@@ -28,7 +29,7 @@ const
   SC_NPROCESSORS_ONLN = 84;   { Linux }
   {$ENDIF}
 var
-  N: Int64;
+  N: NativeInt;
 {$ENDIF}
 begin
   {$IFDEF UNIX}

--- a/source/shared/ProcessorDetection.pas
+++ b/source/shared/ProcessorDetection.pas
@@ -1,0 +1,47 @@
+unit ProcessorDetection;
+
+{$I Shared.inc}
+
+interface
+
+// Returns the online processor count, with a minimum of one.
+function GetProcessorCount: Integer;
+
+implementation
+
+uses
+  Classes;
+
+{ FPC 3.2.2 can report one processor on multicore macOS hosts. Use
+  the native online processor count for both CLI and compliance workers. }
+
+{$IFDEF UNIX}
+function libc_sysconf(Name: Integer): Int64; cdecl; external 'c' name 'sysconf';
+{$ENDIF}
+
+function GetProcessorCount: Integer;
+{$IFDEF UNIX}
+const
+  {$IFDEF DARWIN}
+  SC_NPROCESSORS_ONLN = 58;
+  {$ELSE}
+  SC_NPROCESSORS_ONLN = 84;   { Linux }
+  {$ENDIF}
+var
+  N: Int64;
+{$ENDIF}
+begin
+  {$IFDEF UNIX}
+  N := libc_sysconf(SC_NPROCESSORS_ONLN);
+  if N > 0 then
+    Result := Integer(N)
+  else
+    Result := 1;
+  {$ELSE}
+  Result := TThread.ProcessorCount;
+  if Result < 1 then
+    Result := 1;
+  {$ENDIF}
+end;
+
+end.


### PR DESCRIPTION
## Summary

- Fix the TOML compliance runner defaulting to one worker on multicore macOS hosts with FPC 3.2.2. On the verified 18-CPU host, its default now resolves to 18.
- Move the existing CLI processor detector into `source/shared/ProcessorDetection.pas` and reuse it for compliance. Explicit `--jobs` handling and CLI file-count limits are preserved.
- Add a native regression that compares both defaults with the operating system, and document the default. No linked issue.

Related toolkit fix: https://github.com/frostney/lwpt/pull/295.

The native `sysconf` binding uses `NativeInt` to match C `long` on supported 32-bit and 64-bit Unix targets. The CPU regression also calls the actual CLI `GetJobCount` path with multiple files and checks its single-file cap.

## Testing

- [x] Verified no regressions in end-to-end JavaScript tests: 12,826 passed in the interpreter and 12,826 in bytecode mode; zero failures or skips.
- [x] Updated documentation.
- [x] Native CPU regression: original compliance implementation fails with `Expected 1 to be 18`; patched implementation passes both cases on macOS/aarch64, FPC 3.2.2.
- [x] Built `testrunner` and `tomlcompliancerunner`; formatter and all contribution hooks passed.
- Benchmark comparison is not applicable: this corrects worker selection without changing runtime execution.

Manual diff review covered detector extraction, minimum-one fallback, override preservation, test discovery, and platform conditionals. Other platforms await CI; no throughput claim is made.

Feedback validation at `d56fa99e`: native CPU tests passed; a disposable mutation forcing the CLI default to one failed the new assertion (`Expected 1 to be 18`). Both execution modes passed 12,826 tests. Local runtime verification is macOS/aarch64; 32-bit ABI validation is static against the C signature, not a claimed 32-bit runtime pass.
